### PR TITLE
Update aws nlb manifests installation

### DIFF
--- a/content/ngf/installation/installing-ngf/manifests.md
+++ b/content/ngf/installation/installing-ngf/manifests.md
@@ -91,10 +91,17 @@ kubectl apply -f https://raw.githubusercontent.com/nginx/nginx-gateway-fabric/v{
 
 {{%tab name="AWS NLB"%}}
 
-Deploys NGINX Gateway Fabric with NGINX OSS and an AWS Network Load Balancer service.
+Deploys NGINX Gateway Fabric with NGINX OSS.
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/nginx/nginx-gateway-fabric/v{{< version-ngf >}}/deploy/aws-nlb/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/nginx/nginx-gateway-fabric/v{{< version-ngf >}}/deploy/default/deploy.yaml
+```
+
+To set up an AWS Network Load Balancer service, add these annotations to your Gateway infrastructure fields:
+
+```yaml
+service.beta.kubernetes.io/aws-load-balancer-type: "external"
+service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
There is no longer an aws-nlb deploy.yaml file, so we need to update the manifests installation and give some information on setting annotations in the Gateway.

Problem: There is no longer an aws-nlb deploy.yaml file, so we need to update documentation.

Solution: Update the documentation and give information on setting annotations on the Gateway.

Testing: Checked with `make watch`

Related with: https://github.com/nginx/nginx-gateway-fabric/pull/3362

Closes 

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have rebased my branch onto main
- [ ] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [x] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.