### PR TITLE
Unpublished Global Server Load Balancing with Amazon Route 53 and NGINX Plus

### DIFF
--- a/content/nginx/deployment-guides/amazon-web-services/route-53-global-server-load-balancing.md
+++ b/content/nginx/deployment-guides/amazon-web-services/route-53-global-server-load-balancing.md
@@ -7,6 +7,8 @@ doctypes:
 title: Global Server Load Balancing with Amazon Route 53 and NGINX Plus
 toc: true
 weight: 300
+draft: true
+noindex: true
 ---
 
 This deployment guide explains how to configure global server load balancing (GSLB) of traffic for web domains hosted in Amazon [Elastic Compute Cloud](https://aws.amazon.com/ec2/) (EC2). For high availability and improved performance, you set up multiple backend servers (web servers, application servers, or both) for a domain in two or more AWS regions. Within each region, NGINX Plus load balances traffic across the backend servers.


### PR DESCRIPTION
### Proposed changes

This PR:

- Unpublishes and de-indexes the [Global Server Load Balancing with Amazon Route 53 and NGINX Plus](https://docs.nginx.com/nginx/deployment-guides/amazon-web-services/route-53-global-server-load-balancing/) guide.

Issues:

- The guide has 18 broken images and needs a complete overhaul. 
- Views for the guide have dropped from 1402 a year ago to 215 now (an 85% decline), with most views lasting between 0-1 second.
