### PR TITLE
Revert "Updated change log for namespace release"

### DIFF
--- a/content/nginx-one/changelog.md
+++ b/content/nginx-one/changelog.md
@@ -30,20 +30,6 @@ h2 {
 
 Stay up-to-date with what's new and improved in the F5 NGINX One Console.
 
-## Apr 28, 2025
-
-### Manage RBAC access with namespaces
-
-We have added support for namespaces in N1C. You can now:
-
-- Manage resources in isolation in different namespaces.
-- Configure granular user permission controls base on namespace.
-
-If you already have set up resources in a namespace that:
-
-- Does not exist in your F5 Distributed Cloud tenant
-- Was deleted from your NGINX One Console tenant
-
 ## April 3, 2025
 
 ### Create Custom Roles with more precise permissions


### PR DESCRIPTION
Reverts nginx/documentation#434

Nginx One production fix is blocked on staging failure. Best to not show changelog until that's resolved