### PR TITLE
Improve readability of NGINX reverse proxy doc (#299)

### DIFF
--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -43,7 +43,6 @@ location ~ \.php {
 
 Note that in the first example above, the address of the proxied server is followed by a URI, `/link/`. If the URI is specified along with the address, it replaces the part of the request URI that matches the location parameter. 
 
-
 For example, the request with the `/some/path/page.html` URI will be proxied to `http://www.example.com/link/page.html`. However, if a path is not specified or it is not possible to determine the part of URI to be replaced, the full request URI is passed (possibly, modified).
 
 To pass a request to a non-HTTP proxied server, the appropriate `**_pass` directive should be used:

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -91,7 +91,7 @@ The directive that is responsible for enabling and disabling buffering is [proxy
 
 The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) and [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directives control how NGINX stores and buffers data.
 
-[proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) :
+[proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers):
 
 The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) directive controls the size and the number of buffers allocated for a request.These buffers store the body of the response, which typically makes up the larger portion of the data.
 

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -95,7 +95,7 @@ The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#pr
 
 The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) directive controls the size and the number of buffers allocated for a request.These buffers store the body of the response, which typically makes up the larger portion of the data.
 
-[proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) :
+[proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size):
 
 The
 [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directive sets the size of a separate buffer which is used to store the first part of a response.It usually contains a comparatively small response header and can be made smaller than the buffers used for the rest of the response.

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -91,13 +91,7 @@ The directive that is responsible for enabling and disabling buffering is [proxy
 
 The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) and [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directives control how NGINX stores and buffers data.
 
-[proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers):
-
-The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) directive controls the size and the number of buffers allocated for a request.These buffers store the body of the response, which typically makes up the larger portion of the data.
-
-[proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size):
-
-The [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directive sets the size of a separate buffer which is used to store the first part of a response. It usually contains a comparatively small response header and can be made smaller than the buffers used for the rest of the response.
+The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) directive controls the size and the number of buffers allocated for a request. The first part of the response from a proxied server is stored in a separate buffer, the size of which is set with the [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directive. This part usually contains a comparatively small response header and can be made smaller than the buffers for the rest of the response.
 
 In the following example, the default number of buffers is increased and the size of the buffer for the first portion of the response is made smaller than the default.
 

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -17,7 +17,15 @@ Proxying is typically used to distribute the load among several servers, seamles
 
 ## Passing a Request to a Proxied Server
 
-When NGINX proxies a request, it sends the request to a specified proxied server, fetches the response, and sends it back to the client. It is possible to proxy requests to an HTTP server (another NGINX server or any other server) or a non-HTTP server (which can run an application developed with a specific framework, such as PHP or Python) using a specified protocol. Supported protocols include [FastCGI](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html), [uwsgi](https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html), [SCGI](https://nginx.org/en/docs/http/ngx_http_scgi_module.html), and [memcached](https://nginx.org/en/docs/http/ngx_http_memcached_module.html).
+When NGINX proxies a request, it:
+
+1. Sends the request to a specified proxied server
+
+2. Fetches the response
+
+3. Sends the response back to the client. 
+
+It is possible to proxy requests to an HTTP server (another NGINX server or any other server) or a non-HTTP server (which can run an application developed with a specific framework, such as PHP or Python) using a specified protocol. Supported protocols include [FastCGI](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html), [uwsgi](https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html), [SCGI](https://nginx.org/en/docs/http/ngx_http_scgi_module.html), and [memcached](https://nginx.org/en/docs/http/ngx_http_memcached_module.html).
 
 To pass a request to an HTTP proxied server, the [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) directive is specified inside a [location](https://nginx.org/en/docs/http/ngx_http_core_module.html#location). For example:
 
@@ -35,7 +43,10 @@ location ~ \.php {
 }
 ```
 
-Note that in the first example above, the address of the proxied server is followed by a URI, `/link/`. If the URI is specified along with the address, it replaces the part of the request URI that matches the location parameter. For example, here the request with the `/some/path/page.html` URI will be proxied to `http://www.example.com/link/page.html`. If the address is specified without a URI, or it is not possible to determine the part of URI to be replaced, the full request URI is passed (possibly, modified).
+Note that in the first example above, the address of the proxied server is followed by a URI, `/link/`. If the URI is specified along with the address, it replaces the part of the request URI that matches the location parameter. 
+
+
+For example, the request with the `/some/path/page.html` URI will be proxied to `http://www.example.com/link/page.html`. However, if a path is not specified or it is not possible to determine the part of URI to be replaced, the full request URI is passed (possibly, modified).
 
 To pass a request to a non-HTTP proxied server, the appropriate `**_pass` directive should be used:
 
@@ -46,14 +57,14 @@ To pass a request to a non-HTTP proxied server, the appropriate `**_pass` direct
 
 Note that in these cases, the rules for specifying addresses may be different. You may also need to pass additional parameters to the server (see the [reference documentation](https://nginx.org/en/docs/) for more detail).
 
-The [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) directive can also point to a [named group](https://nginx.org/en/docs/http/load_balancing.html#algorithms) of servers. In this case, requests are distributed among the servers in the group according to the [specified method](https://www.nginx.com/resources/admin-guide/load-balancer/).
+The [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) directive can also be used to forward requests to a [named group](https://nginx.org/en/docs/http/load_balancing.html#algorithms) of servers. In this case, requests are distributed among the servers in the group according to the [specified method](https://www.nginx.com/resources/admin-guide/load-balancer/).
 
 <span id="headers"></span>
 ## Passing Request Headers
 
-By default, NGINX redefines two header fields in proxied requests, “Host” and “Connection”, and eliminates the header fields whose values are empty strings. “Host” is set to the `$proxy_host` variable, and “Connection” is set to `close`.
+By default, NGINX modifies two header fields in proxied requests, “Host” and “Connection”, and eliminates the header fields whose values are empty strings before passing the request. “Host” is set to the value of the `$proxy_host` variable, and “Connection” is set to `close`.
 
-To change these setting, as well as modify other header fields, use the [proxy_set_header](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header) directive. This directive can be specified in a [location](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) or higher. It can also be specified in a particular [server](https://nginx.org/en/docs/http/ngx_http_core_module.html#server) context or in the [http](https://nginx.org/en/docs/http/ngx_http_core_module.html#http) block. For example:
+To change these settings, as well as modify other header fields, use the [proxy_set_header](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header) directive. This directive can be specified in a [location](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) or higher. It can also be specified in a particular [server](https://nginx.org/en/docs/http/ngx_http_core_module.html#server) context or in the [http](https://nginx.org/en/docs/http/ngx_http_core_module.html#http) block. For example:
 
 ```nginx
 location /some/path/ {
@@ -81,7 +92,16 @@ By default NGINX buffers responses from proxied servers. A response is stored in
 
 The directive that is responsible for enabling and disabling buffering is [proxy_buffering](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering). By default it is set to `on` and buffering is enabled.
 
-The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) directive controls the size and the number of buffers allocated for a request. The first part of the response from a proxied server is stored in a separate buffer, the size of which is set with the [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directive. This part usually contains a comparatively small response header and can be made smaller than the buffers for the rest of the response.
+The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) and [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directives control how NGINX stores and buffers data.
+
+[proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) :
+
+The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) directive controls the size and the number of buffers allocated for a request.These buffers store the body of the response, which typically makes up the larger portion of the data.
+
+[proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) :
+
+The
+[proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directive sets the size of a separate buffer which is used to store the first part of a response.It usually contains a comparatively small response header and can be made smaller than the buffers used for the rest of the response.
 
 In the following example, the default number of buffers is increased and the size of the buffer for the first portion of the response is made smaller than the default.
 
@@ -113,7 +133,7 @@ A common use of a reverse proxy is to provide load balancing. Learn how to impro
 
 If your proxy server has several network interfaces, sometimes you might need to choose a particular source IP address for connecting to a proxied server or an upstream. This may be useful if a proxied server behind NGINX is configured to accept connections from particular IP networks or IP address ranges.
 
-Specify the [proxy_bind](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_bind) directive and the IP address of the necessary network interface:
+In such cases, you can specify the [proxy_bind](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_bind) directive and the IP address of the necessary network interface:
 
 ```nginx
 location /app1/ {

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -43,7 +43,7 @@ location ~ \.php {
 
 Note that in the first example above, the address of the proxied server is followed by a URI, `/link/`. If the URI is specified along with the address, it replaces the part of the request URI that matches the location parameter. 
 
-For example, the request with the `/some/path/page.html` URI will be proxied to `http://www.example.com/link/page.html`. However, if a path is not specified or it is not possible to determine the part of URI to be replaced, the full request URI is passed (possibly, modified).
+For example, the request with the `/some/path/page.html` URI will be proxied to `http://www.example.com/link/page.html`. However, if the address is specified without a URI, or it is not possible to determine the part of URI to be replaced, the full request URI is passed (possibly, modified).
 
 To pass a request to a non-HTTP proxied server, the appropriate `**_pass` directive should be used:
 

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -54,7 +54,7 @@ To pass a request to a non-HTTP proxied server, the appropriate `**_pass` direct
 
 Note that in these cases, the rules for specifying addresses may be different. You may also need to pass additional parameters to the server (see the [reference documentation](https://nginx.org/en/docs/) for more detail).
 
-The [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) directive can also be used to forward requests to a [named group](https://nginx.org/en/docs/http/load_balancing.html#algorithms) of servers. In this case, requests are distributed among the servers in the group according to the [specified method](https://www.nginx.com/resources/admin-guide/load-balancer/).
+The [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass) directive can also be used to pass requests to a [named group](https://nginx.org/en/docs/http/load_balancing.html#algorithms) of servers. In this case, requests are distributed among the servers in the group according to the [specified method](https://www.nginx.com/resources/admin-guide/load-balancer/).
 
 <span id="headers"></span>
 ## Passing Request Headers

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -97,8 +97,7 @@ The [proxy_buffers](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#pr
 
 [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size):
 
-The
-[proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directive sets the size of a separate buffer which is used to store the first part of a response.It usually contains a comparatively small response header and can be made smaller than the buffers used for the rest of the response.
+The [proxy_buffer_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) directive sets the size of a separate buffer which is used to store the first part of a response. It usually contains a comparatively small response header and can be made smaller than the buffers used for the rest of the response.
 
 In the following example, the default number of buffers is increased and the size of the buffer for the first portion of the response is made smaller than the default.
 

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -19,11 +19,9 @@ Proxying is typically used to distribute the load among several servers, seamles
 
 When NGINX proxies a request, it:
 
-1. Sends the request to a specified proxied server
-
-2. Fetches the response
-
-3. Sends the response back to the client. 
+1. Sends the request to a specified proxy server
+1. Fetches the response
+1. Sends the response back to the client. 
 
 It is possible to proxy requests to an HTTP server (another NGINX server or any other server) or a non-HTTP server (which can run an application developed with a specific framework, such as PHP or Python) using a specified protocol. Supported protocols include [FastCGI](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html), [uwsgi](https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html), [SCGI](https://nginx.org/en/docs/http/ngx_http_scgi_module.html), and [memcached](https://nginx.org/en/docs/http/ngx_http_memcached_module.html).
 

--- a/content/nginx/admin-guide/web-server/reverse-proxy.md
+++ b/content/nginx/admin-guide/web-server/reverse-proxy.md
@@ -59,7 +59,7 @@ The [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy
 <span id="headers"></span>
 ## Passing Request Headers
 
-By default, NGINX modifies two header fields in proxied requests, “Host” and “Connection”, and eliminates the header fields whose values are empty strings before passing the request. “Host” is set to the value of the `$proxy_host` variable, and “Connection” is set to `close`.
+By default, NGINX modifies two header fields in proxied requests, “Host” and “Connection”, and eliminates the header fields whose values are empty strings. “Host” is set to the value of the `$proxy_host` variable, and “Connection” is set to `close`.
 
 To change these settings, as well as modify other header fields, use the [proxy_set_header](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header) directive. This directive can be specified in a [location](https://nginx.org/en/docs/http/ngx_http_core_module.html#location) or higher. It can also be specified in a particular [server](https://nginx.org/en/docs/http/ngx_http_core_module.html#server) context or in the [http](https://nginx.org/en/docs/http/ngx_http_core_module.html#http) block. For example:
 


### PR DESCRIPTION
Problem: A user had reported that the content was hard to read through a Qualtrics survey.

Solution: The content was summarized and split into bullet points where possible in order to make it more digestible and easier to read for non-native English speakers.

This PR addresses [Issue - reportedly difficult to read](https://github.com/nginx/documentation/issues/299) 

<!-- Closes #299 -->

