### PR TITLE
specified the correct URL for known issues, faq, and changelog

### DIFF
--- a/content/nginxaas-azure/changelog.md
+++ b/content/nginxaas-azure/changelog.md
@@ -3,6 +3,8 @@ title: "Changelog"
 weight: 900
 toc: true
 docs: "DOCS-870"
+url: /nginxaas/azure/changelog/
+
 ---
 
 Learn about the latest updates, new features, and resolved bugs in F5 NGINX as a Service for Azure.

--- a/content/nginxaas-azure/faq.md
+++ b/content/nginxaas-azure/faq.md
@@ -4,6 +4,8 @@ weight: 800
 categories: ["concepts"]
 toc: true
 docs: "DOCS-881"
+url: /nginxaas/azure/faq/
+
 ---
 
 Common questions about F5 NGINX as a Service for Azure (NGINXaaS).

--- a/content/nginxaas-azure/known-issues.md
+++ b/content/nginxaas-azure/known-issues.md
@@ -3,6 +3,8 @@ title: "Known issues"
 weight: 1000
 toc: true
 docs: "DOCS-871"
+url: /nginxaas/azure/known-issues/
+
 ---
 
 List of known issues in the latest release of F5 NGINX as a Service for Azure (NGINXaaS).


### PR DESCRIPTION
### Proposed changes

This PR fixes the URLs for the Changelog, Known Issues, and FAQ topics.

### Bug Description

The **Known Issues**, **Changelog**, and **FAQ** pages for **NGINXaaS for Azure** have URLs that don’t follow the standard format used for other NGINXaaS for Azure (N4A) docs:

- [https://docs.nginx.com/nginxaas-azure/faq/](https://docs.nginx.com/nginxaas-azure/faq/)
- [https://docs.nginx.com/nginxaas-azure/changelog/](https://docs.nginx.com/nginxaas-azure/changelog/)
- [https://docs.nginx.com/nginxaas-azure/known-issues/](https://docs.nginx.com/nginxaas-azure/known-issues/)

### Expected Behavior

The URLs should follow the correct structure:

`https://docs.nginx.com/nginxaas/azure/…/`