### PR TITLE
feat: Update NIM Security Monitoring front matter and reference links

### DIFF
--- a/content/nim/nginx-app-protect/security-monitoring/_index.md
+++ b/content/nim/nginx-app-protect/security-monitoring/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Security Monitoring
-weight: 10000
+weight: 500
 url: /nginx-instance-manager/nginx-app-protect/security-monitoring/
 ---

--- a/content/nim/nginx-app-protect/security-monitoring/_index.md
+++ b/content/nim/nginx-app-protect/security-monitoring/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Security Monitoring
 weight: 10000
-url: /nginx-instance-manager/monitoring/security-monitoring/
+url: /nginx-instance-manager/nginx-app-protect/security-monitoring/
 ---

--- a/content/nim/nginx-app-protect/security-monitoring/troubleshooting.md
+++ b/content/nim/nginx-app-protect/security-monitoring/troubleshooting.md
@@ -1,12 +1,11 @@
 ---
-docs: DOCS-1226
-doctypes:
-- reference
-tags:
-- docs
 title: Troubleshooting
+weight: 500
 toc: true
-weight: 1000
+type: how-to
+product: NIM
+docs: DOCS-1226
+
 ---
 
 ## Security event log backup with Security Monitoring

--- a/content/nim/nginx-app-protect/security-monitoring/update-geo-db.md
+++ b/content/nim/nginx-app-protect/security-monitoring/update-geo-db.md
@@ -26,15 +26,15 @@ Ensure the following prerequisites are met:
 ## Update the geolocation database
 
 1. Create a [MaxMind](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data/) account and subscribe to receive updates for the GeoLite2 database.
-2. Download the GeoLite2 Country database (Edition ID: GeoLite2-Country) in GeoIP2 Binary `.mmdb` format from the [MaxMind](https://www.maxmind.com/en/accounts/current/geoip/downloads) website. The database is included in a `.gzip` file.
-3. Extract the `.gzip` file to access the GeoLite2 Country database file, named `GeoLite2-Country.mmdb`.
-4. Replace the existing `GeoLite2-Country.mmdb` file on the NGINX Instance Manager control plane at `/usr/share/nms/geolite2/GeoLite2-Country.mmdb` with the new database:
+1. Download the GeoLite2 Country database (Edition ID: GeoLite2-Country) in GeoIP2 Binary `.mmdb` format from the [MaxMind](https://www.maxmind.com/en/accounts/current/geoip/downloads) website. The database is included in a `.gzip` file.
+1. Extract the `.gzip` file to access the GeoLite2 Country database file, named `GeoLite2-Country.mmdb`.
+1. Replace the existing `GeoLite2-Country.mmdb` file on the NGINX Instance Manager control plane at `/usr/share/nms/geolite2/GeoLite2-Country.mmdb` with the new database:
 
     ```bash
     sudo scp /path/to/GeoLite2-Country.mmdb {user}@{host}:/usr/share/nms/geolite2/GeoLite2-Country.mmdb
     ```
 
-5. Restart the NGINX Instance Manager services to apply the update:
+1. Restart the NGINX Instance Manager services to apply the update:
 
     ```bash
     sudo systemctl restart nms-ingestion

--- a/content/nim/nginx-app-protect/security-monitoring/update-signatures.md
+++ b/content/nim/nginx-app-protect/security-monitoring/update-signatures.md
@@ -28,20 +28,20 @@ Ensure the following prerequisites are met:
 ## Update the Signature Database
 
 1. Open an SSH connection to the data plane host and log in.
-2. Generate a Signature Report file using the [Attack Signature Report Tool]({{< relref "/nap-waf/v4/configuration-guide/configuration.md#attack-signature-report-tool" >}}). Save the file as `signature-report.json`:
+1. Generate a Signature Report file using the [Attack Signature Report Tool]({{< relref "/nap-waf/v4/configuration-guide/configuration.md#attack-signature-report-tool" >}}). Save the file as `signature-report.json`:
 
     ```bash
     sudo /opt/app_protect/bin/get-signatures -o ./signature-report.json
     ```
 
-3. Open an SSH connection to the management plane host and log in.
-4. Copy the `signature-report.json` file to the NGINX Instance Manager control plane at `/usr/share/nms/sigdb/`:
+1. Open an SSH connection to the management plane host and log in.
+1. Copy the `signature-report.json` file to the NGINX Instance Manager control plane at `/usr/share/nms/sigdb/`:
 
     ```bash
     sudo scp /path/to/signature-report.json {user}@{host}:/usr/share/nms/sigdb/signature-report.json
     ```
 
-5. Restart the NGINX Instance Manager services to apply the update:
+1. Restart the NGINX Instance Manager services to apply the update:
 
     ```bash
     sudo systemctl restart nms-ingestion

--- a/content/nim/nginx-app-protect/setup-waf-config-management.md
+++ b/content/nim/nginx-app-protect/setup-waf-config-management.md
@@ -1,17 +1,13 @@
 ---
+title: Manage Your App Protect WAF Configs
+weight: 100
+toc: true
 description: Learn how to use F5 NGINX Instance Manager to secure your
   applications with NGINX App Protect WAF security policies.
+type: how-to
+product: NIM
 docs: DOCS-996
-doctypes:
-- task
-tags:
-- docs
-title: Manage Your App Protect WAF Configs
-toc: true
-weight: 100
 ---
-
-{{< shortversions "2.6.0" "latest" "nimvers" >}}
 
 ## Overview
 
@@ -21,9 +17,9 @@ Instance Manager helps you manage your F5 NGINX App Protect WAF configurations, 
 
 Complete the following prerequisites before proceeding with this guide.
 
-- You have one or more instances of [NGINX App Protect WAF](https://docs.nginx.com/nginx-app-protect/admin-guide/install/) installed and running. See [Support for NGINX App Protect WAF]({{< relref "tech-specs#support-for-nginx-app-protect-waf" >}}) for a list of supported versions.
+- You have one or more instances of [NGINX App Protect WAF]({{< ref "/nap-waf/" >}}) installed and running. See [Support for NGINX App Protect WAF]({{< ref "tech-specs.md#support-for-nginx-app-protect-waf" >}}) for a list of supported versions.
 
-    {{<note>}}If you are using configuration management and the NGINX Instance Manager Security Monitoring, follow the instructions in the [setup guide]({{<relref "/nim/nginx-app-protect/security-monitoring/set-up-app-protect-instances" >}}) to set up your NGINX App Protect instances before proceeding with this guide.{{</note>}}
+    {{< note >}} If you are using configuration management and the NGINX Instance Manager Security Monitoring, follow the instructions in the [setup guide]({{< ref "/nim/nginx-app-protect/security-monitoring/set-up-app-protect-instances.md" >}}) to set up your NGINX App Protect instances before proceeding with this guide. {{</ note >}}
 
 - You have Instance Manager v2.6.0 or later [installed]({{< relref "/nim/deploy/vm-bare-metal/_index.md" >}}), licensed, and running.
   If you have a subscription to NGINX App Protect WAF, you can find your Instance Manager license in the subscription details section of [MyF5](https://my.f5.com).
@@ -398,7 +394,7 @@ curl -X POST 'https://{{NMS_FQDN}}/api/platform/v1/security/threat-campaigns' \
 
 The Security Monitoring module's analytics dashboards make use of a Signature Database to provide more information on Attack Signatures that have triggered Security Violations, such as the Signature's name, accuracy, and risk level.
 
-To ensure that the dashboards show the most up-to-date information, you need to [update the Security Monitoring Signature Database]({{< relref "/nim/nginx-app-protect/security-monitoring/update-signatures" >}})
+To ensure that the dashboards show the most up-to-date information, you need to [update the Security Monitoring Signature Database]({{< ref "/nim/nginx-app-protect/security-monitoring/update-signatures.md" >}})
 
 ---
 
@@ -922,7 +918,7 @@ server {
 app_protect_security_log "/etc/nms/secops_dashboard.tgz" syslog:server=127.0.0.1:514;
 ```
 
-Refer to the [Security Monitoring setup guide]({{< relref "/nim/nginx-app-protect/security-monitoring/set-up-app-protect-instances" >}}) to learn more. {{</note>}}
+Refer to the [Security Monitoring setup guide]({{< relref "/nim/nginx-app-protect/security-monitoring/set-up-app-protect-instances.md" >}}) to learn more. {{</note>}}
 
 {{<important>}}
 NGINX configuration for NGINX App Protect Version 5 requires the following changes:


### PR DESCRIPTION
### Proposed changes

This commit updates the Security Monitoring subsection of the NAP WAF documentation within NGINX Instance Manager to have contemporary frontmatter formatting, including a fixed url parameter for the index.

The previous URL parameter was causing some odd behaviour, with duplicate deployments of folders.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have rebased my branch onto main
- [ ] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [ ] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.