### PR TITLE
feat: Add NGINX Gateway Fabric to CODEOWNERS, alphabetize file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,19 +15,31 @@
 
 # DocOps Writers
 *                           @nginx/nginx-docs
+
 # DocOps Engineers
 .github/*                   @nginx/docs-engineering
-# NGINX Plus
-content/nginx/*             @nginx/plus-docs-approvers
+
 # NGINX Agent
 content/nginx/nms/agent/*   @nginx/agent-docs-approvers
-# NGINX One
-content/nginx-one/*         @nginx/one-docs-approvers
-# NGINX Instance Manager
-content/nms/nim/*           @nginx/nim-docs-approvers
-content/nim/*               @nginx/nim-docs-approvers
+
+# NGINX App Protect DoS
+content/nap-dos/*           @nginx/dos-docs-approvers
+
 # NGINX App Protect WAF
 content/nap-waf/*           @nginx/nap-docs-approvers
 data/nap-waf/*              @nginx/nap-docs-approvers
-# NGINX App Protect DoS
-content/nap-dos/*           @nginx/dos-docs-approvers
+
+# NGINX Gateway Fabric
+content/ngf/*               @nginx/nginx-gateway-fabric
+content/includes/ngf/*      @nginx/nginx-gateway-fabric
+
+# NGINX Instance Manager
+content/nms/nim/*           @nginx/nim-docs-approvers
+content/nim/*               @nginx/nim-docs-approvers
+
+# NGINX Plus
+content/nginx/*             @nginx/plus-docs-approvers
+
+# NGINX One
+content/nginx-one/*         @nginx/one-docs-approvers
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 .github/*                   @nginx/docs-engineering
 
 # NGINX Agent
-content/nginx/nms/agent/*   @nginx/agent-docs-approvers
+content/nginx/nms/agent/*   @nginx/nginx-agent 
 
 # NGINX App Protect DoS
 content/nap-dos/*           @nginx/dos-docs-approvers


### PR DESCRIPTION
### Proposed changes

This commit adds the NGINX Gateway Fabric team as codeowners of the NGF subfolders related to the product, ensuring they get tagged when relevant. As part of this change, I have also alphabetized the teams and adjusting the spacing for readability.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes, I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.