### PR TITLE
fix: fixed see-also call-outs that weren't resolving in NGINX Plus deployment guides

### DIFF
--- a/content/nginx/deployment-guides/single-sign-on/active-directory-federation-services.md
+++ b/content/nginx/deployment-guides/single-sign-on/active-directory-federation-services.md
@@ -11,7 +11,7 @@ weight: 100
 
 This guide explains how to enable single sign-on (SSO) for applications being proxied by F5 NGINX Plus. The solution uses OpenID Connect as the authentication mechanism, with [Microsoft Active Directory Federation Services](https://docs.microsoft.com/en-us/windows-server/identity/active-directory-federation-services) (AD FS) as the identity provider (IdP) and NGINX Plus as the relying party.
 
-{{< see-also >}}{{< readfile file="includes/nginx-openid-repo-note.txt" markdown="true" >}}{{< /see-also >}}
+{{< see-also >}}{{< include "nginx-plus/nginx-openid-repo-note.txt" >}}{{< /see-also >}}
 
 <span id="prereqs"></span>
 ## Prerequisites

--- a/content/nginx/deployment-guides/single-sign-on/auth0.md
+++ b/content/nginx/deployment-guides/single-sign-on/auth0.md
@@ -18,7 +18,7 @@ This documentation applies to F5 NGINX Plus R15 and later.
 
 You can use NGINX Plus with [Auth0](https://auth0.com/) and OpenID Connect to enable single sign-on (SSO) for your proxied applications. By following the steps in this guide, you will learn how to set up SSO using OpenID Connect as the authentication mechanism, with Auth0 as the identity provider (IdP), and NGINX Plus as the relying party.
 
-{{< see-also >}}{{< readfile file="includes/nginx-openid-repo-note.txt" markdown="true" >}}{{< /see-also >}}
+{{< see-also >}}{{< include "nginx-plus/nginx-openid-repo-note.txt" >}}{{< /see-also >}}
 
 ## Prerequisites
 

--- a/content/nginx/deployment-guides/single-sign-on/cognito.md
+++ b/content/nginx/deployment-guides/single-sign-on/cognito.md
@@ -11,7 +11,7 @@ weight: 100
 
 This guide explains how to enable single sign‑on (SSO) for applications being proxied by F5 NGINX Plus. The solution uses OpenID Connect as the authentication mechanism, with [Amazon Cognito](https://aws.amazon.com/cognito/) as the identity provider (IdP), and NGINX Plus as the relying party.
 
-{{< see-also >}}{{< readfile file="includes/nginx-openid-repo-note.txt" markdown="true" >}}{{< /see-also >}}
+{{< see-also >}}{{< include "nginx-plus/nginx-openid-repo-note.txt" >}}{{< /see-also >}}
 
 
 <span id="prereqs"></span>

--- a/content/nginx/deployment-guides/single-sign-on/keycloak.md
+++ b/content/nginx/deployment-guides/single-sign-on/keycloak.md
@@ -11,7 +11,7 @@ weight: 100
 
 This guide explains how to enable single sign-on (SSO) for applications being proxied by F5 NGINX Plus. The solution uses OpenID Connect as the authentication mechanism, with [Keycloak](https://www.keycloak.org/) as the identity provider (IdP), and NGINX Plus as the relying party.
 
-{{< see-also >}}{{< readfile file="includes/nginx-openid-repo-note.txt" markdown="true" >}}{{< /see-also >}}
+{{< see-also >}}{{< include "nginx-plus/nginx-openid-repo-note.txt" >}}{{< /see-also >}}
 
 
 <span id="prereqs"></span>

--- a/content/nginx/deployment-guides/single-sign-on/okta.md
+++ b/content/nginx/deployment-guides/single-sign-on/okta.md
@@ -16,7 +16,7 @@ This documentation applies to F5 NGINX Plus R15 and later.
 
 You can use NGINX Plus with Okta and OpenID Connect to enable single sign-on (SSO) for your proxied applications. By following the steps in this guide, you will learn how to set up SSO using OpenID Connect as the authentication mechanism, with Okta as the identity provider (IdP), and NGINX Plus as the relying party.
 
-{{< see-also >}}{{< readfile file="includes/nginx-openid-repo-note.txt" markdown="true" >}}{{< /see-also >}}
+{{< see-also >}}{{< include "nginx-plus/nginx-openid-repo-note.txt" >}}{{< /see-also >}}
 
 ## Prerequisites
 

--- a/content/nginx/deployment-guides/single-sign-on/onelogin.md
+++ b/content/nginx/deployment-guides/single-sign-on/onelogin.md
@@ -18,7 +18,7 @@ This documentation applies to F5 NGINX Plus R15 and later.
 
 You can use NGINX Plus with [OneLogin](https://www.onelogin.com/) and the OpenID Connect protocol to enable single sign-on (SSO) for your proxied applications. By following the steps in this guide, you will learn how to set up SSO using OpenID Connect as the authentication mechanism, with OneLogin as the identity provider (IdP) and NGINX Plus as the relying party.
 
-{{< see-also >}}{{< readfile file="includes/nginx-openid-repo-note.txt" markdown="true" >}}{{< /see-also >}}
+{{< see-also >}}{{< include "nginx-plus/nginx-openid-repo-note.txt" >}}{{< /see-also >}}
 
 ## Prerequisites
 

--- a/content/nginx/deployment-guides/single-sign-on/ping-identity.md
+++ b/content/nginx/deployment-guides/single-sign-on/ping-identity.md
@@ -13,7 +13,7 @@ This guide explains how to enable single sign-on (SSO) for applications being pr
 
 The instructions in this document apply to both Ping Identity's on‑premises and cloud products, PingFederate and PingOne for Enterprise.
 
-{{< see-also >}}{{< readfile file="includes/nginx-openid-repo-note.txt" markdown="true" >}}{{< /see-also >}}
+{{< see-also >}}{{< include "nginx-plus/nginx-openid-repo-note.txt" >}}{{< /see-also >}}
 
 <span id="prereqs"></span>
 ## Prerequisites


### PR DESCRIPTION
### Proposed changes

This PR fixes several `see-also` call-outs that weren't resolving in NGINX Deployment guides.

Closes #128 

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
- [x] If the change involves potentially sensitive changes, I have assessed the possible impact
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.