### PR TITLE
Update docs for regex matching for HTTPRoutes and GRPCRoutes

### DIFF
--- a/content/ngf/overview/gateway-api-compatibility.md
+++ b/content/ngf/overview/gateway-api-compatibility.md
@@ -167,8 +167,8 @@ See the [static-mode]({{< ref "/ngf/reference/cli-help.md#static-mode">}}) comma
   - `rules`
     - `matches`
       - `path`: Partially supported. Only `PathPrefix` and `Exact` types.
-      - `headers`: Partially supported. Only `Exact` type.
-      - `queryParams`: Partially supported. Only `Exact` type.
+      - `headers`: Supported.
+      - `queryParams`: Supported.
       - `method`: Supported.
     - `filters`
       - `type`: Supported.
@@ -219,7 +219,7 @@ See the [static-mode]({{< ref "/ngf/reference/cli-help.md#static-mode">}}) comma
   - `rules`
     - `matches`
       - `method`: Partially supported. Only `Exact` type with both `method.service` and `method.method` specified.
-      - `headers`: Partially supported. Only `Exact` type.
+      - `headers`: Supported
     - `filters`
       - `type`: Supported.
       - `requestHeaderModifier`: Supported. If multiple filters are configured, NGINX Gateway Fabric will choose the first and ignore the rest.


### PR DESCRIPTION
### Proposed changes

Write a clear and concise description that helps reviewers understand the purpose and impact of your changes. Use the
following format:

Problem: Users need updated documentation for regex matching header and query params for HTTPRoutes and GRPCRoutes

Solution: Adds documentation for advanced routing and gateway compatibility document.

Testing: [Deploy preview ](https://frontdoor-test-docs.nginx.com/previews/nginx-gateway-fabric/3093/)

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

If this PR addresses an [issue](https://github.com/nginx/documentation/issues) on GitHub, ensure that you link to it here:

NGF Repository Story - https://github.com/nginx/nginx-gateway-fabric/issues/1965

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
- [x] If the change involves potentially sensitive changes, I have assessed the possible impact
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.