### PR TITLE
Fix broken link in upgrade-nap-waf.md

### DIFF
--- a/content/nap-waf/v4/admin-guide/upgrade-nap-waf.md
+++ b/content/nap-waf/v4/admin-guide/upgrade-nap-waf.md
@@ -19,7 +19,7 @@ Upgrade NGINX App Protect by installing the new version of _nms-nap-compiler_ on
 
 Ensure the **nms-integrations** service recognizes both the new and existing _nms-nap-compiler_ versions. Complete this step before upgrading NGINX App Protect on your data planes.
 
-For details on matching NGINX App Protect WAF releases with their WAF compiler versions, refer to the the [WAF Compiler and Supported App Protect Versions](https://docs.nginx.com/nginx-instance-manager/nginx-app-protect/setup-waf-config-management/#install-the-waf-compiler) topic.
+For details on matching NGINX App Protect WAF releases with their WAF compiler versions, refer to the the [WAF Compiler and Supported App Protect Versions]({{< ref "/nim/nginx-app-protect/setup-waf-config-management.md#install-the-waf-compiler" >}}) topic.
 
 ## Upgrade NGINX App Protect on the Data Plane
 

--- a/content/nap-waf/v4/admin-guide/upgrade-nap-waf.md
+++ b/content/nap-waf/v4/admin-guide/upgrade-nap-waf.md
@@ -19,7 +19,7 @@ Upgrade NGINX App Protect by installing the new version of _nms-nap-compiler_ on
 
 Ensure the **nms-integrations** service recognizes both the new and existing _nms-nap-compiler_ versions. Complete this step before upgrading NGINX App Protect on your data planes.
 
-For details on matching NGINX App Protect WAF releases with their WAF compiler versions, refer to the the [WAF Compiler and Supported App Protect Versions](https://docs.nginx.com/nginx-instance-manager/app-protect/setup-waf-config-management/#install-the-waf-compiler) topic.
+For details on matching NGINX App Protect WAF releases with their WAF compiler versions, refer to the the [WAF Compiler and Supported App Protect Versions](https://docs.nginx.com/nginx-instance-manager/nginx-app-protect/setup-waf-config-management/#install-the-waf-compiler) topic.
 
 ## Upgrade NGINX App Protect on the Data Plane
 


### PR DESCRIPTION
Fix broken link in nginx-app-protect-waf

### Proposed changes

Problem: Automation found broken link in nginx-app-protect-waf docs. https://github.com/nginx/documentation/actions/runs/12685140469/job/35354980039
Possibly caused by Azure content update.

Solution: URL is updated.

Testing: Local testing, URL opens correctly. No more 404


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [x] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
- [ ] If the change involves:
  - Code
  - Anything that resembles Personally identifying information (PII)
    - Make sure to use placeholders such as `<username>` in place of PII
  - URLs (watch for [typosquatting](https://support.microsoft.com/en-us/topic/what-is-typosquatting-54a18872-8459-4d47-b3e3-d84d9a362eb0))
  - Significant new/revised content
    
  In these cases, the change will require at least two (2) approvals before merging
