### PR TITLE
feat: Add NGINXaaS for Azure team as CODEOWNERS for their documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,10 @@ content/nap-dos/*           @nginx/dos-docs-approvers
 content/nap-waf/*           @nginx/nap-docs-approvers
 data/nap-waf/*              @nginx/nap-docs-approvers
 
+# NGINXaaS for Azure 
+content/nginxaas-azure/*          @nginx/n4a-docs
+content/includes/nginxaas-azure/* @nginx/n4a-docs
+
 # NGINX Gateway Fabric
 content/ngf/*               @nginx/nginx-gateway-fabric
 content/includes/ngf/*      @nginx/nginx-gateway-fabric


### PR DESCRIPTION
### Proposed changes

This commit updates the CODEOWNERS file to add lines for the n4a-docs team, responsible for maintaining the documentation for NGINXaaS for Azure.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have rebased my branch onto main
- [x] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [x] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.