### PR TITLE
Unpublished docs for Controller, Service Mesh, NMS

### DIFF
--- a/content/controller/_index.md
+++ b/content/controller/_index.md
@@ -6,6 +6,7 @@ weight: 2100
 cascade:
   logo: "NGINX-Controller-product-icon-RGB.svg"
   type: "ctlr-eos"
+  noindex: true
 url: /nginx-controller/
 ---
 

--- a/content/mesh/_index.md
+++ b/content/mesh/_index.md
@@ -6,5 +6,6 @@ linkTitle: "NGINX Service Mesh"
 menu: docs
 cascade:
    type: "mesh-eos"
+   noindex: true
 url: /nginx-service-mesh/
 ---

--- a/content/modsec-waf/_index.md
+++ b/content/modsec-waf/_index.md
@@ -6,6 +6,7 @@ description: |
 weight: 5000
 url: /nginx-waf/
 cascade:
+  noindex: true
   logo: "NGINX-WAF-product-icon-RGB.svg"
 ---
 

--- a/content/success.md
+++ b/content/success.md
@@ -1,7 +1,0 @@
----
-_build:
-  list: never
-  render: always
-display_breadcrumb: false
-title: Thank you for contacting us
----


### PR DESCRIPTION
### Proposed changes

This PR:

- Unpublishes docs for the following products that are EOSL:
  - NGINX Controller
  - NGINX Service Mesh
  - NGINX Management Suite