### PR TITLE
Update NGF documentation on how to use NginxProxy 

### DIFF
--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -11,13 +11,172 @@ Learn how to dynamically update the NGINX Gateway Fabric global data plane confi
 
 ## Overview
 
-NGINX Gateway Fabric can dynamically update the global data plane configuration without restarting. The data plane configuration is a global configuration for NGINX that has options that are not available using the standard Gateway API resources. This includes such things as setting an OpenTelemetry collector config, disabling http2, changing the IP family, or setting the NGINX error log level.
+NGINX Gateway Fabric can dynamically update the global data plane configuration without restarting. The data plane configuration contains configuration for NGINX that are not available using the standard Gateway API resources. This includes such things as setting an OpenTelemetry collector config, disabling http2, changing the IP family, or setting the NGINX error log level.
 
-The data plane configuration is stored in the NginxProxy custom resource, which is a cluster-scoped resource that is attached to the `nginx` GatewayClass.
+The data plane configuration is stored in the NginxProxy custom resource, which is a namespace-scoped resource that can be attached to a GatewayClass or Gateway. When attached to a GatewayClass, the fields in the NginxProxy affect all Gateways that belong to the GatewayClass.
+When attached to a Gateway, the fields in the NginxProxy only affect the Gateway. If a GatewayClass and its Gateway both specify an NginxProxy, the GatewayClass NginxProxy provides defaults that can be overridden by the Gateway NginxProxy. See the [Merging Semantics](#merging-semantics) section for more detail.
 
-By default, the NginxProxy resource is not created when installing NGINX Gateway Fabric. However, you can set configuration options in the `nginx.config` Helm values, and the resource will be created and attached when NGINX Gateway Fabric is installed using Helm. You can also [manually create and attach](#manually-creating-the-configuration) the resource after NGINX Gateway Fabric is already installed.
+---
 
-When installed using the Helm chart, the NginxProxy resource is named `<release-name>-proxy-config`.
+## Merging Semantics
+
+NginxProxy resources are merged when a GatewayClass and a Gateway reference different NginxProxy resources.
+
+For fields that are bools, integers, and strings:
+- If a field on the Gateway's NginxProxy is unspecified (`nil`), the Gateway __inherits__ the value of the field in the GatewayClass's NginxProxy.
+- If a field on the Gateway's NginxProxy is specified, its value __overrides__ the value of the field in the GatewayClass's NginxProxy.
+
+For array fields:
+- If the array on the Gateway's NginxProxy is unspecified (`nil`), the Gateway __inherits__ the entire array in the GatewayClass's NginxProxy.
+- If the array on the Gateway's NginxProxy is empty, it __overrides__ the entire array in the GatewayClass's NginxProxy, effectively unsetting the field.
+- If the array on the Gateway's NginxProxy is specified and not empty, it __overrides__ the entire array in the GatewayClass's NginxProxy.
+
+
+### Merging Examples
+
+This section contains examples of how NginxProxy resources are merged when they are attached to both a Gateway and its GatewayClass.
+
+#### Disable HTTP/2 for a Gateway
+
+A GatewayClass references the following NginxProxy which explicitly allows HTTP/2 traffic and sets the IPFamily to ipv4:
+
+```yaml
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: gateway-class-enable-http2
+  namespace: default
+spec:
+  ipFamily: "ipv4"
+  disableHTTP: false
+```
+
+To disable HTTP/2 traffic for a particular Gateway, reference the following NginxProxy in the Gateway's spec:
+
+```yaml
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: gateway-disable-http
+  namespace: default
+spec:
+  disableHTTP: true
+```
+
+These NginxProxy resources are merged and the following settings are applied to the Gateway:
+
+```yaml
+ipFamily: "ipv4"
+disableHTTP: true
+```
+
+#### Change Telemetry configuration for a Gateway
+
+A GatewayClass references the following NginxProxy which configures telemetry:
+
+```yaml
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: gateway-class-telemetry
+  namespace: default
+spec:
+  telemetry:
+    exporter:
+      endpoint: "my.telemetry.collector:9000"
+      interval: "60s"
+      batchSize: 20
+    serviceName: "my-company"
+    spanAttributes:
+    - key: "company-key"
+      value: "company-value"
+```
+
+To change the telemetry configuration for a particular Gateway, reference the following NginxProxy in the Gateway's spec:
+
+```yaml
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: gateway-telemetry-service-name
+  namespace: default
+spec:
+  telemetry:
+    exporter:
+      batchSize: 50
+      batchCount: 5
+    serviceName: "my-app"
+    spanAttributes:
+    - key: "app-key"
+      value: "app-value"
+```
+
+These NginxProxy resources are merged and the following settings are applied to the Gateway:
+
+```yaml
+  telemetry:
+    exporter:
+      endpoint: "my.telemetry.collector:9000"
+      interval: "60s"
+      batchSize: 50
+      batchCount: 5
+    serviceName: "my-app"
+    spanAttributes:
+    - key: "app-key"
+      value: "app-value"
+```
+
+#### Disable Tracing for a Gateway
+
+A GatewayClass references the following NginxProxy which configures telemetry:
+
+```yaml
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: gateway-class-telemetry
+  namespace: default
+spec:
+  telemetry:
+    exporter:
+      endpoint: "my.telemetry.collector:9000"
+      interval: "60s"
+    serviceName: "my-company"
+```
+
+To disable tracing for a particular Gateway, reference the following NginxProxy in the Gateway's spec:
+
+```yaml
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: gateway-disable-tracing
+  namespace: default
+spec:
+  telemetry:
+    disabledFeatures:
+    - DisableTracing
+```
+
+These NginxProxy resources are merged and the following settings are applied to the Gateway:
+
+```yaml
+telemetry:
+    exporter:
+      endpoint: "my.telemetry.collector:9000"
+      interval: "60s"
+    serviceName: "my-app"
+    disabledFeatures:
+    - DisableTracing
+```
+
+---
+
+## Configuring the GatewayClass NginxProxy on Install
+
+By default, the NginxProxy resource is not created when installing NGINX Gateway Fabric. However, you can set configuration options in the `nginx.config` Helm values, and the resource will be created and attached to the GatewayClass when NGINX Gateway Fabric is installed using Helm. You can also [manually create and attach](#manually-creating-nginxproxies) the resource after NGINX Gateway Fabric is already installed.
+
+When installed using the Helm chart, the NginxProxy resource is named `<release-name>-proxy-config` and is created in the release Namespace.
 
 **For a full list of configuration options that can be set, see the `NginxProxy spec` in the [API reference]({{< ref "/ngf/reference/api.md" >}}).**
 
@@ -25,30 +184,48 @@ When installed using the Helm chart, the NginxProxy resource is named `<release-
 
 ---
 
-## Viewing and Updating the Configuration
+## Manually Creating NginxProxies
 
-If the `NginxProxy` resource already exists, you can view and edit it.
+The following command creates a basic `NginxProxy` configuration that sets the IP family to `ipv4` instead of the default value of `dual`:
 
-{{< note >}} For the following examples, the name `ngf-proxy-config` should be updated to the name of the resource created for your installation. {{< /note >}}
-
-To view the current configuration:
-
-```shell
-kubectl describe nginxproxies ngf-proxy-config
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: ngf-proxy-config
+  namespace: default
+spec:
+  ipFamily: ipv4
+EOF
 ```
 
-To update the configuration:
+**For a full list of configuration options that can be set, see the `NginxProxy spec` in the [API reference]({{< ref "/ngf/reference/api.md" >}}).**
+
+---
+
+### Attaching NginxProxy to GatewayClass
+
+To attach the `ngf-proxy-config` NginxProxy to the GatewayClass:
 
 ```shell
-kubectl edit nginxproxies ngf-proxy-config
+kubectl edit gatewayclass <gateway-class-name>
 ```
 
-This will open the configuration in your default editor. You can then update and save the configuration, which is applied automatically to the data plane.
+This will open your default editor, allowing you to add the following to the `spec`:
 
-To view the status of the configuration, check the GatewayClass that it is attached to:
+```yaml
+parametersRef:
+    group: gateway.nginx.org
+    kind: NginxProxy
+    name: ngf-proxy-config
+    namespace: default
+```
+
+After updating, you can check the status of the GatewayClass to see if the configuration is valid:
 
 ```shell
-kubectl describe gatewayclasses nginx
+kubectl describe gatewayclasses <gateway-class-name>
 ```
 
 ```text
@@ -67,42 +244,29 @@ If everything is valid, the `ResolvedRefs` condition should be `True`. Otherwise
 
 ---
 
-## Manually create the configuration
+### Attaching NginxProxy to Gateway
 
-If the `NginxProxy` resource doesn't exist, you can create it and attach it to the GatewayClass.
-
-The following command creates a basic `NginxProxy` configuration that sets the IP family to `ipv4` instead of the default value of `dual`:
-
-```yaml
-kubectl apply -f - <<EOF
-apiVersion: gateway.nginx.org/v1alpha1
-kind: NginxProxy
-metadata:
-  name: ngf-proxy-config
-spec:
-  ipFamily: ipv4
-EOF
-```
-
-Now we need to attach it to the GatewayClass:
+To attach the `ngf-proxy-config` NginxProxy to a Gateway:
 
 ```shell
-kubectl edit gatewayclass nginx
+kubectl edit gateway <gateway-name>
 ```
 
 This will open your default editor, allowing you to add the following to the `spec`:
 
 ```yaml
-parametersRef:
-    group: gateway.nginx.org
-    kind: NginxProxy
-    name: ngf-proxy-config
+infrastructure:
+    parametersRef:
+        group: gateway.nginx.org
+        kind: NginxProxy
+        name: ngf-proxy-config
+        namespace: default
 ```
 
-After updating, you can check the status of the GatewayClass to see if the configuration is valid:
+After updating, you can check the status of the Gateway to see if the configuration is valid:
 
 ```shell
-kubectl describe gatewayclasses nginx
+kubectl describe gateway <gateway-name>
 ```
 
 ```text
@@ -129,7 +293,7 @@ The following command creates a basic `NginxProxy` configuration that sets the l
 
 ```yaml
 kubectl apply -f - <<EOF
-apiVersion: gateway.nginx.org/v1alpha1
+apiVersion: gateway.nginx.org/v1alpha2
 kind: NginxProxy
 metadata:
   name: ngf-proxy-config
@@ -138,8 +302,6 @@ spec:
     errorLevel: warn
 EOF
 ```
-
-After attaching the NginxProxy to the GatewayClass, the log level of the data plane will be updated to `warn`.
 
 To view the full list of supported log levels, see the `NginxProxy spec` in the [API reference]({{< ref "/ngf/reference/api.md" >}}).
 
@@ -189,7 +351,7 @@ The following command creates an `NginxProxy` resource with `RewriteClientIP` se
 
 ```yaml
 kubectl apply -f - <<EOF
-apiVersion: gateway.nginx.org/v1alpha1
+apiVersion: gateway.nginx.org/v1alpha2
 kind: NginxProxy
 metadata:
   name: ngf-proxy-config

--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -209,7 +209,7 @@ EOF
 To attach the `ngf-proxy-config` NginxProxy to the GatewayClass:
 
 ```shell
-kubectl edit gatewayclass <gateway-class-name>
+kubectl edit gatewayclass nginx
 ```
 
 This will open your default editor, allowing you to add the following to the `spec`:
@@ -225,7 +225,7 @@ parametersRef:
 After updating, you can check the status of the GatewayClass to see if the configuration is valid:
 
 ```shell
-kubectl describe gatewayclasses <gateway-class-name>
+kubectl describe gatewayclass nginx
 ```
 
 ```text

--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -11,7 +11,7 @@ Learn how to dynamically update the NGINX Gateway Fabric global data plane confi
 
 ## Overview
 
-NGINX Gateway Fabric can dynamically update the global data plane configuration without restarting. The data plane configuration contains configuration for NGINX that are not available using the standard Gateway API resources. This includes such things as setting an OpenTelemetry collector config, disabling http2, changing the IP family, or setting the NGINX error log level.
+NGINX Gateway Fabric can dynamically update the global data plane configuration without restarting. The data plane configuration contains configuration for NGINX that is not available using the standard Gateway API resources. This includes such things as setting an OpenTelemetry collector config, disabling http2, changing the IP family, or setting the NGINX error log level.
 
 The data plane configuration is stored in the NginxProxy custom resource, which is a namespace-scoped resource that can be attached to a GatewayClass or Gateway. When attached to a GatewayClass, the fields in the NginxProxy affect all Gateways that belong to the GatewayClass.
 When attached to a Gateway, the fields in the NginxProxy only affect the Gateway. If a GatewayClass and its Gateway both specify an NginxProxy, the GatewayClass NginxProxy provides defaults that can be overridden by the Gateway NginxProxy. See the [Merging Semantics](#merging-semantics) section for more detail.

--- a/content/ngf/overview/gateway-api-compatibility.md
+++ b/content/ngf/overview/gateway-api-compatibility.md
@@ -98,6 +98,10 @@ See the [static-mode]({{< ref "/ngf/reference/cli-help.md#static-mode">}}) comma
 
 - `spec`
   - `gatewayClassName`: Supported.
+  - `infrastructure`: Partially Supported.
+    - `parametersRef`: NginxProxy resource supported.
+    - `labels`: Not supported.
+    - `annotations`: Not supported.
   - `listeners`
     - `name`: Supported.
     - `hostname`: Supported.


### PR DESCRIPTION
### Proposed changes

Problem: The documentation for NGF's NginxProxy API needs to be updated now that NGF supports attaching NginxProxy resources to Gateways.

Solution: Updates the Gateway API Compatibility doc to list Gateway Infrastructure field as partially supported. Also, updates the data plane configuration how-to to describe how to attach NginxProxy resources to Gateways and GatewayClasses.

Testing: Checked the rendered documentation.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes, I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.