### PR TITLE
Pin lighthouse runner to 22.04

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -74,7 +74,7 @@ jobs:
   lighthouseci:
     if: github.event.pull_request
     needs: call-docs-build-push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Pin lighthouse runner to ubuntu 22.04.
This should be pinned to 24.04 when we get lighthouse to run there properly.