### PR TITLE
feat: Remove broken link to Yioop search engine

### DIFF
--- a/content/includes/nap-waf/config/common/anti-automation.md
+++ b/content/includes/nap-waf/config/common/anti-automation.md
@@ -131,7 +131,7 @@ This is a list of the trusted bots that are currently part of the bot signatures
 |MojeekBot | [Mojeek search engine](https://www.mojeek.com/) |
 |Yahoo! Slurp | [Yahoo search engine](https://www.yahoo.com/) |
 |Yandex | [Yandex search engine](https://yandex.com/) |
-|YioopBot | [Yioop search engine](https://www.yioop.com/) |
+|YioopBot | Yioop search engine |
 {{</bootstrap-table>}}
 
 


### PR DESCRIPTION
### Proposed changes

This commit removes the link to the Yioop search engine, which is currently offline. Our pipeline automatically checks for broken links, and has been firing warnings about this.

By changing the link to plain text, readers still retain the context that the associated bot is trusted.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have rebased my branch onto main
- [ ] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [ ] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.