### PR TITLE
fix: update k8s values file to include secmon image for NIM K8s deployment

### DIFF
--- a/content/nim/deploy/kubernetes/deploy-using-helm.md
+++ b/content/nim/deploy/kubernetes/deploy-using-helm.md
@@ -216,6 +216,7 @@ By default, the following network policies will be created in the release namesp
   dpm            app.kubernetes.io/name=dpm            4m47s
   ingestion      app.kubernetes.io/name=ingestion      4m47s
   integrations   app.kubernetes.io/name=integrations   4m47s
+  secmon         app.kubernetes.io/name=secmon         4m47s
   utility        app.kubernetes.io/name=integrations   4m47s
   ```
 

--- a/content/nim/deploy/kubernetes/deploy-using-helm.md
+++ b/content/nim/deploy/kubernetes/deploy-using-helm.md
@@ -132,27 +132,31 @@ The `values.yaml` file customizes the Helm chart installation without modifying 
             - name: regcred
         apigw:
             image:
-                repository: private-registry.nginx.com/nms-apigw
+                repository: private-registry.nginx.com/nms/apigw
                 tag: <version>
         core:
             image:
-                repository: private-registry.nginx.com/nms-core
+                repository: private-registry.nginx.com/nms/core
                 tag: <version>
         dpm:
             image:
-                repository: private-registry.nginx.com/nms-dpm
+                repository: private-registry.nginx.com/nms/dpm
                 tag: <version>
         ingestion:
             image:
-                repository: private-registry.nginx.com/nms-ingestion
+                repository: private-registry.nginx.com/nms/ingestion
                 tag: <version>
         integrations:
             image:
-                repository: private-registry.nginx.com/nms-integrations
+                repository: private-registry.nginx.com/nms/integrations
+                tag: <version>
+        secmon:
+            image:
+                repository: private-registry.nginx.com/nms/secmon
                 tag: <version>
         utility:
             image:
-                repository: private-registry.nginx.com/nms-utility
+                repository: private-registry.nginx.com/nms/utility
                 tag: <version>
     ```
 


### PR DESCRIPTION
### Proposed changes

Fixed the image paths and added a new `secmon` image to `values.yaml` file for NIM k8s helm deployment as part of NIM v2.19.0 release.

Testing: Tested locally.
<img width="834" alt="Screenshot 2025-02-12 at 4 00 33 PM" src="https://github.com/user-attachments/assets/37e8703f-bd75-4217-b028-fc3015c28e3e" />


Closes # N/A

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes, I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.