### PR TITLE
Resolve duplicate and scrolling note for self-signed certs

### DIFF
--- a/content/includes/licensing-and-reporting/configure-nginx-plus-report-to-nim.md
+++ b/content/includes/licensing-and-reporting/configure-nginx-plus-report-to-nim.md
@@ -12,9 +12,7 @@ docs:
     }
     ```
 
-  {{<call-out "note" "Self-signed certificates" "" >}}
-    For details on using self-signed certificates, see [Configure SSL verification for usage reporting with self-signed certificates]({{< relref "nim/system-configuration/secure-traffic.md#configure-ssl-verify" >}}).
-  {{</call-out>}}
+    {{<call-out "note" "Extra steps for self-signed certificates">}}If you use self-signed certificates in your NGINX Instance Manager environment, follow the steps in [Configure SSL verification for usage reporting with self-signed certificates]({{< relref "nim/system-configuration/secure-traffic.md#configure-ssl-verify" >}}).{{</call-out>}}
 
 3. Reload NGINX:
 

--- a/content/solutions/about-subscription-licenses.md
+++ b/content/solutions/about-subscription-licenses.md
@@ -77,8 +77,6 @@ In environments where NGINX Plus instances cannot access the internet, you'll ne
 
 #### Configure NGINX Plus to report usage to NGINX Instance Manager
 
-{{<call-out "note" "Extra setup for self-signed certificates">}}If your NGINX Instance Manager environment uses self-signed certificates, see [Configure SSL verification for usage reporting with self-signed certificates]({{< relref "nim/system-configuration/secure-traffic.md#configure-ssl-verify" >}}).{{</call-out>}}
-
 To configure NGINX Plus R33 or later to report usage data to NGINX Instance Manger:
 
 {{< include "licensing-and-reporting/configure-nginx-plus-report-to-nim.md" >}}


### PR DESCRIPTION
This PR makes two improvements to the way we show notes about self-signed certificates:

1. It removes repeated notes to keep things clear and simple.
2. It fixes a formatting issue that made the note hard to read and caused it to scroll awkwardly.

### Before

<img width="890" alt="image" src="https://github.com/user-attachments/assets/5488d42d-8a4f-4d71-865b-fc64c1e31b26" />


https://github.com/user-attachments/assets/a458d7e0-6d31-4ec0-9125-0f03c5fa77da

### After

<img width="885" alt="image" src="https://github.com/user-attachments/assets/d4f623c9-bb2d-4918-8387-1532fe29e7e3" />
