### PR TITLE
Use full path for cost calculator imports temporarily

### DIFF
--- a/content/nginxaas-azure/billing/usage-and-cost-estimator.md
+++ b/content/nginxaas-azure/billing/usage-and-cost-estimator.md
@@ -9,7 +9,7 @@ url: /nginxaas/azure/billing/usage-and-cost-estimator/
 
 {{< raw-html >}}
 
-<link rel="stylesheet" href="nginxaas-azure/css/cost-calculator_v2.css">
+<link rel="stylesheet" href="/nginxaas-azure/css/cost-calculator_v2.css">
 <div id="calculator">
     <h3 id="calculator-section-heading">
             Cost Estimation for Standard V2 Plan
@@ -142,5 +142,5 @@ Max(
         </div>
     </div>
 </div>
-<script type="module" src="nginxaas-azure/js/cost-calculator_v2.js"></script>
+<script type="module" src="/nginxaas-azure/js/cost-calculator_v2.js"></script>
 {{< /raw-html >}}


### PR DESCRIPTION
### Proposed changes

Use full path for cost calculator imports temporarily.
The cost calculator should use the normal hugo approach to pulling in scripts and css, but this will fix the nginxaas migration for now.

*note* This will not work in previews, only in dev/staging/production where the hardcoded url matches.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [x] If the change involves potentially sensitive changes, I have assessed the possible impact
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation.

Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.