### PR TITLE
fix: unmanaged certs only include metadata

### DIFF
--- a/content/nginx-one/how-to/certificates/manage-certificates.md
+++ b/content/nginx-one/how-to/certificates/manage-certificates.md
@@ -178,7 +178,7 @@ If you register an instance to NGINX One Console, as described in [Add your NGIN
 - Are used in their NGINX configuration
 - Do _not_ match an existing managed SSL certificate/CA bundle
 
-These certificates appear in the list of unmanaged certificates. NGINX One Console does not store unmanaged certs or keys, only metadata associated with them for monitoring.
+These certificates appear in the list of unmanaged certificates. NGINX One Console does not store unmanaged certs or keys, only metadata associated with certs for monitoring.
 
 We recommend that you convert your unmanaged certificates. Converting to a managed certificate allows you to centrally manage, update, and deploy a certificate to your data plane from the NGINX One Console.
 

--- a/content/nginx-one/how-to/certificates/manage-certificates.md
+++ b/content/nginx-one/how-to/certificates/manage-certificates.md
@@ -178,7 +178,7 @@ If you register an instance to NGINX One Console, as described in [Add your NGIN
 - Are used in their NGINX configuration
 - Do _not_ match an existing managed SSL certificate/CA bundle
 
-These certificates appear in the list of unmanaged certificates.
+These certificates appear in the list of unmanaged certificates. NGINX One Console has no data on those certificates, except for the metadata shown in the console.
 
 We recommend that you convert your unmanaged certificates. Converting to a managed certificate allows you to centrally manage, update, and deploy a certificate to your data plane from the NGINX One Console.
 

--- a/content/nginx-one/how-to/certificates/manage-certificates.md
+++ b/content/nginx-one/how-to/certificates/manage-certificates.md
@@ -178,7 +178,7 @@ If you register an instance to NGINX One Console, as described in [Add your NGIN
 - Are used in their NGINX configuration
 - Do _not_ match an existing managed SSL certificate/CA bundle
 
-These certificates appear in the list of unmanaged certificates. NGINX One Console has no data on those certificates, except for the metadata shown in the console.
+These certificates appear in the list of unmanaged certificates. NGINX One Console does not store unmanaged certs or keys, only metadata associated with them for monitoring.
 
 We recommend that you convert your unmanaged certificates. Converting to a managed certificate allows you to centrally manage, update, and deploy a certificate to your data plane from the NGINX One Console.
 

--- a/content/nginx-one/how-to/config-sync-groups/manage-config-sync-groups.md
+++ b/content/nginx-one/how-to/config-sync-groups/manage-config-sync-groups.md
@@ -37,7 +37,7 @@ Config Sync Groups support configuration inheritance and persistance. If you've 
 
 On the other hand, if you remove all instances from a Config Sync Group, the original configuration persists. In other words, the group retains the configuration from that first instance (or the original configuration). Any new instance that you add later still inherits that configuration.
 
-{{< tip >}}You can use _unmanaged_ certificates. Your actions can affect the [Config Sync Group status](#config-sync-group-status). For future instances on the data plane, if it:
+{{< tip >}}You can use _unmanaged_ certificates. NGINX One Console collects _only_ the metadata shown in the console. It does not include the content of the certificate. Your actions can affect the [Config Sync Group status](#config-sync-group-status). For future instances on the data plane, if it:
 
 - Has unmanaged certificates in the same file paths as defined by the NGINX configuration as the Config Sync Group, that instance will be [**In Sync**](#config-sync-group-status).
 - Will be [**Out of Sync**](#config-sync-group-status) if the instance:

--- a/content/nginx-one/how-to/config-sync-groups/manage-config-sync-groups.md
+++ b/content/nginx-one/how-to/config-sync-groups/manage-config-sync-groups.md
@@ -37,7 +37,7 @@ Config Sync Groups support configuration inheritance and persistance. If you've 
 
 On the other hand, if you remove all instances from a Config Sync Group, the original configuration persists. In other words, the group retains the configuration from that first instance (or the original configuration). Any new instance that you add later still inherits that configuration.
 
-{{< tip >}}You can use _unmanaged_ certificates. NGINX One Console does not store unmanaged certs or keys, only metadata associated with them for monitoring. Your actions can affect the [Config Sync Group status](#config-sync-group-status). For future instances on the data plane, if it:
+{{< tip >}}You can use _unmanaged_ certificates. NGINX One Console does not store unmanaged certs or keys, only metadata associated with the certs or keys for monitoring. Your actions can affect the [Config Sync Group status](#config-sync-group-status). For future instances on the data plane, if it:
 
 - Has unmanaged certificates in the same file paths as defined by the NGINX configuration as the Config Sync Group, that instance will be [**In Sync**](#config-sync-group-status).
 - Will be [**Out of Sync**](#config-sync-group-status) if the instance:

--- a/content/nginx-one/how-to/config-sync-groups/manage-config-sync-groups.md
+++ b/content/nginx-one/how-to/config-sync-groups/manage-config-sync-groups.md
@@ -37,7 +37,7 @@ Config Sync Groups support configuration inheritance and persistance. If you've 
 
 On the other hand, if you remove all instances from a Config Sync Group, the original configuration persists. In other words, the group retains the configuration from that first instance (or the original configuration). Any new instance that you add later still inherits that configuration.
 
-{{< tip >}}You can use _unmanaged_ certificates. NGINX One Console collects _only_ the metadata shown in the console. It does not include the content of the certificate. Your actions can affect the [Config Sync Group status](#config-sync-group-status). For future instances on the data plane, if it:
+{{< tip >}}You can use _unmanaged_ certificates. NGINX One Console does not store unmanaged certs or keys, only metadata associated with them for monitoring. Your actions can affect the [Config Sync Group status](#config-sync-group-status). For future instances on the data plane, if it:
 
 - Has unmanaged certificates in the same file paths as defined by the NGINX configuration as the Config Sync Group, that instance will be [**In Sync**](#config-sync-group-status).
 - Will be [**Out of Sync**](#config-sync-group-status) if the instance:


### PR DESCRIPTION
### Proposed changes

Based on feeback. 

We need to clarify: N1C collects _only_ the metadata associated with unmanaged certs. IOW, it does not include the actual cert.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have rebased my branch onto main
- [ ] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [ ] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.