### PR TITLE
feat: Add explicit URL parameter to Gateway Fabric index pages

### DIFF
--- a/content/ngf/how-to/_index.md
+++ b/content/ngf/how-to/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "How-to guides"
+url: /nginx-gateway-fabric/how-to/
 weight: 400
 ---

--- a/content/ngf/how-to/monitoring/_index.md
+++ b/content/ngf/how-to/monitoring/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Monitoring and troubleshooting"
+url: /nginx-gateway-fabric/how-to/monitoring/
 weight: 300
 ---

--- a/content/ngf/how-to/traffic-management/_index.md
+++ b/content/ngf/how-to/traffic-management/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Traffic management"
+url: /nginx-gateway-fabric/how-to/traffic-management/
 weight: 100
 ---

--- a/content/ngf/how-to/traffic-security/_index.md
+++ b/content/ngf/how-to/traffic-security/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Traffic security"
+url: /nginx-gateway-fabric/how-to/traffic-security
 weight: 200
 ---

--- a/content/ngf/installation/_index.md
+++ b/content/ngf/installation/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Installation"
+url: /nginx-gateway-fabric/installation/
 weight: 300
 ---

--- a/content/ngf/installation/installing-ngf/_index.md
+++ b/content/ngf/installation/installing-ngf/_index.md
@@ -1,9 +1,5 @@
 ---
 title: "Install NGINX Gateway Fabric"
-description:
+url: /nginx-gateway-fabric/installation/installing-ngf/
 weight: 100
-linkTitle: "Install NGINX Gateway Fabric"
-menu:
-  docs:
-    parent: Installation
 ---

--- a/content/ngf/overview/_index.md
+++ b/content/ngf/overview/_index.md
@@ -1,4 +1,5 @@
 ---
-title: Overview
+title: "Overview"
 weight: 100
+url: /nginx-gateway-fabric/overview
 ---

--- a/content/ngf/reference/_index.md
+++ b/content/ngf/reference/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Reference"
 weight: 500
+url: /nginx-gateway-fabric/reference/
 ---


### PR DESCRIPTION
### Proposed changes

This commit adds an explicit URL to the subfolders of the NGINX Gateway Fabric set, which is inherited by the pages within the folders. It is necessary for URLs to resolve sensibly, as otherwise they default to the folder path, /ngf/, which we do not map as part of the deployment.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
- [] If the change involves potentially sensitive changes, I have assessed the possible impact
- [] If applicable, I have added tests that prove my fix is effective or that my feature works
- [] If applicable, I have checked that any relevant tests pass after adding my changes
- [] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [] I have rebased my branch onto main
- [] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.