### PR TITLE
NGINX Plus: Fix inconsistent quoting in access log format example

### DIFF
--- a/content/nginx/admin-guide/monitoring/logging.md
+++ b/content/nginx/admin-guide/monitoring/logging.md
@@ -64,7 +64,7 @@ http {
     log_format upstream_time '$remote_addr - $remote_user [$time_local] '
                              '"$request" $status $body_bytes_sent '
                              '"$http_referer" "$http_user_agent"'
-                             'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
+                             'rt="$request_time" uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
 
     server {
         access_log /spool/logs/nginx-access.log upstream_time;


### PR DESCRIPTION
## Description
This PR fixes a minor inconsistency in the access log format example under the "Setting Up the Access Log" section.

Closes #464 

Previously, `$request_time` was not quoted while the other upstream time variables (`$upstream_connect_time`, `$upstream_header_time`, `$upstream_response_time`) were.  
For consistency and to prevent possible confusion when parsing logs, `$request_time` is now also surrounded by double quotes.

## Changes
- Updated the `log_format` example to quote `$request_time` consistently.

```nginx
http {
    log_format upstream_time '$remote_addr - $remote_user [$time_local] '
                             '"$request" $status $body_bytes_sent '
                             '"$http_referer" "$http_user_agent"'
                             'rt="$request_time" uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';

    server {
        access_log /spool/logs/nginx-access.log upstream_time;
        ...
    }
}
```

## Related Feedback
- Based on user survey feedback (Response ID: `R_32x2MusOk4P1dto`).

## Impact
- Improves clarity and consistency in the documentation examples.
- No functional changes to NGINX behavior.