### PR TITLE
Add documentation on running NGINX in debug mode

### DIFF
--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -317,18 +317,29 @@ To run NGINX Gateway Fabric with NGINX in debug mode, follow the [installation d
 
 Using Helm: Set `nginx.debug` to true.
 
-Using Kubernetes Manifests: Under the `nginx` container of the deployment manifest, add `-c` and `rm -rf /var/run/nginx/*.sock && nginx-debug -g 'daemon off;'`
-as arguments and add `/bin/sh` as the command. The deployment manifest should look something like this:
+Using Kubernetes Manifests: In the deployment manifest, set the `spec.kubernetes.deployment.container.debug` field in the `NginxProxy` resource to true.
 
-```text
-...
-- args:
-  - -c
-  - rm -rf /var/run/nginx/*.sock && nginx-debug -g 'daemon off;'
-  command:
-  - /bin/sh
-...
+If you want to change the NGINX mode after deploying NGINX Gateway Fabric, you can do so through the `NginxProxy` `spec.kubernetes.deployment.container.debug` field.
+
+The following command creates a basic `NginxProxy` configuration that both sets the NGINX log level to `debug` and runs NGINX in `debug` mode.
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: ngf-proxy-config
+spec:
+  logging:
+    errorLevel: debug
+  kubernetes:
+    deployment:
+      container:
+        debug: true
+EOF
 ```
+
+{{< note >}} When modifying any `deployment` field in the `NginxProxy` resource, any corresponding NGINX instances will be restarted. {{< /note >}}
 
 ---
 


### PR DESCRIPTION
### Proposed changes

Problem: Added support for running NGINX in debug mode in NGF's CP-DP split which changes the old way to run NGINX in debug mode.

Solution: Update docs to show new way to run NGINX in debug mode.

Testing: Generated documentation using `make watch`.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have rebased my branch onto main
- [ ] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [x] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.