### PR TITLE
Tooling: Pull request triggers support slashes in branch names

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -33,7 +33,7 @@ on:
         type: string
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
       - "main"


### PR DESCRIPTION
This adds support for `/`'s in branch names, to trigger build and deploys from PRs.