### PR TITLE
fix: Update F5 CLA workflow instructions

### DIFF
--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -1,40 +1,49 @@
----
 name: F5 CLA
+
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
   pull_request_target:
-    types: [opened, closed, synchronize]
-permissions: read-all
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.ref_name }}-cla
+
+permissions:
+  contents: read
+
 jobs:
   f5-cla:
     name: F5 CLA
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       actions: write
+      contents: read
       pull-requests: write
       statuses: write
     steps:
       - name: Run F5 Contributor License Agreement (CLA) assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have hereby read the F5 CLA and agree to its terms') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: contributor-assistant/github-action@f41946747f85d28e9a738f4f38dbcc74b69c7e0e # v2.5.1
         with:
           # Any pull request targeting the following branch will trigger a CLA check.
-          # NOTE: You might need to edit this value to 'main'.
-          branch: main
+          branch: "main"
           # Path to the CLA document.
-          path-to-document: https://github.com/f5/.github/blob/main/CLA/cla-markdown.md
+          path-to-document: "https://github.com/f5/.github/blob/main/CLA/cla-markdown.md"
           # Custom CLA messages.
-          custom-notsigned-prcomment: '🎉 Thank you for your contribution! It appears you have not yet signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md), which is required for your changes to be incorporated into an F5 Open Source Software (OSS) project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and reply on a new comment with the following text to agree:'
-          custom-pr-sign-comment: 'I have hereby read the F5 CLA and agree to its terms'
-          custom-allsigned-prcomment: '✅ All required contributors have signed the F5 CLA for this PR. Thank you!'
+          custom-notsigned-prcomment: "🎉 Thank you for your contribution! It appears you have not yet signed the F5 Contributor License Agreement (CLA), which is required for your changes to be incorporated into an F5 Open Source Software (OSS) project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and reply on a new comment with the following text to agree:"
+          custom-pr-sign-comment: "I have hereby read the F5 CLA and agree to its terms"
+          custom-allsigned-prcomment: "✅ All required contributors have signed the F5 CLA for this PR. Thank you!"
           # Remote repository storing CLA signatures.
-          remote-organization-name: f5
-          remote-repository-name: f5-cla-data
-          path-to-signatures: signatures/signatures.json
+          remote-organization-name: "f5"
+          remote-repository-name: "f5-cla-data"
+          path-to-signatures: "signatures/beta/signatures.json"
           # Comma separated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
-          # NOTE: You will want to edit the usernames to suit your project needs.
-          allowlist: alessfg, bot*
+          allowlist: bot*
           # Do not lock PRs after a merge.
           lock-pullrequest-aftermerge: false
         env:


### PR DESCRIPTION
### Proposed changes

Problem: F5 CLA Bot should automatically write usernames, etc. for users who agree to the [F5 Contributor License Agreement](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).

The current bot is not working.

Solution: I've taken (most) a f5-cla.yml file from a repo where the process works (https://github.com/nginx/agent/blob/main/.github/workflows/f5-cla.yml) to modify a different version of the same file in this documentation repository.

Testing: Hopefully we can set up a test as part of this PR.

Unknown: could the problem be related to the new year.

GitHub issue:
closes: #37 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
- [ ] If the change involves:
  - Code
  - Anything that resembles Personally identifying information (PII)
    - Make sure to use placeholders such as `<username>` in place of PII
  - URLs (watch for [typosquatting](https://support.microsoft.com/en-us/topic/what-is-typosquatting-54a18872-8459-4d47-b3e3-d84d9a362eb0))
  - Significant new/revised content
    
  In these cases, the change will require at least two (2) approvals before merging
