### PR TITLE
Removed extra slash in URI

### DIFF
--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -252,7 +252,7 @@ You will need to use your NGINX repo certificates to setup automatic retrieval o
     <summary>Example request</summary>
 
     ```shell
-    curl -X POST 'https://{{NMS_FQDN}}//api/platform/v1/certs'  \
+    curl -X POST 'https://{{NMS_FQDN}}/api/platform/v1/certs'  \
         --header "Authorization: Bearer <access token>"      \
         --header "Content-Type: application/json"                \
         -d@nginx-repo-certs.json
@@ -372,7 +372,7 @@ You will need to use the [Instance Manager REST API]({{< relref "/nim/fundamenta
 <summary>Attack Signatures Example</summary>
 
 ```shell
-curl -X POST 'https://{{NMS_FQDN}}//api/platform/v1/security/attack-signatures' \
+curl -X POST 'https://{{NMS_FQDN}}/api/platform/v1/security/attack-signatures' \
     --header "Authorization: Bearer <access token>"      \
     --form 'revisionTimestamp="2022.11.16"'                 \
     --form 'filename=@"/attack-signatures.tgz"'
@@ -384,7 +384,7 @@ curl -X POST 'https://{{NMS_FQDN}}//api/platform/v1/security/attack-signatures' 
 <summary>Threat Campaigns Example</summary>
 
 ```shell
-curl -X POST 'https://{{NMS_FQDN}}//api/platform/v1/security/threat-campaigns' \
+curl -X POST 'https://{{NMS_FQDN}}/api/platform/v1/security/threat-campaigns' \
     --header "Authorization: Bearer <access token>"      \
     --form 'revisionTimestamp="2022.11.15"'                 \
     --form 'filename=@"/threat-campaigns.tgz"'


### PR DESCRIPTION
### Proposed changes

URI in `curl -X POST 'https://{{NMS_FQDN}}//api/platform/v1/certs'  \` starts with a double slash which gets a 404/not found resource. Fixed this by removing the extra slash

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [X] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [X] I have rebased my branch onto main
- [X] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [X] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [X] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [X] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] I have ensured that existing tests pass after adding my changes
- [X] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.