### PR TITLE
feat: Update PR links to GitHub URLs, fix inline Tutorial guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,16 +21,16 @@ Closes #ISSUE
 
 Before merging a pull request, run through this checklist and mark each as complete.
 
-- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
 - [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
-- [ ] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
+- [ ] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
 - [ ] If the change involves potentially sensitive changes, I have assessed the possible impact
 - [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
 - [ ] If applicable, I have checked that any relevant tests pass after adding my changes
-- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
+- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)
 - [ ] I have rebased my branch onto main
 - [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
 
 Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.
 
-Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.
+Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.

--- a/archetypes/concept.md
+++ b/archetypes/concept.md
@@ -35,7 +35,7 @@ It is an example of a <other concept>, and is closely related to <third concept>
 
 ## Use cases
 
-[//]: # "Name the individual use case sections after the actual use case itself, e.g "Route traffic between applications"
+[//]: # "Name the individual use case sections after the actual use case itself, e.g 'Route traffic between applications'"
 
 ### Use case 1
 


### PR DESCRIPTION
### Proposed changes

This commit updates the links from the PR templates to use the actual GitHub links: they are currently relative links that do not parse as intended, instead linking to parts of the GitHub website.

It also fixes an issue in the Tutorial archetype's inline Markdown guidance caused by an unintentionally escaped quotation mark.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have ensured that documentation content adheres to [the style guide](/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes, I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md))
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](/templates/style-guide.md) for guidance about placeholder content.