### PR TITLE
replaced span styles with markdown

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-amazon-web-services.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-amazon-web-services.md
@@ -30,7 +30,7 @@ To quickly set up an NGINX Plus environment on AWS:
 
     Click the **Continue to Subscribe** button to proceed to the **Launch on EC2** page.
 
-3. Select the type of launch by clicking the appropriate tab (**1&#8209;Click&nbsp;Launch***, **Manual Launch**, or **Service Catalog**). Choose the desired options for billing, instance size, and so on, and click the **Accept&nbsp;Software&nbsp;Terms…** button.
+3. Select the type of launch by clicking the appropriate tab (**1&#8209;Click&nbsp;Launch***, **Manual&nbsp;Launch**, or **Service&nbsp;Catalog**). Choose the desired options for billing, instance size, and so on, and click the **Accept&nbsp;Software&nbsp;Terms…** button.
 4. When configuring the firewall rules, add a rule to accept web traffic on TCP ports 80 and 443 (this happens automatically if you launch from the **1&#8209;Click&nbsp;Launch** tab).
 5. As soon as the new EC2 instance launches, NGINX Plus starts automatically and serves a default **index.html** page. To view the page, use a web browser to access the public DNS name of the new instance. You can also check the status of the NGINX Plus server by logging into the EC2 instance and running this command:
 

--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-amazon-web-services.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-amazon-web-services.md
@@ -30,8 +30,8 @@ To quickly set up an NGINX Plus environment on AWS:
 
     Click the **Continue to Subscribe** button to proceed to the **Launch on EC2** page.
 
-3. Select the type of launch by clicking the appropriate tab (<span style="white-space: nowrap; font-weight:bold;">1‑Click Launch</span>, **Manual Launch**, or **Service Catalog**). Choose the desired options for billing, instance size, and so on, and click the <span style="white-space: nowrap; font-weight:bold;">Accept Software Terms…</span> button.
-4. When configuring the firewall rules, add a rule to accept web traffic on TCP ports 80 and 443 (this happens automatically if you launch from the <span style="white-space: nowrap; font-weight:bold;">1-Click Launch</span> tab).
+3. Select the type of launch by clicking the appropriate tab (**1‑Click Launch**, **Manual Launch**, or **Service Catalog**). Choose the desired options for billing, instance size, and so on, and click the **Accept&nbsp;Software&nbsp;Terms…** button.
+4. When configuring the firewall rules, add a rule to accept web traffic on TCP ports 80 and 443 (this happens automatically if you launch from the **1&#8209;Click&nbsp;Launch** tab).
 5. As soon as the new EC2 instance launches, NGINX Plus starts automatically and serves a default **index.html** page. To view the page, use a web browser to access the public DNS name of the new instance. You can also check the status of the NGINX Plus server by logging into the EC2 instance and running this command:
 
 	```nginx

--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-amazon-web-services.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-amazon-web-services.md
@@ -30,7 +30,7 @@ To quickly set up an NGINX Plus environment on AWS:
 
     Click the **Continue to Subscribe** button to proceed to the **Launch on EC2** page.
 
-3. Select the type of launch by clicking the appropriate tab (**1‑Click Launch**, **Manual Launch**, or **Service Catalog**). Choose the desired options for billing, instance size, and so on, and click the **Accept&nbsp;Software&nbsp;Terms…** button.
+3. Select the type of launch by clicking the appropriate tab (**1&#8209;Click&nbsp;Launch***, **Manual Launch**, or **Service Catalog**). Choose the desired options for billing, instance size, and so on, and click the **Accept&nbsp;Software&nbsp;Terms…** button.
 4. When configuring the firewall rules, add a rule to accept web traffic on TCP ports 80 and 443 (this happens automatically if you launch from the **1&#8209;Click&nbsp;Launch** tab).
 5. As soon as the new EC2 instance launches, NGINX Plus starts automatically and serves a default **index.html** page. To view the page, use a web browser to access the public DNS name of the new instance. You can also check the status of the NGINX Plus server by logging into the EC2 instance and running this command:
 

--- a/content/nginx/admin-guide/monitoring/new-relic-plugin.md
+++ b/content/nginx/admin-guide/monitoring/new-relic-plugin.md
@@ -33,7 +33,7 @@ Download the [plug‑in and installation instructions](https://docs.newrelic.com
 
 ## Configuring the Plug‑In
 
-The configuration file for the NGINX plug‑in is <span style="white-space: nowrap; font-weight:bold;">/etc/nginx-nr-agent/nginx-nr-agent.ini</span>. The minimal configuration includes:
+The configuration file for the NGINX plug‑in is **/etc/nginx&#8209;nr&#8209;agent/nginx&#8209;nr&#8209;agent.ini**. The minimal configuration includes:
 
 - Your New Relic license key in the `newrelic_license_key` statement in the `global` section.
 
@@ -44,7 +44,7 @@ The configuration file for the NGINX plug‑in is <span style="white-space: nowr
 
 You can include the optional `http_user` and `http_pass` statements to set HTTP basic authentication credentials in cases where the corresponding location is protected by the NGINX [auth_basic](https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html#auth_basic) directive.
 
-The default log file is <span style="white-space: nowrap; font-weight:bold;">/var/log/nginx-nr-agent.log</span>.
+The default log file is **/var/log/nginx&#8209;nr&#8209;agent.log**.
 
 ## Running the Plug‑In
 

--- a/content/nginx/deployment-guides/amazon-web-services/high-availability-keepalived.md
+++ b/content/nginx/deployment-guides/amazon-web-services/high-availability-keepalived.md
@@ -96,8 +96,8 @@ Allocate an Elastic IP address and remember its ID. For detailed instructions, s
 
 The NGINX Plus HA solution uses two scripts, which are invoked by `keepalived`:
 
-- <span style="white-space: nowrap; font-weight:bold;">nginx-ha-check</span> – Determines the health of NGINX Plus.
-- <span style="white-space: nowrap; font-weight:bold;">nginx-ha-notify</span> – Moves the Elastic IP address when a state transition happens, for example when the backup instance becomes the primary.
+- **nginx&#8209;ha&#8209;check** – Determines the health of NGINX Plus.
+- **nginx&#8209;ha&#8209;notify** – Moves the Elastic IP address when a state transition happens, for example when the backup instance becomes the primary.
 
 1. Create a directory for the scripts, if it doesn’t already exist.
 
@@ -121,7 +121,7 @@ The NGINX Plus HA solution uses two scripts, which are invoked by `keepalived`:
 There are two configuration files for the HA solution:
 
 - **keepalived.conf** – The main configuration file for `keepalived`, slightly different for each NGINX Plus instance.
-- <span style="white-space: nowrap; font-weight:bold;">nginx-ha-notify</span> – The script you downloaded in [Step 4](#ha-aws_ha-scripts), with several user‑defined variables.
+- **nginx&#8209;ha&#8209;notify** – The script you downloaded in [Step 4](#ha-aws_ha-scripts), with several user‑defined variables.
 
 <span id="ha-aws_keepalived-conf-file"></span>
 ### Creating keepalived.conf
@@ -158,8 +158,8 @@ You must change values for the following configuration keywords. As you do so, a
 
 - `script` in the `chk_nginx_service` block – The script that sends health checks to NGINX Plus.
 
-  - On Ubuntu systems, <span style="white-space: nowrap; font-weight:bold;">/usr/lib/keepalived/nginx-ha-check</span>
-  - On CentOS systems, <span style="white-space: nowrap; font-weight:bold;">/usr/libexec/keepalived/nginx-ha-check</span>
+  - On Ubuntu systems, **/usr/lib/keepalived/nginx&#8209;ha&#8209;check**
+  - On CentOS systems, **/usr/libexec/keepalived/nginx&#8209;ha&#8209;check**
 
 - `priority` – The value that controls which instance becomes primary, with a higher value meaning a higher priority. Use `101` for the primary instance and `100` for the backup.
 
@@ -171,13 +171,13 @@ You must change values for the following configuration keywords. As you do so, a
 
 - `notify` – The script that is invoked during a state transition.
 
-  - On Ubuntu systems, <span style="white-space: nowrap; font-weight:bold;">/usr/lib/keepalived/nginx-ha-notify</span>
-  - On CentOS systems, <span style="white-space: nowrap; font-weight:bold;">/usr/libexec/keepalived/nginx-ha-notify</span>
+  - On Ubuntu systems, **/usr/lib/keepalived/nginx&#8209;ha&#8209;notify**
+  - On CentOS systems, **/usr/libexec/keepalived/nginx&#8209;ha&#8209;notify**
 
 <span id="ha-aws_nginx-ha-notify-script"></span>
 ### Creating nginx-ha-notify
 
-Modify the user‑defined variables section of the <span style="white-space: nowrap; font-weight:bold;">nginx-ha-notify</span> script, replacing each `<value>` placeholder with the value specified in the list below:
+Modify the user‑defined variables section of the **nginx&#8209;ha&#8209;notify** script, replacing each `<value>` placeholder with the value specified in the list below:
 
 ```none
 export AWS_ACCESS_KEY_ID=<value>
@@ -223,7 +223,7 @@ Check the state on the backup instance, confirming that it has transitioned to `
 <span id="ha-aws_troubleshooting"></span>
 ## Troubleshooting
 
-If the solution doesn’t work as expected, check the `keepalived` logs, which are written to <span style="white-space: nowrap; font-weight:bold;">/var/log/syslog</span>. Also, you can manually run the commands that invoke the `awscli` utility in the <span style="white-space:nowrap; font-weight:bold;">nginx-ha-notify</span> script to check that the utility is working properly.
+If the solution doesn’t work as expected, check the `keepalived` logs, which are written to **/var/log/syslog**. Also, you can manually run the commands that invoke the `awscli` utility in the **nginx&#8209;ha&#8209;notify** script to check that the utility is working properly.
 
 <span id="ha-aws_caveats"></span>
 ## Caveats

--- a/content/nginx/deployment-guides/amazon-web-services/high-availability-network-load-balancer.md
+++ b/content/nginx/deployment-guides/amazon-web-services/high-availability-network-load-balancer.md
@@ -254,15 +254,15 @@ Assign the following names to the instances, then install the indicated NGINX so
 
 - Four NGINX Open Source instances:
   - App 1:
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-1</span>
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-2</span>
+    - **ngx-oss-app1-1**
+    - **ngx-oss-app1-2**
   - App 2:
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-1</span>
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-2</span>
+    - **ngx-oss-app2-1**
+    - **ngx-oss-app2-2**
 
 - Two NGINX Plus instances:
-  - <span style="color:#666666; font-weight:bolder">ngx-plus-1</span>
-  - <span style="color:#666666; font-weight:bolder">ngx-plus-2</span>
+  - **ngx-plus-1**
+  - **ngx-plus-2**
 
 <a href="/nginx/images/aws-nlb-instances-summary.png"><img src="/nginx/images/aws-nlb-instances-summary.png" alt="" width="1024" height="263" class="aligncenter size-full wp-image-54856" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
@@ -278,11 +278,11 @@ Use the *Step‑by‑step* instructions in our deployment guide, [Setting Up an 
 Repeat the instructions on all four web servers:
 
 - Running App 1:
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-1</span>
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-2</span>
+  - **ngx-oss-app1-1**
+  - **ngx-oss-app1-2**
 - Running App 2:
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-1</span>
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-2</span>
+  - **ngx-oss-app2-1**
+  - **ngx-oss-app2-2**
 
 <span id="configure-load-balancers"></span>
 #### Configure NGINX Plus on the load balancers
@@ -291,7 +291,7 @@ Configure NGINX Plus instances as load balancers. These distribute requests to 
 
 Use the *Step‑by‑step* instructions in our deployment guide, [Setting Up an NGINX Demo Environment]({{< ref "/nginx/deployment-guides/setting-up-nginx-demo-environment.md" >}}).
 
-Repeat the instructions on both <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-plus-1</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-plus-2</span>.
+Repeat the instructions on both **ngx&#8209;plus&#8209;1** and **ngx&#8209;plus&#8209;2**.
 
 <span id="create-instances-automated"></span>
 ### Automate instance setup with Packer and Terraform
@@ -317,7 +317,7 @@ To run the scripts, follow these instructions:
 
 3. Set your AWS credentials in the Packer and Terraform scripts:
 
-   - For Packer, set your credentials in the `variables` block in <span style="text-decoration: underline;">both</span> <span style="white-space: nowrap; font-weight:bold;">packer/ngx-oss/packer.json</span> and <span style="white-space: nowrap; font-weight:bold;">packer/ngx-plus/packer.json</span>:
+   - For Packer, set your credentials in the `variables` block in <span style="text-decoration: underline;">both</span> **packer/ngx&#8209;oss/packer.json** and **packer/ngx&#8209;plus/packer.json**:
 
      ```none
      "variables": {

--- a/content/nginx/deployment-guides/amazon-web-services/ingress-controller-elastic-kubernetes-services.md
+++ b/content/nginx/deployment-guides/amazon-web-services/ingress-controller-elastic-kubernetes-services.md
@@ -43,14 +43,14 @@ This guide covers the `eksctl` command as it is the simplest option.
 
 1. Follow the instructions in the [eksctl.io documentation](https://eksctl.io/installation/) to install or update the `eksctl` command.
 
-2. Create an Amazon EKS cluster by following the instructions in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html). Select the <span style="white-space: nowrap; font-weight:bold;">Managed nodes – Linux</span> option for each step. Note that the <span style="white-space: nowrap;">`eksctl create cluster`</span> command in the first step can take ten minutes or more.
+2. Create an Amazon EKS cluster by following the instructions in the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html). Select the **Managed&nbsp;nodes&nbsp;–&nbsp;Linux** option for each step. Note that the <span style="white-space: nowrap;">`eksctl create cluster`</span> command in the first step can take ten minutes or more.
 
 <span id="amazon-ecr"></span>
 ## Push the NGINX Plus Ingress Controller Image to AWS ECR
 
 This step is only required if you do not plan to use the prebuilt NGINX Open Source image.
 
-1. Use the [AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) to create a repository in the Amazon Elastic Container Registry (ECR). In Step 4 of the AWS instructions, name the repository <span style="white-space: nowrap; font-weight:bold;">nginx-plus-ic</span> as that is what we use in this guide. 
+1. Use the [AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) to create a repository in the Amazon Elastic Container Registry (ECR). In Step 4 of the AWS instructions, name the repository **nginx&#8209;plus&#8209;ic** as that is what we use in this guide. 
 
 2. Run the following AWS CLI command. It generates an auth token for your AWS ECR registry, then pipes it into the `docker login` command. This lets AWS ECR authenticate and authorize the upcoming Docker requests. For details about the command, see the [AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html).
 

--- a/content/nginx/deployment-guides/amazon-web-services/route-53-global-server-load-balancing.md
+++ b/content/nginx/deployment-guides/amazon-web-services/route-53-global-server-load-balancing.md
@@ -40,7 +40,7 @@ The setup for global server load balancing (GSLB) in this guide combines Amazon 
 
 <img src="/nginx/images/aws-route-53-topology.png" alt="Diagram showing a topology for global server load balancing (GSLB). Eight backend servers, four in each of two regions, host the content for a domain. Two NGINX Plus load balancers in each region route traffic to the backend servers. For each client requesting DNS information for the domain, Amazon Route 53 provides the DNS record for the region closest to the client." style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-Route 53 is a Domain Name System (DNS) service that performs global server load balancing by routing each request to the AWS region closest to the requester's location. This guide uses two regions: <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West (Oregon)</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East (N. Virginia)</span>.
+Route 53 is a Domain Name System (DNS) service that performs global server load balancing by routing each request to the AWS region closest to the requester's location. This guide uses two regions: **US&nbsp;West&nbsp;(Oregon)** and **US&nbsp;East&nbsp;(N.&nbsp;Virginia)**.
 
 In each region, two or more NGINX Plus load balancers are deployed in a high‑availability (HA) configuration. In this guide, there are two NGINX Plus load balancer instances per region. You can also use NGINX Open Source for this purpose, but it lacks the [application health checks](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-health-check/) that make for more precise error detection. For simplicity, we'll refer to NGINX Plus load balancers throughout this guide, noting when features specific to NGINX Plus are used.
 
@@ -79,7 +79,7 @@ Create a _hosted zone_, which basically involves designating a domain name to be
 
 1. Log in to the [AWS Management Console](https://console.aws.amazon.com/) (**console.aws.amazon.com/**).
 
-2. Access the Route 53 dashboard page by clicking **Services** in the top AWS navigation bar, mousing over **Networking** in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">All AWS Services</span> column and then clicking **Route 53**.
+2. Access the Route 53 dashboard page by clicking **Services** in the top AWS navigation bar, mousing over **Networking** in the **All&nbsp;AWS&nbsp;Services** column and then clicking **Route 53**.
 
     <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-dashboard-open.png" alt="Screenshot showing how to access the Amazon Route 53 dashboard to configure global load balancing (GLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -87,7 +87,7 @@ Create a _hosted zone_, which basically involves designating a domain name to be
 
     <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-registered-domains-tab.png" alt="Screenshot showing the Route 53 Registered domains tab during configuration of NGINX GSLB (global server load balancing)" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-    If you see the Route 53 home page instead, access the **Registered domains** tab by clicking the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Get started now </span> button under <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Domain registration</span>.
+    If you see the Route 53 home page instead, access the **Registered domains** tab by clicking the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Get started now </span> button under **Domain&nbsp;registration**.
 
     <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-homepage.png" alt="Screenshot showing the Amazon Route 53 homepage for a first-time Route 53 user during configuration of AWS GSLB (global server load balancing) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -123,21 +123,21 @@ Create records sets for your domain:
 
 4. Fill in the fields in the **Create Record Set** column:
 
-    - **Name** – You can leave this field blank, but for this guide we are setting the name to <span style="color:#666666; font-weight:bolder; white-space: nowrap;">www.nginxroute53.com</span>.
-    - **Type** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">A – IPv4 address</span>.
-    - **Alias** – <span style="color:#666666; font-weight:bolder;">No</span>.
-    - **TTL (Seconds)** – <span style="color:#666666; font-weight:bolder;">60</span>.
+    - **Name** – You can leave this field blank, but for this guide we are setting the name to **www.nginxroute53.com**.
+    - **Type** – **A –&nbsp;IPv4&nbsp;address**.
+    - **Alias** – **No**.
+    - **TTL (Seconds)** – **60**.
 
-        **Note**: Reducing TTL from the default of <span style="color:#666666; font-weight:bolder;">300</span> in this way can decrease the time that it takes for Route 53 to fail over when both NGINX Plus load balancers in the region are down, but there is always a delay of about two minutes regardless of the TTL setting. This is a built‑in limitation of Route 53.
+        **Note**: Reducing TTL from the default of **300** in this way can decrease the time that it takes for Route 53 to fail over when both NGINX Plus load balancers in the region are down, but there is always a delay of about two minutes regardless of the TTL setting. This is a built‑in limitation of Route 53.
 
-    - **Value** – [Elastic IP addresses](#elastic-ip) of the NGINX Plus load balancers in the first region [in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West (Oregon)</span>].
-    - **Routing Policy** – <span style="color:#666666; font-weight:bolder;">Latency</span>.
+    - **Value** – [Elastic IP addresses](#elastic-ip) of the NGINX Plus load balancers in the first region [in this guide, **US&nbsp;West&nbsp;(Oregon)**].
+    - **Routing Policy** – **Latency**.
 
-5. A new area opens when you select <span style="color:#666666; font-weight:bolder;">Latency</span>. Fill in the fields as indicated (see the figure below):
+5. A new area opens when you select **Latency**. Fill in the fields as indicated (see the figure below):
 
-    - **Region** – Region to which the load balancers belong (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">us-west-2</span>).
-    - **Set ID** – Identifier for this group of load balancers (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LBs</span>).
-    - **Associate with Health Check** – <span style="color:#666666; font-weight:bolder;">No</span>.
+    - **Region** – Region to which the load balancers belong (in this guide, **us&#8209;west&#8209;2**).
+    - **Set ID** – Identifier for this group of load balancers (in this guide, **US&nbsp;West&nbsp;LBs**).
+    - **Associate with Health Check** – **No**.
 
     When you complete all fields, the tab looks like this:
 
@@ -145,7 +145,7 @@ Create records sets for your domain:
 
 6. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create </span> button.
 
-7. Repeat Steps 3 through 6 for the load balancers in the other region [in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East (N. Virginia)</span>].
+7. Repeat Steps 3 through 6 for the load balancers in the other region [in this guide, **US&nbsp;East&nbsp;(N.&nbsp;Virginia)**].
 
 You can now test your website. Insert your domain name into a browser and see that your request is being load balanced between servers based on your location.
 
@@ -172,21 +172,21 @@ We create health checks both for each NGINX Plus load balancer individually and
 
     <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-health-checks-tab-welcome.png" alt="Screenshot of Amazon Route 53 welcome screen seen by first-time user of Route 53 during configuration of global server load balancing (GSLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-2. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create health check </span> button. In the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Configure health check</span> form that opens, specify the following values, then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Next </span> button.
+2. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create health check </span> button. In the **Configure&nbsp;health&nbsp;check** form that opens, specify the following values, then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Next </span> button.
 
-   - **Name** – Identifier for an NGINX Plus load balancer instance, for example <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 1</span>.
-   - **What to monitor** – <span style="color:#666666; font-weight:bolder;">Endpoint</span>.
-   - **Specify endpoint by** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">IP address</span>.
+   - **Name** – Identifier for an NGINX Plus load balancer instance, for example **US&nbsp;West&nbsp;LB&nbsp;1**.
+   - **What to monitor** – **Endpoint**.
+   - **Specify endpoint by** – **IP&nbsp;address**.
    - **IP address** – The [elastic IP address](#elastic-ip) of the NGINX Plus load balancer.
-   - **Port** – The port advertised to clients for your domain or web service (the default is <span style="color:#666666; font-weight:bolder;">80</span>).
+   - **Port** – The port advertised to clients for your domain or web service (the default is **80**).
 
    <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-configure-health-check.png" alt="Screenshot of Amazon Route 53 interface for configuring health checks, during configuration of AWS global load balancing (GLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-3. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Get notified when health check fails</span> screen that opens, set the **Create alarm** radio button to **Yes** or **No** as appropriate, then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create health check </span> button.
+3. On the **Get&nbsp;notified&nbsp;when&nbsp;health&nbsp;check&nbsp;fails** screen that opens, set the **Create alarm** radio button to **Yes** or **No** as appropriate, then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create health check </span> button.
 
    <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-get-notified-health-check.png" alt="Screenshot of Route 53 configuration screen for enabling notifications of failed health checks, during configuration of Route 53 global load balancing (GLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-4. Repeat Steps 2 and 3 for your other NGINX Plus load balancers (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 2</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB 1</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB 2</span>).
+4. Repeat Steps 2 and 3 for your other NGINX Plus load balancers (in this guide, **US&nbsp;West&nbsp;LB&nbsp;2**, **US&nbsp;East&nbsp;LB&nbsp;1**, and **US&nbsp;East&nbsp;LB&nbsp;2**).
 
 5. Proceed to the next section to configure health checks for the load balancer pairs.
 
@@ -195,18 +195,18 @@ We create health checks both for each NGINX Plus load balancer individually and
 
 1. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create health check </span> button.
 
-2. In the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Configure health check</span> form that opens, specify the following values, then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Next </span> button.
+2. In the **Configure&nbsp;health&nbsp;check** form that opens, specify the following values, then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Next </span> button.
 
-   - **Name** – Identifier for the pair of NGINX Plus load balancers in the first region, for example <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LBs</span>.
-   - **What to monitor** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Status of other health checks </span>.
+   - **Name** – Identifier for the pair of NGINX Plus load balancers in the first region, for example **US&nbsp;West&nbsp;LBs**.
+   - **What to monitor** – **Status&nbsp;of&nbsp;other&nbsp;health&nbsp;checks **.
    - **Health checks to monitor** – The health checks of the two US West load balancers (add them one after the other by clicking in the box and choosing them from the drop‑down menu as shown).
-   - **Report healthy when** – <span style="color:#666666; font-weight:bolder;">at least 1 of 2 selected health checks are healthy</span> (the choices in this field are obscured in the screenshot by the drop‑down menu).
+   - **Report healthy when** – **at least 1 of 2 selected health checks are healthy** (the choices in this field are obscured in the screenshot by the drop‑down menu).
 
    <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-configure-health-check-status-others.png" alt="Screenshot of Amazon Route 53 interface for configuring a health check of combined other health checks, during configuration of global server load balancing (GSLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-3. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Get notified when health check fails</span> screen that opens, set the **Create alarm** radio button as appropriate (see Step 5 in the <a href="#route-53-health-checks-individual">previous section</a>), then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create health check </span> button.
+3. On the **Get&nbsp;notified&nbsp;when&nbsp;health&nbsp;check&nbsp;fails** screen that opens, set the **Create alarm** radio button as appropriate (see Step 5 in the <a href="#route-53-health-checks-individual">previous section</a>), then click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create health check </span> button.
 
-4. Repeat Steps 1 through 3 for the paired load balancers in the other region [in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East (N. Virginia)</span>].
+4. Repeat Steps 1 through 3 for the paired load balancers in the other region [in this guide, **US&nbsp;East&nbsp;(N.&nbsp;Virginia)**].
 
 When you have finished configuring all six health checks, the **Health checks** tab looks like this:
 
@@ -223,13 +223,13 @@ When you have finished configuring all six health checks, the **Health checks** 
 
    The tab changes to display the record sets for the domain.
 
-3. In the list of record sets that opens, click the row for the record set belonging to your first region [in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West (Oregon)</span>]. The <span style="font-weight: bolder; white-space: nowrap;">Edit Record Set</span> column opens on the right side of the tab.
+3. In the list of record sets that opens, click the row for the record set belonging to your first region [in this guide, **US&nbsp;West&nbsp;(Oregon)**]. The <span style="font-weight: bolder; white-space: nowrap;">Edit Record Set</span> column opens on the right side of the tab.
 
    <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-route53-edit-record-set.png" alt="Screenshot of interface for editing Route 53 record sets during configuration of global server load balancing (GSLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-4. Change the **Associate with Health Check** radio button to <span style="color:#666666; font-weight:bolder;">Yes</span>.
+4. Change the **Associate with Health Check** radio button to **Yes**.
 
-5. In the **Health Check to Associate** field, select the paired health check for your first region (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LBs</span>).
+5. In the **Health Check to Associate** field, select the paired health check for your first region (in this guide, **US&nbsp;West&nbsp;LBs**).
 
 6. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Save Record Set </span> button.
 
@@ -242,7 +242,7 @@ These instructions assume that you have configured NGINX Plus on two EC2 instan
 
 **Note:** Some commands require `root` privilege. If appropriate for your environment, prefix commands with the `sudo` command.
 
-1. Connect to the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 1</span> instance. For instructions, see <a href="../ec2-instances-for-nginx/#connect-to-instance">Connecting to an EC2 Instance</a>.
+1. Connect to the **US&nbsp;West&nbsp;LB&nbsp;1** instance. For instructions, see <a href="../ec2-instances-for-nginx/#connect-to-instance">Connecting to an EC2 Instance</a>.
 
 2. Change directory to **/etc/nginx/conf.d**.
 
@@ -250,7 +250,7 @@ These instructions assume that you have configured NGINX Plus on two EC2 instan
    cd /etc/nginx/conf.d
    ```
 
-3. Edit the <span style="white-space: nowrap; font-weight:bold;">west-lb1.conf</span> file and add the **@healthcheck** location to set up health checks.
+3. Edit the **west&#8209;lb1.conf** file and add the **@healthcheck** location to set up health checks.
 
    ```nginx
    upstream backend-servers {
@@ -282,9 +282,9 @@ These instructions assume that you have configured NGINX Plus on two EC2 instan
    nginx -s reload
    ```
 
-5. Repeat Steps 1 through 4 for the other three load balancers (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 2</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB 1</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB2</span>).
+5. Repeat Steps 1 through 4 for the other three load balancers (**US&nbsp;West&nbsp;LB&nbsp;2**, **US&nbsp;East&nbsp;LB&nbsp;1**, and **US&nbsp;East&nbsp;LB2**).
 
-   In Step 3, change the filename as appropriate (<span style="white-space: nowrap; font-weight:bold;">west-lb2.conf</span>, <span style="white-space: nowrap; font-weight:bold;">east-lb1.conf</span>, and <span style="white-space: nowrap; font-weight:bold;">east-lb2.conf</span>). In the <span style="white-space: nowrap; font-weight:bold;">east-lb1.conf</span> and <span style="white-space: nowrap; font-weight:bold;">east-lb2.conf</span> files, the `server` directives specify the public DNS names of Backup 3 and Backup 4.
+   In Step 3, change the filename as appropriate (**west&#8209;lb2.conf**, **east&#8209;lb1.conf**, and **east&#8209;lb2.conf**). In the **east&#8209;lb1.conf** and **east&#8209;lb2.conf** files, the `server` directives specify the public DNS names of Backup 3 and Backup 4.
 
 <span id="appendix"></span>
 ## Appendix
@@ -307,31 +307,31 @@ Step‑by‑step instructions for creating EC2 instances and installing NGINX so
 
 Assign the following names to the instances, and then install the indicated NGINX software.
 
-- In the first region, which is <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West (Oregon)</span> in this guide:
+- In the first region, which is **US&nbsp;West&nbsp;(Oregon)** in this guide:
 
   - Two load balancer instances running NGINX Plus:
 
-    - <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 1</span>
-    - <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 2</span>
+    - **US&nbsp;West&nbsp;LB&nbsp;1**
+    - **US&nbsp;West&nbsp;LB&nbsp;2**
 
   - Two backend instances running NGINX Open Source:
 
-         * <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 1</span>
-    - <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 2</span>
+         * **Backend&nbsp;1**
+    - **Backend&nbsp;2**
 
-- In the second region, which is <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East (N. Virginia)</span> in this guide:
+- In the second region, which is **US&nbsp;East&nbsp;(N.&nbsp;Virginia)** in this guide:
 
   - Two load balancer instances running NGINX Plus:
 
-    - <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB 1</span>
-    - <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB 2</span>
+    - **US&nbsp;East&nbsp;LB&nbsp;1**
+    - **US&nbsp;East&nbsp;LB&nbsp;2**
 
   - Two backend instances running NGINX Open Source:
 
-         * <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 3</span>
-    - <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 4</span>
+         * **Backend&nbsp;3**
+    - **Backend&nbsp;4**
 
-Here's the **Instances** tab after we create the four instances in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">N. Virginia</span> region.
+Here's the **Instances** tab after we create the four instances in the **N.&nbsp;Virginia** region.
 
 <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-ec2-useast-instances.png" alt="Screenshot showing newly created EC2 instances in one of two regions, which is a prerequisite to configuring AWS GSLB (global server load balancing) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -359,14 +359,14 @@ Perform these steps on all eight instances.
 
    <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2016/10/aws-ec2-associate-address-popup.png" alt="Screenshot of the interface for associating an AWS EC2 instance with an elastic IP address, which is a prerequisite to configuring AWS global load balancing (GLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-After you complete the instructions on all instances, the list for a region (here, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Oregon</span>) looks like this:
+After you complete the instructions on all instances, the list for a region (here, **Oregon**) looks like this:
 
 <img src="https://cdn-1.wp.nginx.com/wp-content/uploads/2018/03/aws-ec2-elastic-ip-address-list.png" alt="Screenshot showing the elastic IP addresses assigned to four AWS EC2 instances during configuration of global server load balancing (GSLB) with NGINX Plus" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
 <span id="configure-backend-servers"></span>
 ### Configuring NGINX Open Source on the Backend Servers
 
-Perform these steps on all four backend servers: <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 1</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 2</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 3</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend 4</span>. In Step 3, substitute the appropriate name for `Backend X` in the **index.html** file.
+Perform these steps on all four backend servers: **Backend&nbsp;1**, **Backend&nbsp;2**, **Backend&nbsp;3**, and **Backend&nbsp;4**. In Step 3, substitute the appropriate name for `Backend X` in the **index.html** file.
 
 **Note:** Some commands require `root` privilege. If appropriate for your environment, prefix commands with the `sudo` command.
 
@@ -421,7 +421,7 @@ Perform these steps on all four backend servers: <span style="color:#666666; fon
 <span id="configure-load-balancers"></span>
 ### Configuring NGINX Plus on the Load Balancers
 
-Perform these steps on all four backend servers: <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 1</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 2</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB 1</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 2</span>.
+Perform these steps on all four backend servers: **US&nbsp;West&nbsp;LB&nbsp;1**, **US&nbsp;West&nbsp;LB&nbsp;2**, **US&nbsp;East&nbsp;LB&nbsp;1**, and **US&nbsp;West&nbsp;LB&nbsp;2**.
 
 **Note:** Some commands require `root` privilege. If appropriate for your environment, prefix commands with the `sudo` command.
 
@@ -439,10 +439,10 @@ Perform these steps on all four backend servers: <span style="color:#666666; fon
 
 4. Create a new file containing the following text, which configures load balancing of the two backend servers in the relevant region. The filename on each instance is:
 
-   - For <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 1</span> – <span style="font-weight:bold; white-space: nowrap;">west-lb1.conf</span>
-   - For <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 2</span> – <span style="font-weight:bold; white-space: nowrap;">west-lb2.conf</span>
-   - For <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US East LB 1</span> – <span style="font-weight:bold; white-space: nowrap;">east-lb1.conf</span>
-   - For <span style="color:#666666; font-weight:bolder; white-space: nowrap;">US West LB 2</span> – <span style="font-weight:bold; white-space: nowrap;">east-lb2.conf</span>
+   - For **US&nbsp;West&nbsp;LB&nbsp;1** – **west&#8209;lb1.conf**
+   - For **US&nbsp;West&nbsp;LB&nbsp;2** – **west&#8209;lb2.conf**
+   - For **US&nbsp;East&nbsp;LB&nbsp;1** – **east&#8209;lb1.conf**
+   - For **US&nbsp;West&nbsp;LB&nbsp;2** – **east&#8209;lb2.conf**
 
    In the `server` directives in the `upstream` block, substitute the public DNS names of the backend instances in the region; to learn them, see the **Instances** tab in the EC2 Dashboard.
 

--- a/content/nginx/deployment-guides/global-server-load-balancing/ns1-global-server-load-balancing.md
+++ b/content/nginx/deployment-guides/global-server-load-balancing/ns1-global-server-load-balancing.md
@@ -69,9 +69,9 @@ The solution functions alongside other NS1 capabilities, such as geo‑proximal 
 
 5. The **Add Record** window pops up. Enter the following values:
 
-   - **Record Type** – <span style="color:#666666; font-weight:bolder; font-family:helvetica;">A</span> (the default).
+   - **Record Type** – **A** (the default).
    - <span style="color:#666666; font-family:helvetica;">name</span> – Leave blank unless you are creating the ``A`` record for a subdomain.
-   - **TTL** – <span style="color:#666666; font-weight:bolder; font-family:helvetica;">3600</span> is the default, which we are not changing.
+   - **TTL** – **3600** is the default, which we are not changing.
    - **ANSWERS** – The public IP address of the first NGINX Plus instance. To add each of the other instances, click the <span style="color:#ea1f71; font-family:helvetica; white-space: nowrap;">Add Answer</span> button. (In this guide we're using private IP addresses in the 10.0.0.0/8 range as examples.)
 
    Click the <span style="background-color:#ea1f71; color:white; font-family:helvetica; white-space: nowrap;"> Save All Changes </span> button.
@@ -86,24 +86,24 @@ The solution functions alongside other NS1 capabilities, such as geo‑proximal 
 
    <img src="/nginx/images/ns1-3-answers.png" alt="Screenshot of NS1 GUI: list of answers for nginxgslb.cf" width="1024" height="393" class="aligncenter size-full wp-image-63023" />
 
-8. In the **Answer Metadata** window that pops up, click <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> Up/down </span> in the <span style="background-color:#e8ebed; font-family:helvetica; white-space: nowrap;"> STATUS </span> section of the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> SETTING </span> column, if it is not already selected. Click the **Select** box in the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> AVAILABLE </span> column, and then select either <span style="color:#666666; font-weight:bolder; font-family:helvetica">Up</span> or <span style="color:#666666; font-weight:bolder; font-family:helvetica">Down</span> from the drop‑down menu. In this guide we're selecting <span style="color:#666666; font-weight:bolder; font-family:helvetica">Up</span> to indicate that the NGINX Plus instance is operational.
+8. In the **Answer Metadata** window that pops up, click <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> Up/down </span> in the <span style="background-color:#e8ebed; font-family:helvetica; white-space: nowrap;"> STATUS </span> section of the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> SETTING </span> column, if it is not already selected. Click the **Select** box in the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> AVAILABLE </span> column, and then select either **Up** or **Down** from the drop‑down menu. In this guide we're selecting **Up** to indicate that the NGINX Plus instance is operational.
    <img src="/nginx/images/ns1-answer-metadata-status.png" alt="Screenshot of NS1 GUI: setting STATUS answer metadata" width="1024" height="1105" class="aligncenter size-full wp-image-63022" />
 
 9. Click a value in the <span style="background-color:#e8ebed; font-family:helvetica; white-space: nowrap;"> GEOGRAPHICAL </span> section of the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> SETTING </span> column and specify the location of the NGINX Plus instance. Begin by choosing one of the several types of codes that NS1 offers for identifying locations:
 
    - **Canadian province(s)** – Two‑letter codes for Canadian provinces
    - **Country/countries** – Two‑letter codes for nations and territories
-   - **Geographic region(s)** – Identifiers like <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">US-WEST</span> and <span style="color:#666666; font-weight:bolder; font-family:helvetica;">ASIAPAC</span>
+   - **Geographic region(s)** – Identifiers like **US&#8209;WEST** and **ASIAPAC**
    - **ISO region code** – Identification codes for nations and territories as defined in [ISO 3166](https://www.iso.org/iso-3166-country-codes.html)
    - **Latitude** – Degrees, minutes, and seconds of latitude (northern or southern hemisphere)
    - **Longitude** – Degrees, minutes, and seconds of longitude (eastern or western hemisphere)
    - **US State(s)** – Two‑letter codes for US states
 
-   In this guide we're using **Country/countries** codes. For the first NGINX Plus instance, we select <span style="color:#666666; font-weight:bolder; font-family:helvetica;">Americas > Northern America > United States (US)</span> and click the <span style="background-color:#ea1f71; color:white; font-family:helvetica;"> Ok </span> button.
+   In this guide we're using **Country/countries** codes. For the first NGINX Plus instance, we select **Americas > Northern America > United States (US)** and click the <span style="background-color:#ea1f71; color:white; font-family:helvetica;"> Ok </span> button.
 
     <img src="/nginx/images/ns1-answer-metadata-geographical.png" alt="Screenshot of NS1 GUI: setting GEOGRAPHICAL answer metadata" width="1024" height="1024" class="aligncenter size-full wp-image-63021" />
 
-10. Repeat Steps 7–9 for both of the other two NGINX Plus instances. For the country in Step 9, we're selecting <span style="color:#666666; font-weight:bolder; font-family:helvetica;">Europe > Western Europe > Germany (DE)</span> for NGINX Plus instance 2 and <span style="color:#666666; font-weight:bolder; font-family:helvetica;">Asia > South‑Eastern Asia > Singapore (SG)</span> for NGINX Plus instance 3.
+10. Repeat Steps 7–9 for both of the other two NGINX Plus instances. For the country in Step 9, we're selecting **Europe > Western Europe > Germany (DE)** for NGINX Plus instance 2 and **Asia > South‑Eastern Asia > Singapore (SG)** for NGINX Plus instance 3.
 
     When finished with both instances, on the details page for the ``A`` record click the <span style="background-color:#ea1f71; color:white; font-family:helvetica; white-space: nowrap;"> Save Record </span> button.
 
@@ -113,9 +113,9 @@ The solution functions alongside other NS1 capabilities, such as geo‑proximal 
 
 12. In the **Add Filters** window that pops up, click the plus sign (+) on the button for each filter you want to apply. In this guide, we're configuring the filters in this order:
 
-    - <span style="color:#666666; font-weight:bolder; font-family:helvetica;">Up</span> in the <span style="background-color:#28ccbb; color:white; font-weight:bolder; font-family:helvetica;"> HEALTHCHECKS </span> section
-    - <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">Geotarget Country</span> in the <span style="background-color:#28ccbb; color:white; font-weight:bolder; font-family:helvetica;;"> GEOGRAPHIC </span> section
-    - <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">Select First N</span> in the <span style="background-color:#28ccbb; color:white; font-weight:bolder; font-family:helvetica; white-space: nowrap;"> TRAFFIC MANAGEMENT </span> section
+    - **Up** in the ** HEALTHCHECKS ** section
+    - **Geotarget&nbsp;Country** in the ** GEOGRAPHIC ** section
+    - **Select&nbsp;First&nbsp;N** in the ** TRAFFIC&nbsp;MANAGEMENT ** section
 
     Click the <span style="background-color:#ea1f71; color:white; font-family:helvetica; white-space: nowrap;"> Save Filter Chain </span>  button.
 
@@ -128,17 +128,17 @@ In this section we install and configure the NS1 agent on the same hosts as our 
 
 1. Follow the instructions in the [NS1 documentation](https://help.ns1.com/hc/en-us/articles/360020474154) to set up and connect a separate data feed for each of the three NGINX Plus instances, which NS1 calls _answers_.
 
-   On the first page (**Configure a new data source from NSONE Data Feed API v1**) specify a name for the _data source_, which is the administrative container for the data feeds you will be creating. Use the same name each of the three times you go through the instructions. We're naming the data source <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">NGINX-GSLB</span>.
+   On the first page (**Configure a new data source from NSONE Data Feed API v1**) specify a name for the _data source_, which is the administrative container for the data feeds you will be creating. Use the same name each of the three times you go through the instructions. We're naming the data source **NGINX&#8209;GSLB**.
 
    On the next page (**Create Feed from NSONE Data Feed API v1**), create a data feed for the instance. Because the **Name** field is just for internal use, any value is fine. The value in the **Label** field is used in the YAML configuration file for the instance (see Step 4 below). We're specifying labels that indicate the country (using the ISO 3166 codes) in which the instance is running:
 
-   - <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">us-nginxgslb-datafeed</span> for instance 1 in the US
-   - <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">de-nginxgslb-datafeed</span> for instance 2 in Germany
-   - <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">sg-nginxgslb-datafeed</span> for instance 3 in Singapore
+   - **us&#8209;nginxgslb&#8209;datafeed** for instance 1 in the US
+   - **de&#8209;nginxgslb&#8209;datafeed** for instance 2 in Germany
+   - **sg&#8209;nginxgslb&#8209;datafeed** for instance 3 in Singapore
 
-   After creating the three feeds, note the value in the **Feeds URL** field on the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> INTEGRATIONS </span> tab. The final element of the URL is the ``<NS1-data-source-ID>`` you will specify in the YAML configuration file in Step 4. In the third screenshot in the [NS1 documentation](https://help.ns1.com/hc/en-us/articles/360020474154), for example, it is <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">e566332c5d22c6b66aeaa8837eae90ac</span>.
+   After creating the three feeds, note the value in the **Feeds URL** field on the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> INTEGRATIONS </span> tab. The final element of the URL is the ``<NS1-data-source-ID>`` you will specify in the YAML configuration file in Step 4. In the third screenshot in the [NS1 documentation](https://help.ns1.com/hc/en-us/articles/360020474154), for example, it is **e566332c5d22c6b66aeaa8837eae90ac**.
 
-2. Follow the instructions in the [NS1 documentation](https://help.ns1.com/hc/en-us/articles/360017341694-Creating-managing-API-keys) to create an NS1 API key for the agent, if you have not already. (To access **Account Settings** in Step 1, click your username in the upper right corner of the NS1 title bar.) We're naming the app <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">NGINX-GSLB</span>. Make note of the key value – you'll specify it as ``<NS1-API-key>`` in the YAML configuration file in Step 4. To see the actual hexadecimal value, click on the circled letter **i** in the **API Key** field.
+2. Follow the instructions in the [NS1 documentation](https://help.ns1.com/hc/en-us/articles/360017341694-Creating-managing-API-keys) to create an NS1 API key for the agent, if you have not already. (To access **Account Settings** in Step 1, click your username in the upper right corner of the NS1 title bar.) We're naming the app **NGINX&#8209;GSLB**. Make note of the key value – you'll specify it as ``<NS1-API-key>`` in the YAML configuration file in Step 4. To see the actual hexadecimal value, click on the circled letter **i** in the **API Key** field.
 
 3. On each NGINX Plus host, clone the [GitHub repo](https://github.com/nginxinc/nginx-ns1-gslb) for the NS1 agent.
 
@@ -185,14 +185,14 @@ In this section we install and configure the NS1 agent on the same hosts as our 
 
 In this section we describe how to verify that NS1 correctly redistributes traffic to an alternate PoP when the PoP nearest to the client is not operational (in the setup in this guide, each of the three NGINX Plus instances corresponds to a PoP). There are three ways to indicate to NS1 that a PoP is down:
 
-- [Change the status of the NGINX Plus instance](#verify-when-status-down) to <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">Down</span> in the NS1 ``A`` record
+- [Change the status of the NGINX Plus instance](#verify-when-status-down) to **Down** in the NS1 ``A`` record
 - [Take down the servers in the proxied upstream group](#verify-when-upstream-down)
 - [Cause traffic to exceed a configured threshold](#verify-when-over-threshold)
 
 <span id="verify-when-status-down"></span>
 ### Verifying Traffic Redistribution when an NGINX Plus Instance Is Marked Down
 
-Here we verify that NS1 switches over to the next‑nearest NGINX Plus instance when we change the metadata on the nearest NGINX Plus instance to <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">Down</span>.
+Here we verify that NS1 switches over to the next‑nearest NGINX Plus instance when we change the metadata on the nearest NGINX Plus instance to **Down**.
 
 1. On a host located in the US, run the following command to determine which site NS1 is returning as nearest. Appropriately, it's returning 10.10.10.1, the IP address of the NGINX Plus instance in the US.
 
@@ -207,7 +207,7 @@ Here we verify that NS1 switches over to the next‑nearest NGINX Plus instance
    Address: 10.10.10.1
    ```
 
-2. Change the **Up/Down** answer metadata on the US instance to <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">Down</span> (see Step 8 in [Setting Up NS1](#ns1-setup)).
+2. Change the **Up/Down** answer metadata on the US instance to **Down** (see Step 8 in [Setting Up NS1](#ns1-setup)).
 
 3. Wait an hour – because we didn't change the default <span style="white-space: nowrap;">time-to-live</span> (TTL) of 3600 seconds on the ``A`` record for **nginxgslb.cf** – and issue the ``nslookup`` command again. NS1 returns 10.10.10.2, the IP address of the NGINX Plus instance in Germany, which is now the nearest.
 
@@ -349,7 +349,7 @@ First we perform these steps to create the shed filter:
 
    <img src="/nginx/images/ns1-add-filters-shed-load.png" alt="Screenshot of NS1 GUI: clicking Shed Load button on Add Filters page" width="1022" height="701" class="aligncenter size-full wp-image-63017" />
 
-3. The **Shed Load** filter is added as the fourth (lowest) box in the **Active Filters** section. Move it to be third by clicking and dragging it above the <span style="white-space: nowrap; font-weight:bold;">Select First N</span> box.
+3. The **Shed Load** filter is added as the fourth (lowest) box in the **Active Filters** section. Move it to be third by clicking and dragging it above the **Select&nbsp;First&nbsp;N** box.
 
 4. Click the <span style="background-color:#ea1f71; color:white; font-family:helvetica; white-space: nowrap;"> Save Filter Chain </span> button.
 
@@ -363,9 +363,9 @@ First we perform these steps to create the shed filter:
 
 7. In the **Answer Metadata** window that opens, set values for the following metadata. In each case, click the icon in the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> FEED </span> column of the metadata's row, then select or enter the indicated value in the <span style="background-color:#000000; color:white; font-family:helvetica; white-space: nowrap;"> AVAILABLE </span> column. (For testing purposes, we're setting very small values for the watermarks so that the threshold is exceeded very quickly.)
 
-   - **Active connections** – <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">us-nginxgslb-datafeed</span>
-   - **High watermark** – <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">5</span>
-   - **Low watermark** – <span style="color:#666666; font-weight:bolder; font-family:helvetica; white-space: nowrap;">2</span>
+   - **Active connections** – **us&#8209;nginxgslb&#8209;datafeed**
+   - **High watermark** – **5**
+   - **Low watermark** – **2**
 
    After setting all three, click the <span style="background-color:#ea1f71; color:white; font-family:helvetica;"> Ok </span> button. (The screenshot shows the window just before this action.)
 

--- a/content/nginx/deployment-guides/google-cloud-platform/high-availability-all-active.md
+++ b/content/nginx/deployment-guides/google-cloud-platform/high-availability-all-active.md
@@ -15,7 +15,7 @@ This guide explains how to deploy F5 NGINX Plus in a high-availability configura
 **Notes:**
 
 - The GCE environment changes constantly. This could include names and arrangements of GUI elements. This guide was accurate when published. But, some GCE GUI elements might have changed over time. Use this guide as a reference and adapt to the current GCE working environment.
-- The configuration described in this guide allows anyone from a public IP address to access the NGINX Plus instances. While this works in common scenarios in a test environment, we do not recommend it in production. Block external HTTP/HTTPS access to <span style="color:#666666; font-weight:bolder; white-space: nowrap;">app-1</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">app-2</span> instances to external IP address before production deployment. Alternatively, remove the external IP addresses for all application instances, so they're accessible only on the internal GCE network.
+- The configuration described in this guide allows anyone from a public IP address to access the NGINX Plus instances. While this works in common scenarios in a test environment, we do not recommend it in production. Block external HTTP/HTTPS access to **app&#8209;1** and **app&#8209;2** instances to external IP address before production deployment. Alternatively, remove the external IP addresses for all application instances, so they're accessible only on the internal GCE network.
 
 
 
@@ -38,7 +38,7 @@ The GCE network LB assigns each new client to a specific NGINX Plus LB. This ass
 
 NGINX Plus LB uses the round-robin algorithm to forward requests to specific app instances. It also adds a session cookie. It keeps future requests from the same client on the same app instance as long as it's running.
 
-This deployment guide uses two groups of app instances: – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">app-1</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">app-2</span>. It demonstrates [load balancing](https://www.nginx.com/products/nginx/load-balancing/) between different app types. But both groups have the same app configurations.
+This deployment guide uses two groups of app instances: – **app&#8209;1** and **app&#8209;2**. It demonstrates [load balancing](https://www.nginx.com/products/nginx/load-balancing/) between different app types. But both groups have the same app configurations.
 
 You can adapt the deployment to distribute unique connections to different groups of app instances. This can be done by creating discrete upstream blocks and routing content based on the URI.
 
@@ -67,19 +67,19 @@ All component names, like projects and instances, are examples only. You can cha
 
 Create a new GCE project to host the all‑active NGINX Plus deployment.
 
-1. Log into the [GCP Console](http://console.cloud.google.com) at <span style="font-weight:bold; white-space: nowrap;">console.cloud.google.com</span>.
+1. Log into the [GCP Console](http://console.cloud.google.com) at **console.cloud.google.com**.
 
-2. The GCP <span style="font-weight:bold; white-space: nowrap;">Home > Dashboard</span> tab opens. Its contents depend on whether you have any existing projects.
+2. The GCP **Home&nbsp;>&nbsp;Dashboard** tab opens. Its contents depend on whether you have any existing projects.
 
    - If there are no existing projects, click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create a project </span> button.
 
      <img src="/nginx/images/gce-dashboard-no-project.png" alt="Screenshot of the Google Cloud Platform dashboard that appears when there are no existing projects (creating a project is the first step in configuring NGINX Plus as the Google Cloud load balancer)" width="1024" height="422" class="aligncenter size-full wp-image-47475" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-   - If there are existing projects, the name of one of them appears in the upper left of the blue header bar (in the screenshot, it's <span style="background-color:#3366cc; color:white; white-space: nowrap;"> My Test Project </span>). Click the project name and select <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create project</span> from the menu that opens.
+   - If there are existing projects, the name of one of them appears in the upper left of the blue header bar (in the screenshot, it's <span style="background-color:#3366cc; color:white; white-space: nowrap;"> My Test Project </span>). Click the project name and select **Create&nbsp;project** from the menu that opens.
 
      <img src="/nginx/images/gce-dashboard-existing-project.png" alt="Screenshot of the Google Cloud Platform page that appears when other projects already exist (creating a project is the first step in configuring NGINX Plus as the Google Cloud load balancer)" width="1024" height="533" class="aligncenter size-full wp-image-47474" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-3. Type your project name in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">New Project</span> window that pops up, then click <span style="color:#3366cc;">CREATE</span>. We're naming the project <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span>.
+3. Type your project name in the **New&nbsp;Project** window that pops up, then click <span style="color:#3366cc;">CREATE</span>. We're naming the project **NGINX Plus&nbsp;All&#8209;Active&#8209;LB**.
 
     <img src="/nginx/images/gce-new-project-popup.png" alt="Screenshot of the New Project pop-up window for naming a new project on the Google Cloud Platform, which is the first step in configuring NGINX Plus as the Google load balancer" width="512" height="249" class="aligncenter size-full wp-image-47514" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -87,24 +87,24 @@ Create a new GCE project to host the all‑active NGINX Plus deployment.
 
 Create firewall rules that allow access to the HTTP and HTTPS ports on your GCE instances. You'll attach the rules to all the instances you create for the deployment.
 
-1. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Networking > Firewall rules</span> tab and click <span style="background-color:#3366cc; color:white;"> + </span> <span style="color:#3366cc;">CREATE FIREWALL RULE</span>. (The screenshot shows the default rules provided by GCE.)
+1. Navigate to the **Networking&nbsp;>&nbsp;Firewall&nbsp;rules** tab and click <span style="background-color:#3366cc; color:white;"> + </span> <span style="color:#3366cc;">CREATE FIREWALL RULE</span>. (The screenshot shows the default rules provided by GCE.)
 
    <img src="/nginx/images/gce-firewall-rules-tab.png" alt="Screenshot of the Google Cloud Platform page for defining new firewall rules; when configuring NGINX Plus as the Google Cloud load balancer, we open ports 80, 443, and 8080 for it." width="1024" height="413" class="aligncenter size-full wp-image-47476" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-2. Fill in the fields on the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create a firewall rule</span> screen that opens:<!-- Tony notes Feb 2018: I have purposely broken the "rule" that if any bullet in a list ends in a period (here, bullet 3), they all must. I think the appropriate values in bullets 1, 2, and 4 are clearer without a final period -->
+2. Fill in the fields on the **Create&nbsp;a&nbsp;firewall&nbsp;rule** screen that opens:<!-- Tony notes Feb 2018: I have purposely broken the "rule" that if any bullet in a list ends in a period (here, bullet 3), they all must. I think the appropriate values in bullets 1, 2, and 4 are clearer without a final period -->
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-fw-rule</span>
-   - **Description** – <span style="color:#666666; font-weight:bolder;">Allow access to ports 80, 8080, and 443 on all NGINX Plus instances</span>
-   - <span style="font-weight:bold; white-space: nowrap;">Source filter</span> – On the drop-down menu, select either <span style="color:#666666; font-weight:bolder;">Allow from any source (0.0.0.0/0)</span>, or <span style="color:#666666; font-weight:bolder; white-space: nowrap;">IP range</span> if you want to restrict access to users on your private network. In the second case, fill in the <span style="font-weight:bold; white-space: nowrap;">Source IP ranges</span> field that opens. In the screenshot, we are allowing unrestricted access.
-   - <span style="font-weight:bold; white-space: nowrap;">Allowed protocols and ports</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">tcp:80; tcp:8080; tcp:443</span>
+   - **Name** – **nginx&#8209;plus&#8209;http&#8209;fw&#8209;rule**
+   - **Description** – **Allow access to ports 80, 8080, and 443 on all NGINX Plus instances**
+   - **Source&nbsp;filter** – On the drop-down menu, select either **Allow from any source (0.0.0.0/0)**, or **IP&nbsp;range** if you want to restrict access to users on your private network. In the second case, fill in the **Source&nbsp;IP&nbsp;ranges** field that opens. In the screenshot, we are allowing unrestricted access.
+   - **Allowed&nbsp;protocols&nbsp;and&nbsp;ports** – **tcp:80;&nbsp;tcp:8080;&nbsp;tcp:443**
 
      **Note:** As noted in the introduction, allowing access from any public IP address is appropriate only in a test environment. Before deploying the architecture in production, create a firewall rule. Use this rule to block access to the external IP address for your application instances. Alternatively, you can disable external IP addresses for the instances. This limits access only to the internal GCE network.
 
-   - <span style="font-weight:bold; white-space: nowrap;">Target tags</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-fw-rule</span>
+   - **Target&nbsp;tags** – **nginx&#8209;plus&#8209;http&#8209;fw&#8209;rule**
 
    <img src="/nginx/images/gce-create-firewall-rule.png" alt="Screenshot of the interface for creating a Google Compute Engine (GCE) firewall rule, used during deployment of NGINX Plus as the Google load balancer." width="1024" height="619" class="aligncenter size-full wp-image-47470" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-3. Click the <span style="background-color:#3366cc; color:white;"> Create </span> button. The new rule is added to the table on the <span style="font-weight:bold; white-space: nowrap;">Firewall rules</span> tab.
+3. Click the <span style="background-color:#3366cc; color:white;"> Create </span> button. The new rule is added to the table on the **Firewall&nbsp;rules** tab.
 
 <span id="source"></span>
 ## Task 2: Creating Source Instances
@@ -123,96 +123,96 @@ The methods to create a source instance are different. Once you've created the s
 
 Create three source VM instances based on a GCE VM image. We're basing our instances on the <span style="white-space: nowrap;">Ubuntu 16.04 LTS</span> image.
 
-1. Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> project is still selected in the Google Cloud Platform header bar.
+1. Verify that the **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** project is still selected in the Google Cloud Platform header bar.
 
-2. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab.
+2. Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab.
 
-3. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create instance </span> button. The <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create an instance</span> page opens.
+3. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create instance </span> button. The **Create&nbsp;an&nbsp;instance** page opens.
 
 <span id="source-vm-app-1"></span>
 #### Creating the First Application Instance from a VM Image
 
-1. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create an instance</span> page, modify or verify the fields and checkboxes as indicated (a screenshot of the completed page appears in the next step):
+1. On the **Create&nbsp;an&nbsp;instance** page, modify or verify the fields and checkboxes as indicated (a screenshot of the completed page appears in the next step):
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span>
-   - **Zone** – The GCP zone that makes sense for your location. We're using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">us-west1-a</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">Machine type</span> – The appropriate size for the level of traffic you anticipate. We're selecting <span style="color:#666666; font-weight:bolder;">micro</span>, which is ideal for testing purposes.
-   - <span style="font-weight:bold; white-space: nowrap;">Boot disk</span> – Click <span style="color:#666666; font-weight:bolder;">Change</span>. The <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Boot disk</span> page opens to the <span style="color:#3366cc; white-space: nowrap;">OS images</span> subtab. Perform the following steps:
+   - **Name** – **nginx&#8209;plus&#8209;app&#8209;1**
+   - **Zone** – The GCP zone that makes sense for your location. We're using **us&#8209;west1&#8209;a**.
+   - **Machine&nbsp;type** – The appropriate size for the level of traffic you anticipate. We're selecting **micro**, which is ideal for testing purposes.
+   - **Boot&nbsp;disk** – Click **Change**. The **Boot&nbsp;disk** page opens to the <span style="color:#3366cc; white-space: nowrap;">OS images</span> subtab. Perform the following steps:
 
-      - Click the radio button for the Unix or Linux image of your choice (here, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Ubuntu 16.04 LTS</span>).
-      - Accept the default values in the <span style="font-weight:bold; white-space: nowrap;">Boot disk type</span> and <span style="font-weight:bold; white-space: nowrap;">Size (GB)</span> fields (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">Standard persistent disk</span> and <span style="color:#666666; font-weight:bolder;">10</span> respectively).
+      - Click the radio button for the Unix or Linux image of your choice (here, **Ubuntu&nbsp;16.04&nbsp;LTS**).
+      - Accept the default values in the **Boot&nbsp;disk&nbsp;type** and **Size&nbsp;(GB)** fields (**Standard&nbsp;persistent&nbsp;disk** and **10** respectively).
       - Click the <span style="background-color:#3366cc; color:white;"> Select </span> button.
 
       <img src="/nginx/images/gce-ubuntu-instance-boot-disk.png" alt="Screenshot of the 'Boot disk' page in Google Cloud Platform for selecting the OS on which a VM runs. In the deployment of NGINX Plus as the Google load balancer, we select Ubuntu 16.04 LTS." width="512" height="577" class="aligncenter size-full wp-image-47484" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-   - <span style="font-weight:bold; white-space: nowrap;">Identity and API access</span> – Keep the defaults for the <span style="font-weight:bold; white-space: nowrap;">Service account </span> field and <span style="font-weight:bold; white-space: nowrap;">Access scopes</span> radio button. Unless you need more granular control.
-   - **Firewall** – Verify that neither check box is checked (the default). The firewall rule invoked in the **Tags** field on the <span style="color:#666666; font-weight:bolder;">Management</span> subtab (see Step 3 below) controls this type of access.
+   - **Identity&nbsp;and&nbsp;API&nbsp;access** – Keep the defaults for the **Service&nbsp;account&nbsp;** field and **Access&nbsp;scopes** radio button. Unless you need more granular control.
+   - **Firewall** – Verify that neither check box is checked (the default). The firewall rule invoked in the **Tags** field on the **Management** subtab (see Step 3 below) controls this type of access.
 
 2. Click <span style="color:#3366cc; white-space: nowrap;">Management, disk, networking, SSH keys</span> to open that set of subtabs. (The screenshot shows the values entered in the previous step.)
 
    <img src="/nginx/images/gce-ubuntu-instance-create.png" alt="Screen shot of the 'Create an instance' page for an application server in the deployment of NGINX Plus as the Google Cloud Platform load balancer." width="487" height="839" class="aligncenter size-full wp-image-47516" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-3. On the <span style="color:#666666; font-weight:bolder;">Management</span> subtab, modify or verify the fields as indicated:
+3. On the **Management** subtab, modify or verify the fields as indicated:
 
-   - **Description** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus app-1 Image</span>
-   - **Tags** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-fw-rule</span>
-   - **Preemptibility** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Off (recommended)</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Automatic restart</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">On (recommended)</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">On host maintenance</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Migrate VM instance (recommended)</span> (the default)
+   - **Description** – **NGINX Plus&nbsp;app&#8209;1&nbsp;Image**
+   - **Tags** – **nginx&#8209;plus&#8209;http&#8209;fw&#8209;rule**
+   - **Preemptibility** – **Off&nbsp;(recommended)** (the default)
+   - **Automatic&nbsp;restart** – **On&nbsp;(recommended)** (the default)
+   - **On&nbsp;host&nbsp;maintenance** – **Migrate&nbsp;VM&nbsp;instance&nbsp;(recommended)** (the default)
 
    <img src="/nginx/images/gce-ubuntu-instance-management.png" alt="Screenshot of the Management subtab used during creation of a new VM instance, part of deploying NGINX Plus as the Google load balancer." width="487" height="551" class="aligncenter size-full wp-image-47486" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-4. On the <span style="color:#666666; font-weight:bolder;">Disks</span> subtab, uncheck the checkbox labeled <span style="color:#666666; font-weight:bolder;">Delete boot disk when instance is deleted</span>.
+4. On the **Disks** subtab, uncheck the checkbox labeled **Delete boot disk when instance is deleted**.
 
    <img src="/nginx/images/gce-ubuntu-instance-disks.png" alt="Screenshot of the Disks subtab used during creation of a new VM instance, part of deploying NGINX Plus as the Google Cloud load balancer." width="487" height="224" class="aligncenter size-full wp-image-47485" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-5. On the <span style="color:#666666; font-weight:bolder;">Networking</span> subtab, verify the default settings, in particular <span style="color:#666666; font-weight:bolder;">Ephemeral</span> for <span style="font-weight:bold; white-space: nowrap;">External IP</span> and <span style="color:#666666; font-weight:bolder;">Off</span> for <span style="font-weight:bold; white-space: nowrap;">IP Forwarding</span>.
+5. On the **Networking** subtab, verify the default settings, in particular **Ephemeral** for **External&nbsp;IP** and **Off** for **IP&nbsp;Forwarding**.
 
    <img src="/nginx/images/gce-ubuntu-instance-networking.png" alt="Screenshot of the Networking subtab used during creation of a new VM instance, part of deploying NGINX Plus as the Google Cloud load balancer." width="488" height="279" class="aligncenter size-full wp-image-47487" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-6. If you're using your own SSH public key instead of your default GCE keys, paste the hexadecimal key string on the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">SSH Keys</span> subtab. Right into the box that reads <span style="color:#666666; font-family:consolas; font-weight:bolder; white-space: nowrap;">Enter entire key data</span>.
+6. If you're using your own SSH public key instead of your default GCE keys, paste the hexadecimal key string on the **SSH&nbsp;Keys** subtab. Right into the box that reads **Enter&nbsp;entire&nbsp;key&nbsp;data**.
 
    <img src="/nginx/images/gce-ubuntu-instance-ssh-keys.png" alt="Screenshot of the SSH Keys subtab used during creation of a new VM instance, part of deploying NGINX Plus as the Google Cloud Platform load balancer." width="488" height="205" class="aligncenter size-full wp-image-47488" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-7. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create </span> button at the bottom of the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create an instance</span> page.
+7. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create </span> button at the bottom of the **Create&nbsp;an&nbsp;instance** page.
 
-    The <span style="color:#666666; font-weight:bolder; white-space: nowrap;">VM instances</span> summary page opens. It can take several minutes for the instance to be created. Wait to continue until the green check mark appears.
+    The **VM&nbsp;instances** summary page opens. It can take several minutes for the instance to be created. Wait to continue until the green check mark appears.
 
     <img src="/nginx/images/gce-ubuntu-instance-summary.png" alt="Screenshot of the summary page that verifies the creation of a new VM instance, part of deploying NGINX Plus as the load balancer for Google Cloud." width="1024" height="192" class="aligncenter size-full wp-image-47490" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
 <span id="source-vm-app-2"></span>
 #### Creating the Second Application Instance from a VM Image
 
-1. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">VM instances</span> summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE</span>.
+1. On the **VM&nbsp;instances** summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE</span>.
 
 2. Repeat the steps in <a href="#source-vm-app-1">Creating the First Application Instance</a> to create the second application instance. Specify the same values as for the first application instance, except:
 
-   - In Step 1, **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2</span>
-   - In Step 3, **Description** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus app-2 Image</span>
+   - In Step 1, **Name** – **nginx&#8209;plus&#8209;app&#8209;2**
+   - In Step 3, **Description** – **NGINX Plus&nbsp;app&#8209;2&nbsp;Image**
 
 <span id="source-vm-lb"></span>
 #### Creating the Load-Balancing Instance from a VM Image
 
-1. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">VM instances</span> summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE</span>.
+1. On the **VM&nbsp;instances** summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE</span>.
 
 2. Repeat the steps in <a href="#source-vm-app-1">Creating the First Application Instance</a> to create the load‑balancing instance. Specify the same values as for the first application instance, except:
 
-   - In Step 1, **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb</span>
-   - In Step 3, **Description** – <span style="color:#666666; font-weight:bolder;">NGINX Plus Load Balancing Image</span>
+   - In Step 1, **Name** – **nginx&#8209;plus&#8209;lb**
+   - In Step 3, **Description** – **NGINX Plus Load Balancing Image**
 
 <span id="source-vm-php"></span>
 #### Configuring PHP and FastCGI on the VM-Based Instances
 
 Install and configure PHP and FastCGI on the instances.
 
-<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb</span>).
+<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (**nginx&#8209;plus&#8209;app&#8209;1**, **nginx&#8209;plus&#8209;app&#8209;2**, and **nginx&#8209;plus&#8209;lb**).
 
 **Note:** Some commands require `root` privilege. If appropriate for your environment, prefix commands with the `sudo` command.
 
 1. Connect to the instance over SSH using the method of your choice. GCE provides a built-in mechanism:
 
-   - Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab.
-   - In the instance's row in the table, click the triangle icon in the <span style="color:#666666; font-weight:bolder;">Connect</span> column at the far right and select a method (for example, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Open in browser window</span>).
+   - Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab.
+   - In the instance's row in the table, click the triangle icon in the **Connect** column at the far right and select a method (for example, **Open&nbsp;in&nbsp;browser&nbsp;window**).
 
    <img src="/nginx/images/gce-ubuntu-instance-ssh.png" alt="Screenshot showing how to connect via SSH to a VM instance, part of deploying NGINX Plus as the Google load balancer." width="1024" height="284" class="aligncenter size-full wp-image-47489" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -222,7 +222,7 @@ Install and configure PHP and FastCGI on the instances.
    apt-get install php7.0-fpm
    ```
 
-3. Edit the PHP 7 configuration to bind to a local network port instead of a Unix socket. Using your preferred text editor, remove the following line from <span style="font-weight:bold; white-space: nowrap;">/etc/php/7.0/fpm/pool.d</span>:
+3. Edit the PHP 7 configuration to bind to a local network port instead of a Unix socket. Using your preferred text editor, remove the following line from **/etc/php/7.0/fpm/pool.d**:
 
    ```none
    listen = /run/php/php7.0-fpm.sock
@@ -253,7 +253,7 @@ Now install NGINX Plus and download files that are specific to the all‑active
 
 Both the configuration and content files are available at the [NGINX GitHub repository](https://github.com/nginxinc/NGINX-Demos/tree/master/gce-nginx-plus-deployment-guide-files).
 
-<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb</span>).
+<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (**nginx&#8209;plus&#8209;app&#8209;1**, **nginx&#8209;plus&#8209;app&#8209;2**, and **nginx&#8209;plus&#8209;lb**).
 
 **Note:** Some commands require `root` privilege. If appropriate for your environment, prefix commands with the `sudo` command.
 
@@ -261,11 +261,11 @@ Both the configuration and content files are available at the [NGINX GitHub repo
 
 2. Clone the GitHub repository for the [all‑active load balancing deployment](https://github.com/nginxinc/NGINX-Demos/tree/master/gce-nginx-plus-deployment-guide-files). (Instructions for downloading the files directly from the GitHub repository are provided below, in case you prefer not to clone it.)
 
-3. Copy the contents of the <span style="font-weight:bold; white-space: nowrap;">usr\_share\_nginx</span> subdirectory from the cloned repository to the local <span style="font-weight:bold; white-space: nowrap;">/usr/share/nginx</span> directory. Create the local directory if needed. (If you choose not to clone the repository, you need to download each file from the GitHub repository individually.)
+3. Copy the contents of the **usr\_share\_nginx** subdirectory from the cloned repository to the local **/usr/share/nginx** directory. Create the local directory if needed. (If you choose not to clone the repository, you need to download each file from the GitHub repository individually.)
 
-4. Copy the right configuration file from the <span style="font-weight:bold; white-space: nowrap;">etc\_nginx\_conf.d</span> subdirectory of the cloned repository to <span style="font-weight:bold; white-space: nowrap;">/etc/nginx/conf.d</span>:
+4. Copy the right configuration file from the **etc\_nginx\_conf.d** subdirectory of the cloned repository to **/etc/nginx/conf.d**:
 
-   - On <span style="text-decoration: underline;">both</span> <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2</span>, copy <span style="font-weight:bold; white-space: nowrap;">gce-all-active-app.conf</span>.
+   - On <span style="text-decoration: underline;">both</span> **nginx&#8209;plus&#8209;app&#8209;1** and **nginx&#8209;plus&#8209;app&#8209;2**, copy **gce&#8209;all&#8209;active&#8209;app.conf**.
 
       You can also run the following commands to download the configuration file directly from the GitHub repository:
 
@@ -281,7 +281,7 @@ Both the configuration and content files are available at the [NGINX GitHub repo
       wget https://github.com/nginxinc/NGINX-Demos/blob/master/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/gce-all-active-app.conf
       ```
 
-   - On <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb</span>, copy <span style="font-weight:bold; white-space: nowrap;">gce-all-active-lb.conf</span>.
+   - On **nginx&#8209;plus&#8209;lb**, copy **gce&#8209;all&#8209;active&#8209;lb.conf**.
 
      You can also run the following commands to download the configuration file directly from the GitHub repository:
 
@@ -297,9 +297,9 @@ Both the configuration and content files are available at the [NGINX GitHub repo
       wget https://github.com/nginxinc/NGINX-Demos/blob/master/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/gce-all-active-lb.conf
       ```
 
-5. On the LB instance (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb</span>), use a text editor to open <span style="font-weight:bold; white-space: nowrap;">gce-all-active-lb.conf</span>. Change the `server` directives in the `upstream` block to reference the internal IP addresses of the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2</span> instances (substitute the address for the expression in angle brackets). You do not need to modify the two application instances.
+5. On the LB instance (**nginx&#8209;plus&#8209;lb**), use a text editor to open **gce&#8209;all&#8209;active&#8209;lb.conf**. Change the `server` directives in the `upstream` block to reference the internal IP addresses of the **nginx&#8209;plus&#8209;app&#8209;1** and **nginx&#8209;plus&#8209;app&#8209;2** instances (substitute the address for the expression in angle brackets). You do not need to modify the two application instances.
 
-   You can look up internal IP addresses in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Internal IP</span> column of the table on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> summary page.
+   You can look up internal IP addresses in the **Internal&nbsp;IP** column of the table on the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** summary page.
 
    ```nginx
    upstream upstream_app_pool {
@@ -318,7 +318,7 @@ Both the configuration and content files are available at the [NGINX GitHub repo
    mv default.conf default.conf.bak
    ```
 
-7. Enable the NGINX Plus [live activity monitoring](https://www.nginx.com/products/nginx/live-activity-monitoring/) dashboard for the instance. Copy <span style="font-weight:bold; white-space: nowrap;">status.html</span> from the <span style="font-weight:bold; white-space: nowrap;">etc\_nginx\_conf.d</span> subdirectory of the cloned repository to <span style="font-weight:bold; white-space: nowrap;">/etc/nginx/conf.d</span>.
+7. Enable the NGINX Plus [live activity monitoring](https://www.nginx.com/products/nginx/live-activity-monitoring/) dashboard for the instance. Copy **status.html** from the **etc\_nginx\_conf.d** subdirectory of the cloned repository to **/etc/nginx/conf.d**.
 
    You can also run the following commands to download the configuration file directly from the GitHub repository:
 
@@ -341,9 +341,9 @@ Both the configuration and content files are available at the [NGINX GitHub repo
    nginx -s reload
    ```
 
-9. Verify the instance is working by accessing it at its external IP address. (As previously noted, we recommend blocking access to the external IP addresses of the application instances in a production environment.) The external IP address for the instance appears on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> summary page, in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">External IP</span> column of the table.
+9. Verify the instance is working by accessing it at its external IP address. (As previously noted, we recommend blocking access to the external IP addresses of the application instances in a production environment.) The external IP address for the instance appears on the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** summary page, in the **External&nbsp;IP** column of the table.
 
-    - Access the <span style="font-weight:bold; white-space: nowrap;">index.html</span> page either in a browser or by running this `curl` command.
+    - Access the **index.html** page either in a browser or by running this `curl` command.
 
       ```shell
       curl http://<external-IP-address>
@@ -351,7 +351,7 @@ Both the configuration and content files are available at the [NGINX GitHub repo
 
     - Access its NGINX Plus live activity monitoring dashboard in a browser, at:
 
-        <span style="font-weight:bold; white-space: nowrap;">https://_external-IP-address_:8080/status.html</span>
+        **https://_external&#8209;IP&#8209;address_:8080/status.html**
 
 10. Proceed to [Task 3: Creating "Gold" Images](#gold).
 
@@ -363,26 +363,26 @@ Create three source instances based on a prebuilt NGINX Plus image running on <
 <span id="source-prebuilt-app-1"></span>
 #### Creating the First Application Instance from a Prebuilt Image
 
-1. Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> project is still selected in the Google Cloud Platform header bar.
+1. Verify that the **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** project is still selected in the Google Cloud Platform header bar.
 
-2. Navigate to the GCP Marketplace and search for <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx plus</span>.
+2. Navigate to the GCP Marketplace and search for **nginx plus**.
 
-3. Click the <span style="font-weight:bold; white-space: nowrap;">NGINX Plus</span> box in the results area.
+3. Click the **NGINX Plus** box in the results area.
 
    <img src="/nginx/images/nginx-plus-in-gcp-marketplace.png" alt="Screenshot of NGINX Plus in the Google Cloud Platform Marketplace; from here, you can create a prebuilt NGINX Plus VM instance when deploying NGINX Plus as the load balancer for Google Cloud." width="1024" height="604" class="aligncenter size-full wp-image-47469" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-4. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus</span> page that opens, click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Launch on Compute Engine </span> button.
+4. On the **NGINX Plus** page that opens, click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Launch on Compute Engine </span> button.
 
-5. Fill in the fields on the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">New NGINX Plus deployment</span> page as indicated.
+5. Fill in the fields on the **New&nbsp;NGINX Plus&nbsp;deployment** page as indicated.
 
-   - <span style="font-weight:bold; white-space: nowrap;">Deployment name</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span>
-   - **Zone** – The GCP zone that makes sense for your location. We're using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">us-west1-a</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">Machine type</span> – The appropriate size for the level of traffic you anticipate. We're selecting <span style="color:#666666; font-weight:bolder; white-space: nowrap;">micro</span>, which is ideal for testing purposes.
-   - <span style="font-weight:bold; white-space: nowrap;">Disk type</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Standard Persistent Disk</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Disk size in GB</span> – <span style="color:#666666; font-weight:bolder;">10</span> (the default and minimum allowed)
-   - <span style="font-weight:bold; white-space: nowrap;">Network name</span> – <span style="color:#666666; font-weight:bolder;">default</span>
-   - <span style="font-weight:bold; white-space: nowrap;">Subnetwork name</span> – <span style="color:#666666; font-weight:bolder;">default</span>
-   - **Firewall** – Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Allow HTTP traffic</span> checkbox is checked.
+   - **Deployment&nbsp;name** – **nginx&#8209;plus&#8209;app&#8209;1**
+   - **Zone** – The GCP zone that makes sense for your location. We're using **us&#8209;west1&#8209;a**.
+   - **Machine&nbsp;type** – The appropriate size for the level of traffic you anticipate. We're selecting **micro**, which is ideal for testing purposes.
+   - **Disk&nbsp;type** – **Standard&nbsp;Persistent&nbsp;Disk** (the default)
+   - **Disk&nbsp;size&nbsp;in&nbsp;GB** – **10** (the default and minimum allowed)
+   - **Network&nbsp;name** – **default**
+   - **Subnetwork&nbsp;name** – **default**
+   - **Firewall** – Verify that the **Allow&nbsp;HTTP&nbsp;traffic** checkbox is checked.
 
    <a href="/nginx/images/gce-marketplace-new-deployment.png"><img src="/nginx/images/gce-marketplace-new-deployment.png" alt="Screenshot of the page for creating a prebuilt NGINX Plus VM instance when deploying NGINX Plus as the Google Cloud Platform load balancer." width="1054" height="973" class="aligncenter size-full wp-image-47468" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
@@ -392,25 +392,25 @@ Create three source instances based on a prebuilt NGINX Plus image running on <
 
    <img src="/nginx/images/gce-marketplace-instance-deployed.png" alt="Screenshot of the page that confirms the creation of a prebuilt NGINX Plus VM instance when deploying NGINX Plus as the Google load balancer." width="1024" height="399" class="aligncenter size-full wp-image-47467" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-7. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab and click <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span> in the <span style="color:#3366cc;">Name</span> column in the table. (The <span style="color:#666666; font-weight:bolder; white-space: nowrap;">-vm</span> suffix is added automatically to the name of the newly created instance.)
+7. Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab and click **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm** in the <span style="color:#3366cc;">Name</span> column in the table. (The **&#8209;vm** suffix is added automatically to the name of the newly created instance.)
 
    <img src="/nginx/images/gce-app-1-vm-select.png" alt="Screenshot showing how to access the page where configuration details for a VM instance can be modified during deployment of NGINX Plus as the Google Cloud load balancer." width="1023" height="194" class="aligncenter size-full wp-image-47465" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-8. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">VM instances</span> page that opens, click <span style="color:#3366cc;">EDIT</span> at the top of the page. In fields that can be edited, the value changes from static text to text boxes, drop‑down menus, and checkboxes.
+8. On the **VM&nbsp;instances** page that opens, click <span style="color:#3366cc;">EDIT</span> at the top of the page. In fields that can be edited, the value changes from static text to text boxes, drop‑down menus, and checkboxes.
 
 9. Modify or verify the indicated editable fields (non‑editable fields are not listed):
 
-   - **Tags** – If a default tag appears (for example, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-tcp-80</span>), click the <span style="color:#666666; font-weight:bolder;">X</span> after its name to remove it. Then, type in <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-fw-rule</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">External IP</span> – <span style="color:#666666; font-weight:bolder;">Ephemeral</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Boot disk and local disks</span> – Uncheck the checkbox labeled <span style="color:#666666; font-weight:bolder;">Delete boot disk when instance is deleted</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">Additional disks</span> – No changes
-   - **Network** – If you must change the defaults, for example, when configuring a production environment, select <span style="color:#3366cc;">default</span> Then, select <span style="color:#3366cc;">EDIT</span> on the opened <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Network details</span> page. After making your changes select the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Save </span> button.
+   - **Tags** – If a default tag appears (for example, **nginx&#8209;plus&#8209;app&#8209;1&#8209;tcp&#8209;80**), click the **X** after its name to remove it. Then, type in **nginx&#8209;plus&#8209;http&#8209;fw&#8209;rule**.
+   - **External&nbsp;IP** – **Ephemeral** (the default)
+   - **Boot&nbsp;disk&nbsp;and&nbsp;local&nbsp;disks** – Uncheck the checkbox labeled **Delete boot disk when instance is deleted**.
+   - **Additional&nbsp;disks** – No changes
+   - **Network** – If you must change the defaults, for example, when configuring a production environment, select <span style="color:#3366cc;">default</span> Then, select <span style="color:#3366cc;">EDIT</span> on the opened **Network&nbsp;details** page. After making your changes select the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Save </span> button.
    - **Firewall** – Verify that neither check box is checked (the default). The firewall rule named in the **Tags** field that's above on the current page (see the first bullet in this list) controls this type of access.
-   - <span style="font-weight:bold; white-space: nowrap;">Automatic restart</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">On (recommended)</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">On host maintenance</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Migrate VM instance (recommended)</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Custom metadata</span> – No changes
-   - <span style="font-weight:bold; white-space: nowrap;">SSH Keys</span> – If you're using your own SSH public key instead of your default GCE keys, paste the hexadecimal key string into the box labeled <span style="color:#666666; font-family:consolas; font-weight:bolder; white-space: nowrap;">Enter entire key data</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">Serial port</span> – Verify that the check box labeled <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Enable connecting to serial ports</span> is not checked (the default).
+   - **Automatic&nbsp;restart** – **On&nbsp;(recommended)** (the default)
+   - **On&nbsp;host&nbsp;maintenance** – **Migrate&nbsp;VM&nbsp;instance&nbsp;(recommended)** (the default)
+   - **Custom&nbsp;metadata** – No changes
+   - **SSH&nbsp;Keys** – If you're using your own SSH public key instead of your default GCE keys, paste the hexadecimal key string into the box labeled **Enter&nbsp;entire&nbsp;key&nbsp;data**.
+   - **Serial&nbsp;port** – Verify that the check box labeled **Enable&nbsp;connecting&nbsp;to&nbsp;serial&nbsp;ports** is not checked (the default).
 
    The screenshot shows the results of your changes. It omits some fields that can't be edited or for which we recommend keeping the defaults.
 
@@ -423,29 +423,29 @@ Create three source instances based on a prebuilt NGINX Plus image running on <
 
 Create the second application instance by cloning the first one.
 
-1. Navigate back to the summary page on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab (click the arrow that is circled in the following figure).
+1. Navigate back to the summary page on the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab (click the arrow that is circled in the following figure).
 
    <img src="/nginx/images/gce-vm-instances-back-arrow.png" alt="Screenshot showing how to return to the VM instance summary page during deployment of NGINX Plus as the Google Cloud Platform load balancer." width="1024" height="110" class="aligncenter size-full wp-image-47492" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-2. Click <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span> in the <span style="color:#3366cc;">Name</span> column of the table (shown in the screenshot in Step 7 of <a href="#source-prebuilt-app-1">Creating the First Application Instance</a>).
+2. Click **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm** in the <span style="color:#3366cc;">Name</span> column of the table (shown in the screenshot in Step 7 of <a href="#source-prebuilt-app-1">Creating the First Application Instance</a>).
 
-3. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">VM instances</span> page that opens, click <span style="color:#3366cc;">CLONE</span> at the top of the page.
+3. On the **VM&nbsp;instances** page that opens, click <span style="color:#3366cc;">CLONE</span> at the top of the page.
 
-4. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create an instance</span> page that opens, modify or verify the fields and checkboxes as indicated:
+4. On the **Create&nbsp;an&nbsp;instance** page that opens, modify or verify the fields and checkboxes as indicated:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-vm</span>. Here we're adding the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">-vm</span> suffix to make the name consistent with the first instance; GCE does not add it automatically when you clone an instance.
-   - **Zone** – The GCP zone that makes sense for your location. We're using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">us-west1-a</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">Machine type</span> – The appropriate size for the level of traffic you anticipate. We're selecting <span style="color:#666666; font-weight:bolder; white-space: nowrap;">f1-micro</span>, which is ideal for testing purposes.
-   - <span style="font-weight:bold; white-space: nowrap;">Boot disk type</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">New 10 GB standard persistent disk</span> (the value inherited from <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span>)
-   - <span style="font-weight:bold; white-space: nowrap;">Identity and API access</span> – Set the <span style="font-weight:bold; white-space: nowrap;">Access scopes</span> radio button to <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Allow default access</span> and accept the default values in all other fields. If you want more granular control over access than is provided by these settings, modify the fields in this section as appropriate.
+   - **Name** – **nginx&#8209;plus&#8209;app&#8209;2&#8209;vm**. Here we're adding the **&#8209;vm** suffix to make the name consistent with the first instance; GCE does not add it automatically when you clone an instance.
+   - **Zone** – The GCP zone that makes sense for your location. We're using **us&#8209;west1&#8209;a**.
+   - **Machine&nbsp;type** – The appropriate size for the level of traffic you anticipate. We're selecting **f1&#8209;micro**, which is ideal for testing purposes.
+   - **Boot&nbsp;disk&nbsp;type** – **New&nbsp;10&nbsp;GB&nbsp;standard&nbsp;persistent&nbsp;disk** (the value inherited from **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm**)
+   - **Identity&nbsp;and&nbsp;API&nbsp;access** – Set the **Access&nbsp;scopes** radio button to **Allow&nbsp;default&nbsp;access** and accept the default values in all other fields. If you want more granular control over access than is provided by these settings, modify the fields in this section as appropriate.
    - **Firewall** – Verify that neither check box is checked (the default).
 
 5. Click <span style="color:#3366cc; white-space: nowrap;">Management, disk, networking, SSH keys</span> to open that set of subtabs.
 
 6. Verify the following settings on the subtabs, modifying them as necessary:
 
-   - <span style="color:#666666; font-weight:bolder;">Management</span> – In the **Tags** field: <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-fw-rule</span>
-   - <span style="color:#666666; font-weight:bolder;">Disks</span> – The <span style="font-weight:bold; white-space: nowrap;">Deletion rule</span> checkbox (labeled <span style="color:#666666; font-weight:bolder;">Delete boot disk when instance is deleted</span>) is <span style="text-decoration: underline;">not</span> checked
+   - **Management** – In the **Tags** field: **nginx&#8209;plus&#8209;http&#8209;fw&#8209;rule**
+   - **Disks** – The **Deletion&nbsp;rule** checkbox (labeled **Delete boot disk when instance is deleted**) is <span style="text-decoration: underline;">not</span> checked
 
 7. Select the <span style="background-color:#3366cc; color:white;"> Create </span> button.
 
@@ -454,21 +454,21 @@ Create the second application instance by cloning the first one.
 
 Create the source load‑balancing instance by cloning the first instance again.
 
-Repeat Steps 2 through 7 of <a href="#source-prebuilt-app-2">Creating the Second Application Instance</a>. In Step 4, specify <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-vm</span> as the name.
+Repeat Steps 2 through 7 of <a href="#source-prebuilt-app-2">Creating the Second Application Instance</a>. In Step 4, specify **nginx&#8209;plus&#8209;lb&#8209;vm** as the name.
 
 <span id="source-prebuilt-php"></span>
 #### Configuring PHP and FastCGI on the Prebuilt-Based Instances
 
 Install and configure PHP and FastCGI on the instances.
 
-<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-vm</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-vm</span>).
+<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (**nginx&#8209;plus&#8209;app&#8209;1&#8209;vm**, **nginx&#8209;plus&#8209;app&#8209;2&#8209;vm**, and **nginx&#8209;plus&#8209;lb&#8209;vm**).
 
 **Note:** Some commands require `root` privilege. If appropriate for your environment, prefix commands with the `sudo` command.
 
 1. Connect to the instance over SSH using the method of your choice. GCE provides a built‑in mechanism:
 
-   - Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab.
-   - In the table, find the row for the instance. Select the triangle icon in the <span style="color:#666666; font-weight:bolder;">Connect</span> column at the far right. Then, select a method (for example, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Open in browser window</span>).
+   - Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab.
+   - In the table, find the row for the instance. Select the triangle icon in the **Connect** column at the far right. Then, select a method (for example, **Open&nbsp;in&nbsp;browser&nbsp;window**).
 
    The screenshot shows instances based on the prebuilt NGINX Plus images.
 
@@ -480,7 +480,7 @@ Install and configure PHP and FastCGI on the instances.
    apt-get install php5-fpm
    ```
 
-3. Edit the PHP 5 configuration to bind to a local network port instead of a Unix socket. Using your preferred text editor, remove the following line from <span style="font-weight:bold; white-space: nowrap;">/etc/php5/fpm/pool.d</span>:
+3. Edit the PHP 5 configuration to bind to a local network port instead of a Unix socket. Using your preferred text editor, remove the following line from **/etc/php5/fpm/pool.d**:
 
    ```none
    Listen = /run/php/php5-fpm.sock
@@ -511,18 +511,18 @@ Now download files that are specific to the all‑active deployment:
 
 Both the configuration and content files are available at the [NGINX GitHub repository](https://github.com/nginxinc/NGINX-Demos/tree/master/gce-nginx-plus-deployment-guide-files).
 
-<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-vm</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-vm</span>).
+<span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for all three source instances (**nginx&#8209;plus&#8209;app&#8209;1&#8209;vm**, **nginx&#8209;plus&#8209;app&#8209;2&#8209;vm**, and **nginx&#8209;plus&#8209;lb&#8209;vm**).
 
 **Note:** Some commands require `root` privilege. If appropriate for your environment, prefix commands with the `sudo` command.
 
 1. Clone the GitHub repository for the [all‑active load balancing deployment](https://github.com/nginxinc/NGINX-Demos/tree/master/gce-nginx-plus-deployment-guide-files). (See the instructions below for downloading the files from GitHub if you choose not to clone it.)
 
-2. Copy the contents of the <span style="font-weight:bold; white-space: nowrap;">usr\_share\_nginx</span> subdirectory from the cloned repo to the local <span style="font-weight:bold; white-space: nowrap;">/usr/share/nginx</span> directory. Create the local directory if necessary. (If you choose not to clone the repository, you need to download each file from the GitHub repository one at a time.)
+2. Copy the contents of the **usr\_share\_nginx** subdirectory from the cloned repo to the local **/usr/share/nginx** directory. Create the local directory if necessary. (If you choose not to clone the repository, you need to download each file from the GitHub repository one at a time.)
 
 
-3. Copy the right configuration file from the <span style="font-weight:bold; white-space: nowrap;">etc\_nginx\_conf.d</span> subdirectory of the cloned repository to <span style="font-weight:bold; white-space: nowrap;">/etc/nginx/conf.d</span>:
+3. Copy the right configuration file from the **etc\_nginx\_conf.d** subdirectory of the cloned repository to **/etc/nginx/conf.d**:
 
-   - On <span style="text-decoration: underline;">both</span> <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-vm</span>, copy <span style="font-weight:bold; white-space: nowrap;">gce-all-active-app.conf</span>.
+   - On <span style="text-decoration: underline;">both</span> **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm** and **nginx&#8209;plus&#8209;app&#8209;2&#8209;vm**, copy **gce&#8209;all&#8209;active&#8209;app.conf**.
 
      You can also run these commands to download the configuration file from GitHub:
 
@@ -538,7 +538,7 @@ Both the configuration and content files are available at the [NGINX GitHub repo
       wget https://github.com/nginxinc/NGINX-Demos/blob/master/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/gce-all-active-app.conf
       ```
 
-   - On <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-vm</span>, copy <span style="font-weight:bold; white-space: nowrap;">gce-all-active-lb.conf</span>.
+   - On **nginx&#8209;plus&#8209;lb&#8209;vm**, copy **gce&#8209;all&#8209;active&#8209;lb.conf**.
 
       You can also run the following commands to download the configuration file directly from the GitHub repository:
 
@@ -554,9 +554,9 @@ Both the configuration and content files are available at the [NGINX GitHub repo
       wget https://github.com/nginxinc/NGINX-Demos/blob/master/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/gce-all-active-lb.conf
       ```
 
-4. On the LB instance (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-vm</span>), use a text editor to open <span style="font-weight:bold; white-space: nowrap;">gce-all-active-lb.conf</span>. Change the `server` directives in the `upstream` block to reference the internal IP addresses of the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-vm</span> instances. (No action is required on the two application instances themselves.)
+4. On the LB instance (**nginx&#8209;plus&#8209;lb&#8209;vm**), use a text editor to open **gce&#8209;all&#8209;active&#8209;lb.conf**. Change the `server` directives in the `upstream` block to reference the internal IP addresses of the **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm** and **nginx&#8209;plus&#8209;app&#8209;2&#8209;vm** instances. (No action is required on the two application instances themselves.)
 
-   You can look up internal IP addresses in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Internal IP</span> column of the table on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> summary page.
+   You can look up internal IP addresses in the **Internal&nbsp;IP** column of the table on the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** summary page.
 
    ```nginx
    upstream upstream_app_pool {
@@ -575,7 +575,7 @@ Both the configuration and content files are available at the [NGINX GitHub repo
    mv default.conf default.conf.bak
    ```
 
-6. Enable the NGINX Plus [live activity monitoring](https://www.nginx.com/products/nginx/live-activity-monitoring/) dashboard for the instance. To do this, copy <span style="font-weight:bold; white-space: nowrap;">status.html</span> from the <span style="font-weight:bold; white-space: nowrap;">etc\_nginx\_conf.d</span> subdirectory of the cloned repository to <span style="font-weight:bold; white-space: nowrap;">/etc/nginx/conf.d</span>.
+6. Enable the NGINX Plus [live activity monitoring](https://www.nginx.com/products/nginx/live-activity-monitoring/) dashboard for the instance. To do this, copy **status.html** from the **etc\_nginx\_conf.d** subdirectory of the cloned repository to **/etc/nginx/conf.d**.
 
    You can also run the following commands to download the configuration file directly from the GitHub repository:
 
@@ -598,9 +598,9 @@ Both the configuration and content files are available at the [NGINX GitHub repo
    nginx -s reload
    ```
 
-8. Verify the instance is working by accessing it at its external IP address. (As noted, we recommend blocking access, in production, to the external IPs of the app.) The external IP address for the instance appears on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> summary page, in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">External IP</span> column of the table.
+8. Verify the instance is working by accessing it at its external IP address. (As noted, we recommend blocking access, in production, to the external IPs of the app.) The external IP address for the instance appears on the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** summary page, in the **External&nbsp;IP** column of the table.
 
-   - Access the <span style="font-weight:bold; white-space: nowrap;">index.html</span> page either in a browser or by running this `curl` command.
+   - Access the **index.html** page either in a browser or by running this `curl` command.
 
       ```shell
      curl http://<external-IP-address-of-NGINX-Plus-server>
@@ -608,7 +608,7 @@ Both the configuration and content files are available at the [NGINX GitHub repo
 
    - Access the NGINX Plus live activity monitoring dashboard in a browser, at:
 
-     <span style="font-weight:bold; white-space: nowrap;">https://_external-IP-address-of-NGINX-Plus-server_:8080/dashboard.html</span>
+     **https://_external&#8209;IP&#8209;address&#8209;of&#8209;NGINX&#8209;Plus&#8209;server_:8080/dashboard.html**
 
 9. Proceed to [Task 3: Creating "Gold" Images](#gold).
 
@@ -617,14 +617,14 @@ Both the configuration and content files are available at the [NGINX GitHub repo
 
 Create _gold images_, which are base images that GCE clones automatically when it needs to scale up the number of instances. They are derived from the instances you created in [Creating Source Instances](#source). Before creating the images, delete the source instances. This breaks the attachment between them and the disk. (you can't create an image from a disk attached to a VM instance).
 
-1. Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> project is still selected in the Google Cloud Platform header bar.
+1. Verify that the **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** project is still selected in the Google Cloud Platform header bar.
 
-2. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab.
+2. Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab.
 
 3. In the table, select all three instances:
 
-   - If you created source instances from [VM (Ubuntu) images](#source-vm): <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb</span>
-   - If you created source instances from [prebuilt NGINX Plus images](#source-prebuilt): <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span>, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-vm</span>, and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-vm</span>
+   - If you created source instances from [VM (Ubuntu) images](#source-vm): **nginx&#8209;plus&#8209;app&#8209;1**, **nginx&#8209;plus&#8209;app&#8209;2**, and **nginx&#8209;plus&#8209;lb**
+   - If you created source instances from [prebuilt NGINX Plus images](#source-prebuilt): **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm**, **nginx&#8209;plus&#8209;app&#8209;2&#8209;vm**, and **nginx&#8209;plus&#8209;lb&#8209;vm**
 
 4. Click <span style="color:#3366cc;">STOP</span> in the top toolbar to stop the instances.
 
@@ -634,43 +634,43 @@ Create _gold images_, which are base images that GCE clones automatically when i
 
    **Note:** If the pop-up warns that it will delete the boot disk for any instance, cancel the deletion. Then, perform the steps below <span style="text-decoration: underline;">for each affected instance</span>:
 
-   - Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab and click the instance in the <span style="color:#3366cc;">Name</span> column in the table. (The screenshot shows <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span>.)
+   - Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab and click the instance in the <span style="color:#3366cc;">Name</span> column in the table. (The screenshot shows **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm**.)
 
      <img src="/nginx/images/gce-app-1-vm-select.png" alt="Screenshot showing how to access the page where configuration details for a VM instance can be modified during deployment of NGINX Plus as the Google Cloud load balancer." width="1023" height="194" class="aligncenter size-full wp-image-47465" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-   - On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">VM instances</span> page that opens, click <span style="color:#3366cc;">EDIT</span> at the top of the page. In fields that can be edited, the value changes from static text to text boxes, drop‑down menus, and checkboxes.
-   - In the <span style="font-weight:bold; white-space: nowrap;">Boot disk and local disks</span> field, uncheck the checkbox labeled <span style="color:#666666; font-weight:bolder;">Delete boot disk when instance is deleted</span>.
+   - On the **VM&nbsp;instances** page that opens, click <span style="color:#3366cc;">EDIT</span> at the top of the page. In fields that can be edited, the value changes from static text to text boxes, drop‑down menus, and checkboxes.
+   - In the **Boot&nbsp;disk&nbsp;and&nbsp;local&nbsp;disks** field, uncheck the checkbox labeled **Delete boot disk when instance is deleted**.
    - Click the <span style="background-color:#3366cc; color:white;"> Save </span> button.
-   - On the <span style="font-weight:bold; white-space: nowrap;">VM instances</span> summary page, select the instance in the table and click <span style="color:#3366cc;">DELETE</span> in the top toolbar to delete it.
+   - On the **VM&nbsp;instances** summary page, select the instance in the table and click <span style="color:#3366cc;">DELETE</span> in the top toolbar to delete it.
 
-6. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > Images</span> tab.
+6. Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;Images** tab.
 
 7. Click <span style="color:#3366cc; white-space: nowrap;">[+] CREATE IMAGE</span>.
 
-8. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create an image</span> page that opens, modify or verify the fields as indicated:
+8. On the **Create&nbsp;an&nbsp;image** page that opens, modify or verify the fields as indicated:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-image</span>
+   - **Name** – **nginx&#8209;plus&#8209;app&#8209;1&#8209;image**
    - **Family** – Leave the field empty
-   - **Description** – <span style="color:#666666; font-weight:bolder;">NGINX Plus Application 1 Gold Image</span>
-   - **Encryption** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Automatic (recommended)</span> (the default)
-   - **Source** – <span style="color:#666666; font-weight:bolder;">Disk</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Source disk</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1</span> or <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-vm</span>, depending on the method you used to create source instances (select the source instance from the drop‑down menu)
+   - **Description** – **NGINX Plus Application 1 Gold Image**
+   - **Encryption** – **Automatic&nbsp;(recommended)** (the default)
+   - **Source** – **Disk** (the default)
+   - **Source&nbsp;disk** – **nginx&#8209;plus&#8209;app&#8209;1** or **nginx&#8209;plus&#8209;app&#8209;1&#8209;vm**, depending on the method you used to create source instances (select the source instance from the drop‑down menu)
 
 9. Click the <span style="background-color:#3366cc; color:white;"> Create </span> button.
 
 10. Repeat Steps 7 through 9 to create a second image with the following values (retain the default values in all other fields):
 
-    - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-image</span>
-    - **Description** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus Application 2 Gold Image</span>
-    - <span style="font-weight:bold; white-space: nowrap;">Source disk</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2</span> or <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-vm</span>, depending on the method you used to create source instances (select the source instance from the drop‑down menu)
+    - **Name** – **nginx&#8209;plus&#8209;app&#8209;2&#8209;image**
+    - **Description** – **NGINX Plus&nbsp;Application&nbsp;2&nbsp;Gold&nbsp;Image**
+    - **Source&nbsp;disk** – **nginx&#8209;plus&#8209;app&#8209;2** or **nginx&#8209;plus&#8209;app&#8209;2&#8209;vm**, depending on the method you used to create source instances (select the source instance from the drop‑down menu)
 
 11. Repeat Steps 7 through 9 to create a third image with the following values (retain the default values in all other fields):
 
-    - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-image</span>
-    - **Description** – <span style="color:#666666; font-weight:bolder;">NGINX Plus LB Gold Image</span>
-    - <span style="font-weight:bold; white-space: nowrap;">Source disk</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb</span> or <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-vm</span>, depending on the method you used to create source instances (select the source instance from the drop‑down menu)
+    - **Name** – **nginx&#8209;plus&#8209;lb&#8209;image**
+    - **Description** – **NGINX Plus LB Gold Image**
+    - **Source&nbsp;disk** – **nginx&#8209;plus&#8209;lb** or **nginx&#8209;plus&#8209;lb&#8209;vm**, depending on the method you used to create source instances (select the source instance from the drop‑down menu)
 
-12. Verify that the three images appear at the top of the table on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > Images</span> tab.
+12. Verify that the three images appear at the top of the table on the **Compute&nbsp;Engine&nbsp;>&nbsp;Images** tab.
 
 <span id="templates"></span>
 ## Task 4: Creating Instance Templates
@@ -681,58 +681,58 @@ Create _instance templates_. They are the compute workloads in instance groups. 
 <span id="templates-app-1"></span>
 ### Creating the First Application Instance Template
 
-1. Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> project is still selected in the Google Cloud Platform header bar.
+1. Verify that the **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** project is still selected in the Google Cloud Platform header bar.
 
-2. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > Instance templates</span> tab.
+2. Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;Instance&nbsp;templates** tab.
 
 3. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create instance template </span> button.
 
-4. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create an instance template</span> page that opens, modify or verify the fields as indicated:
+4. On the **Create&nbsp;an&nbsp;instance&nbsp;template** page that opens, modify or verify the fields as indicated:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-instance-template</span>
-   - <span style="font-weight:bold; white-space: nowrap;">Machine type</span> – The appropriate size for the level of traffic you anticipate. We're selecting <span style="color:#666666; font-weight:bolder;">micro</span>, which is ideal for testing purposes.
-   - <span style="font-weight:bold; white-space: nowrap;">Boot disk</span> – Click <span style="color:#666666; font-weight:bolder;">Change</span>. The <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Boot disk</span> page opens. Perform the following steps:
+   - **Name** – **nginx&#8209;plus&#8209;app&#8209;1&#8209;instance&#8209;template**
+   - **Machine&nbsp;type** – The appropriate size for the level of traffic you anticipate. We're selecting **micro**, which is ideal for testing purposes.
+   - **Boot&nbsp;disk** – Click **Change**. The **Boot&nbsp;disk** page opens. Perform the following steps:
 
-     - Open the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Custom Images</span> subtab.
+     - Open the **Custom&nbsp;Images** subtab.
 
          <img src="/nginx/images/gce-instance-template-boot-disk.png" alt="Screenshot of the 'Boot disk' page in Google Cloud Platform for selecting the source instance of a new instance template, part of deploying NGINX Plus as the Google load balancer." width="491" height="517" class="aligncenter size-full wp-image-47478" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-     - Select <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> from the drop-down menu labeled <span style="font-weight:bold; white-space: nowrap;">Show images from</span>.
+     - Select **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** from the drop-down menu labeled **Show&nbsp;images&nbsp;from**.
 
-     - Click the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-image</span> radio button.
+     - Click the **nginx&#8209;plus&#8209;app&#8209;1&#8209;image** radio button.
 
-     - Accept the default values in the <span style="font-weight:bold; white-space: nowrap;">Boot disk type</span> and <span style="font-weight:bold; white-space: nowrap;">Size (GB)</span> fields (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">Standard persistent disk</span> and <span style="color:#666666; font-weight:bolder;">10</span> respectively).
+     - Accept the default values in the **Boot&nbsp;disk&nbsp;type** and **Size&nbsp;(GB)** fields (**Standard&nbsp;persistent&nbsp;disk** and **10** respectively).
 
      - Click the <span style="background-color:#3366cc; color:white;"> Select </span> button.
 
-   - <span style="font-weight:bold; white-space: nowrap;">Identity and API access</span> – Unless you want more granular control over access, keep the defaults in the <span style="font-weight:bold; white-space: nowrap;">Service account</span> field (<span style="color:#666666; font-weight:bolder;">Compute Engine default service account</span>) and <span style="font-weight:bold; white-space: nowrap;">Access scopes</span> field (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">Allow default access</span>).
-   - **Firewall** – Verify that neither check box is checked (the default). The firewall rule invoked in the **Tags** field on the <span style="color:#666666; font-weight:bolder;">Management</span> subtab (see Step 6 below) controls this type of access.
+   - **Identity&nbsp;and&nbsp;API&nbsp;access** – Unless you want more granular control over access, keep the defaults in the **Service&nbsp;account** field (**Compute Engine default service account**) and **Access&nbsp;scopes** field (**Allow&nbsp;default&nbsp;access**).
+   - **Firewall** – Verify that neither check box is checked (the default). The firewall rule invoked in the **Tags** field on the **Management** subtab (see Step 6 below) controls this type of access.
 
 5. Select <span style="color:#3366cc; white-space: nowrap;">Management, disk, networking, SSH keys</span> (indicated with a red arrow in the following screenshot) to open that set of subtabs.
 
    <img src="/nginx/images/gce-create-instance-template.png" alt="Screenshot of the interface for creating a Google Compute Engine (GCE) instance template, used during deployment of NGINX Plus as the Google load balancer." width="498" height="798" class="aligncenter size-full wp-image-47473" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-6. On the <span style="color:#666666; font-weight:bolder;">Management</span> subtab, modify or verify the fields as indicated:
+6. On the **Management** subtab, modify or verify the fields as indicated:
 
-   - **Description** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus app-1 Instance Template</span>
-   - **Tags** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-fw-rule</span>
-   - **Preemptibility** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Off (recommended)</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Automatic restart</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">On (recommended)</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">On host maintenance</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Migrate VM instance (recommended)</span> (the default)
+   - **Description** – **NGINX Plus&nbsp;app&#8209;1&nbsp;Instance&nbsp;Template**
+   - **Tags** – **nginx&#8209;plus&#8209;http&#8209;fw&#8209;rule**
+   - **Preemptibility** – **Off&nbsp;(recommended)** (the default)
+   - **Automatic&nbsp;restart** – **On&nbsp;(recommended)** (the default)
+   - **On&nbsp;host&nbsp;maintenance** – **Migrate&nbsp;VM&nbsp;instance&nbsp;(recommended)** (the default)
 
    <img src="/nginx/images/gce-instance-template-management.png" alt="Screenshot of the Management subtab used during creation of a new VM instance template, part of deploying NGINX Plus as the Google load balancer." width="487" height="551" class="aligncenter size-full wp-image-47480" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-7. On the <span style="color:#666666; font-weight:bolder;">Disks</span> subtab, verify that the checkbox labeled <span style="color:#666666; font-weight:bolder;">Delete boot disk when instance is deleted</span> is checked.
+7. On the **Disks** subtab, verify that the checkbox labeled **Delete boot disk when instance is deleted** is checked.
 
    Instances from this template are ephemeral instantiations of the gold image. So, we want GCE to reclaim the disk when the instance is terminated. New instances are always based on the gold image. So, there is no reason to keep the instantiations on disk when the instance is deleted.
 
    <img src="/nginx/images/gce-instance-template-disks.png" alt="Screenshot of the Disks subtab used during creation of a new VM instance template, part of deploying NGINX Plus as the Google Cloud load balancer." width="488" height="184" class="aligncenter size-full wp-image-47479" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-8. On the <span style="color:#666666; font-weight:bolder;">Networking</span> subtab, verify the default settings of <span style="color:#666666; font-weight:bolder;">Ephemeral</span> for <span style="font-weight:bold; white-space: nowrap;">External IP</span> and <span style="color:#666666; font-weight:bolder;">Off</span> for <span style="font-weight:bold; white-space: nowrap;">IP Forwarding</span>.
+8. On the **Networking** subtab, verify the default settings of **Ephemeral** for **External&nbsp;IP** and **Off** for **IP&nbsp;Forwarding**.
 
    <img src="/nginx/images/gce-instance-template-networking.png" alt="Screenshot of the Networking subtab used during creation of a new VM instance template, part of deploying NGINX Plus as the Google load balancer." width="488" height="174" class="aligncenter size-full wp-image-47481" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-9. If you're using your own SSH public key instead of your default keys, paste the hexadecimal key string on the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">SSH Keys</span> subtab. Right into the box that reads <span style="color:#666666; font-family:consolas; font-weight:bolder; white-space: nowrap;">Enter entire key data</span>.
+9. If you're using your own SSH public key instead of your default keys, paste the hexadecimal key string on the **SSH&nbsp;Keys** subtab. Right into the box that reads **Enter&nbsp;entire&nbsp;key&nbsp;data**.
 
     <img src="/nginx/images/gce-ubuntu-instance-ssh-keys.png" alt="Screenshot of the SSH Keys subtab used during creation of a new VM instance, part of deploying NGINX Plus as the Google Cloud Platform load balancer." width="488" height="205" class="aligncenter size-full wp-image-47488" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -741,55 +741,55 @@ Create _instance templates_. They are the compute workloads in instance groups. 
 <span id="templates-app-2"></span>
 ### Creating the Second Application Instance Template
 
-1. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Instance templates</span> summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE TEMPLATE</span>.
+1. On the **Instance&nbsp;templates** summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE TEMPLATE</span>.
 
 2. Repeat Steps 4 through 10 of <a href="#templates-app-1">Creating the First Application Instance Template</a> to create a second application instance template. Use the same values as for the first instance template, except as noted:
 
    - In Step 4:
-     - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-instance-template</span>
-     - <span style="font-weight:bold; white-space: nowrap;">Boot disk</span> – Click the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-image</span> radio button
-   - In Step 6, **Description** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus app-2 Instance Template</span>
+     - **Name** – **nginx&#8209;plus&#8209;app&#8209;2&#8209;instance&#8209;template**
+     - **Boot&nbsp;disk** – Click the **nginx&#8209;plus&#8209;app&#8209;2&#8209;image** radio button
+   - In Step 6, **Description** – **NGINX Plus&nbsp;app&#8209;2&nbsp;Instance&nbsp;Template**
 
 <span id="templates-lb"></span>
 ### Creating the Load-Balancing Instance Template
 
-1. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Instance templates</span> summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE TEMPLATE</span>.
+1. On the **Instance&nbsp;templates** summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE TEMPLATE</span>.
 
 2. Repeat Steps 4 through 10 of <a href="#templates-app-1">Creating the First Application Instance Template</a> to create the load‑balancing instance template. Use the same values as for the first instance template, except as noted:
 
    - In Step 4:
-      - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-instance-template</span>.
-      - <span style="font-weight:bold; white-space: nowrap;">Boot disk</span> – Click the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-image</span> radio button
+      - **Name** – **nginx&#8209;plus&#8209;lb&#8209;instance&#8209;template**.
+      - **Boot&nbsp;disk** – Click the **nginx&#8209;plus&#8209;lb&#8209;image** radio button
 
-   - In Step 6, **Description** – <span style="color:#666666; font-weight:bolder;">NGINX Plus Load‑Balancing Instance Template</span>
+   - In Step 6, **Description** – **NGINX Plus Load‑Balancing Instance Template**
 
 <span id="health-checks"></span>
 ## Task 5: Creating Image Health Checks
 
 Define the simple HTTP health check that GCE uses. This verifies that each NGINX Plus LB image is running (and to re-create any LB instance that isn't running).
 
-1. Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> project is still selected in the Google Cloud Platform header bar.
+1. Verify that the **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** project is still selected in the Google Cloud Platform header bar.
 
-2. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > Health checks</span> tab.
+2. Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;Health&nbsp;checks** tab.
 
 3. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create a health check </span> button.
 
-4. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create a health check</span> page that opens, modify or verify the fields as indicated:
+4. On the **Create&nbsp;a&nbsp;health&nbsp;check** page that opens, modify or verify the fields as indicated:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-health-check</span>
-   - **Description** – <span style="color:#666666; font-weight:bolder;">Basic HTTP health check to monitor NGINX Plus instances</span>
-   - **Protocol** – <span style="color:#666666; font-weight:bolder;">HTTP</span> (the default)
-   - **Port** – <span style="color:#666666; font-weight:bolder;">80</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Request path</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">/status-old.html</span>
+   - **Name** – **nginx&#8209;plus&#8209;http&#8209;health&#8209;check**
+   - **Description** – **Basic HTTP health check to monitor NGINX Plus instances**
+   - **Protocol** – **HTTP** (the default)
+   - **Port** – **80** (the default)
+   - **Request&nbsp;path** – **/status&#8209;old.html**
 
-5. If the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Health criteria</span> section is not already open, click <span style="color:#3366cc;">More</span>.
+5. If the **Health&nbsp;criteria** section is not already open, click <span style="color:#3366cc;">More</span>.
 
 6. Modify or verify the fields as indicated:
 
-   - <span style="font-weight:bold; white-space: nowrap;">Check interval</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">10 seconds</span>
-   - **Timeout** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">10 seconds</span>
-   - <span style="font-weight:bold; white-space: nowrap;">Healthy threshold</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">2 consecutive successes</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Unhealthy threshold</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">10 consecutive failures</span>
+   - **Check&nbsp;interval** – **10&nbsp;seconds**
+   - **Timeout** – **10&nbsp;seconds**
+   - **Healthy&nbsp;threshold** – **2&nbsp;consecutive&nbsp;successes** (the default)
+   - **Unhealthy&nbsp;threshold** – **10&nbsp;consecutive&nbsp;failures**
 
 7. Click the <span style="background-color:#3366cc; color:white;"> Create </span> button.
 
@@ -800,28 +800,28 @@ Define the simple HTTP health check that GCE uses. This verifies that each NGINX
 
 Create three independent instance groups, one for each type of function-specific instance.
 
-1. Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> project is still selected in the Google Cloud Platform header bar.
+1. Verify that the **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** project is still selected in the Google Cloud Platform header bar.
 
-2. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > Instance groups</span> tab.
+2. Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;Instance&nbsp;groups** tab.
 
 3. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create instance group </span> button.
 
 <span id="groups-app-1"></span>
 ### Creating the First Application Instance Group
 
-1. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Create a new instance group</span> page that opens, modify or verify the fields as indicated. Ignore fields that are not mentioned:
+1. On the **Create&nbsp;a&nbsp;new&nbsp;instance&nbsp;group** page that opens, modify or verify the fields as indicated. Ignore fields that are not mentioned:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-instance-group</span>
-   - **Description** – <span style="color:#666666; font-weight:bolder;">Instance group to host NGINX Plus app-1 instances</span>
+   - **Name** – **nginx&#8209;plus&#8209;app&#8209;1&#8209;instance&#8209;group**
+   - **Description** – **Instance group to host NGINX Plus app-1 instances**
    - **Location** –
-     - Click the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Single-zone</span> radio button (the default).
-     - **Zone** – The GCP zone you specified when you created source instances (Step 1 of [Creating the First Application Instance from a VM Image](#source-vm-app-1) or Step 5 of [Creating the First Application Instance from a Prebuilt Image](#source-prebuilt)). We're using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">us-west1-a</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">Creation method</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Use instance template</span> radio button (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Instance template</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-instance-template</span> (select from the drop-down menu)
-   - **Autoscaling** – <span style="color:#666666; font-weight:bolder;">Off</span> (the default)
-   - <span style="font-weight:bold; white-space: nowrap;">Number of instances</span> – <span style="color:#666666; font-weight:bolder;">2</span>
-   - <span style="font-weight:bold; white-space: nowrap;">Health check</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-health-check</span> (select from the drop-down menu)
-   - <span style="font-weight:bold; white-space: nowrap;">Initial delay</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">300 seconds</span> (the default)
+     - Click the **Single&#8209;zone** radio button (the default).
+     - **Zone** – The GCP zone you specified when you created source instances (Step 1 of [Creating the First Application Instance from a VM Image](#source-vm-app-1) or Step 5 of [Creating the First Application Instance from a Prebuilt Image](#source-prebuilt)). We're using **us&#8209;west1&#8209;a**.
+   - **Creation&nbsp;method** – **Use&nbsp;instance&nbsp;template** radio button (the default)
+   - **Instance&nbsp;template** – **nginx&#8209;plus&#8209;app&#8209;1&#8209;instance&#8209;template** (select from the drop-down menu)
+   - **Autoscaling** – **Off** (the default)
+   - **Number&nbsp;of&nbsp;instances** – **2**
+   - **Health&nbsp;check** – **nginx&#8209;plus&#8209;http&#8209;health&#8209;check** (select from the drop-down menu)
+   - **Initial&nbsp;delay** – **300&nbsp;seconds** (the default)
 
 3. Click the <span style="background-color:#3366cc; color:white;"> Create </span> button.
 
@@ -834,25 +834,25 @@ Create three independent instance groups, one for each type of function-specific
 
 2. Repeat the steps in [Creating the First Application Instance Group](#groups-app-1) to create a second application instance group. Specify the same values as for the first instance template, except for these fields:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-instance-group</span>
-   - **Description** – <span style="color:#666666; font-weight:bolder;">Instance group to host NGINX Plus app-2 instances</span>
-   - <span style="font-weight:bold; white-space: nowrap;">Instance template</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-instance-template</span> (select from the drop-down menu)
+   - **Name** – **nginx&#8209;plus&#8209;app&#8209;2&#8209;instance&#8209;group**
+   - **Description** – **Instance group to host NGINX Plus app-2 instances**
+   - **Instance&nbsp;template** – **nginx&#8209;plus&#8209;app&#8209;2&#8209;instance&#8209;template** (select from the drop-down menu)
 
 <span id="groups-lb"></span>
 ### Creating the Load-Balancing Instance Group
 
-1. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Instance groups</span> summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE GROUP</span>.
+1. On the **Instance&nbsp;groups** summary page, click <span style="color:#3366cc; white-space: nowrap;">CREATE INSTANCE GROUP</span>.
 
 2. Repeat the steps in [Creating the First Application Instance Group](#groups-app-1) to create the load‑balancing instance group. Specify the same values as for the first instance template, except for these fields:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-instance-group</span>
-   - **Description** – <span style="color:#666666; font-weight:bolder;">Instance group to host NGINX Plus load balancing instances</span>
-   - <span style="font-weight:bold; white-space: nowrap;">Instance template</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-instance-template</span> (select from the drop-down menu)
+   - **Name** – **nginx&#8209;plus&#8209;lb&#8209;instance&#8209;group**
+   - **Description** – **Instance group to host NGINX Plus load balancing instances**
+   - **Instance&nbsp;template** – **nginx&#8209;plus&#8209;lb&#8209;instance&#8209;template** (select from the drop-down menu)
 
 <span id="update-test"></span>
 ### Updating and Testing the NGINX Plus Configuration
 
-Update the NGINX Plus configuration on the two LB instances (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-instance-group-[a...z]</span>). It should list the internal IP addresses of the four application servers (two instances each of <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-instance-group-[a...z]</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-instance-group-[a...z]</span>).
+Update the NGINX Plus configuration on the two LB instances (**nginx&#8209;plus&#8209;lb&#8209;instance&#8209;group&#8209;[a...z]**). It should list the internal IP addresses of the four application servers (two instances each of **nginx&#8209;plus&#8209;app&#8209;1&#8209;instance&#8209;group&#8209;[a...z]** and **nginx&#8209;plus&#8209;app&#8209;2&#8209;instance&#8209;group&#8209;[a...z]**).
 
 <span style="text-decoration: underline; white-space: nowrap;">Repeat these instructions</span> for both LB instances.
 
@@ -860,10 +860,10 @@ Update the NGINX Plus configuration on the two LB instances (<span style="color
 
 1. Connect to the LB instance over SSH using the method of your choice. GCE provides a built-in mechanism:
 
-   - Navigate to the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> tab.
-   - In the table, find the row for the instance. Click the triangle icon in the <span style="color:#666666; font-weight:bolder;">Connect</span> column at the far right. Then, select a method (for example, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Open in browser window</span>).
+   - Navigate to the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** tab.
+   - In the table, find the row for the instance. Click the triangle icon in the **Connect** column at the far right. Then, select a method (for example, **Open&nbsp;in&nbsp;browser&nbsp;window**).
 
-2. In the SSH terminal, use your preferred text editor to edit <span style="font-weight:bold; white-space: nowrap;">gce-all-active-lb.conf</span>. Change the `server` directives in the `upstream` block to  reference the internal IPs of the two <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-1-instance-group-[a...z]</span> instances and the two <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app-2-instance-group-[a...z]</span> instances. You can check the addresses in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Internal IP</span> column of the table on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> summary page. For example:
+2. In the SSH terminal, use your preferred text editor to edit **gce&#8209;all&#8209;active&#8209;lb.conf**. Change the `server` directives in the `upstream` block to  reference the internal IPs of the two **nginx&#8209;plus&#8209;app&#8209;1&#8209;instance&#8209;group&#8209;[a...z]** instances and the two **nginx&#8209;plus&#8209;app&#8209;2&#8209;instance&#8209;group&#8209;[a...z]** instances. You can check the addresses in the **Internal&nbsp;IP** column of the table on the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** summary page. For example:
 
    ```nginx
    upstream upstream_app_pool {
@@ -887,9 +887,9 @@ Update the NGINX Plus configuration on the two LB instances (<span style="color
    nginx -s reload
    ```
 
-4. Verify that the four application instances are receiving traffic and responding. To do this, access the NGINX Plus live activity monitoring dashboard on the load-balancing instance (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-instance-group-[a...z]</span>). You can see the instance's external IP address on the <span style="font-weight:bold; white-space: nowrap;">Compute Engine > VM instances</span> summary page in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">External IP</span> column of the table.
+4. Verify that the four application instances are receiving traffic and responding. To do this, access the NGINX Plus live activity monitoring dashboard on the load-balancing instance (**nginx&#8209;plus&#8209;lb&#8209;instance&#8209;group&#8209;[a...z]**). You can see the instance's external IP address on the **Compute&nbsp;Engine&nbsp;>&nbsp;VM&nbsp;instances** summary page in the **External&nbsp;IP** column of the table.
 
-   <span style="font-weight:bold; white-space: nowrap;">https://_LB-external-IP-address_:8080/status.html</span>
+   **https://_LB&#8209;external&#8209;IP&#8209;address_:8080/status.html**
 
 5. Verify that NGINX Plus is load balancing traffic among the four application instance groups. Do this by running this command on a separate client machine:
 
@@ -904,54 +904,54 @@ Update the NGINX Plus configuration on the two LB instances (<span style="color
 
 Set up a GCE network load balancer. It will distribute incoming client traffic to the NGINX Plus LB instances. First, reserve the static IP address the GCE network load balancer advertises to clients.
 
-1. Verify that the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus All-Active-LB</span> project is still selected in the Google Cloud Platform header bar.
+1. Verify that the **NGINX Plus&nbsp;All&#8209;Active&#8209;LB** project is still selected in the Google Cloud Platform header bar.
 
-2. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Networking > External IP addresses</span> tab.
+2. Navigate to the **Networking&nbsp;>&nbsp;External&nbsp;IP&nbsp;addresses** tab.
 
 3. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Reserve static address </span> button.
 
-4. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Reserve a static address</span> page that opens, modify or verify the fields as indicated:
+4. On the **Reserve&nbsp;a&nbsp;static&nbsp;address** page that opens, modify or verify the fields as indicated:
 
-   - **Name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-network-lb-static-ip</span>
-   - **Description** – <span style="color:#666666; font-weight:bolder;">Static IP address for Network LB frontend to NGINX Plus LB instances</span>
-   - **Type** – Click the <span style="color:#666666; font-weight:bolder;">Regional</span> radio button (the default)
-   - **Region** – The GCP zone you specified when you created source instances (Step 1 of [Creating the First Application Instance from a VM Image](#source-vm-app-1) or Step 5 of [Creating the First Application Instance from a Prebuilt Image](#source-prebuilt)). We're using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">us-west1</span>.
-   - <span style="font-weight:bold; white-space: nowrap;">Attached to</span> – <span style="color:#666666; font-weight:bolder;">None</span> (the default)
+   - **Name** – **nginx&#8209;plus&#8209;network&#8209;lb&#8209;static&#8209;ip**
+   - **Description** – **Static IP address for Network LB frontend to NGINX Plus LB instances**
+   - **Type** – Click the **Regional** radio button (the default)
+   - **Region** – The GCP zone you specified when you created source instances (Step 1 of [Creating the First Application Instance from a VM Image](#source-vm-app-1) or Step 5 of [Creating the First Application Instance from a Prebuilt Image](#source-prebuilt)). We're using **us&#8209;west1**.
+   - **Attached&nbsp;to** – **None** (the default)
 
 5. Click the <span style="background-color:#3366cc; color:white;"> Reserve </span> button.
 
    <img src="/nginx/images/gce-reserve-static-address.png" alt="Screenshot of the interface for reserving a static IP address for Google Compute Engine network load balancer." width="488" height="496" class="aligncenter size-full wp-image-47483" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-6. Navigate to the <span style="font-weight:bold; white-space: nowrap;">Networking > Load balancing</span> tab.
+6. Navigate to the **Networking&nbsp;>&nbsp;Load&nbsp;balancing** tab.
 
 7. Click the <span style="background-color:#3366cc; color:white; white-space: nowrap;"> Create load balancer </span> button.
 
-8. On the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Load balancing</span> page that opens, click <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Start configuration</span> in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">TCP Load Balancing</span> box.
+8. On the **Load&nbsp;balancing** page that opens, click **Start&nbsp;configuration** in the **TCP&nbsp;Load&nbsp;Balancing** box.
 
-9. On the page that opens, click the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">From Internet to my VMs</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">No (TCP)</span> radio buttons (the defaults).
+9. On the page that opens, click the **From&nbsp;Internet&nbsp;to&nbsp;my&nbsp;VMs** and **No&nbsp;(TCP)** radio buttons (the defaults).
 
-10. Click the <span style="background-color:#3366cc; color:white;"> Continue </span> button. The <span style="color:#666666; font-weight:bolder; white-space: nowrap;">New TCP load balancer</span> page opens.
+10. Click the <span style="background-color:#3366cc; color:white;"> Continue </span> button. The **New&nbsp;TCP&nbsp;load&nbsp;balancer** page opens.
 
-11. In the **Name** field, type <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-network-lb-frontend</span>.
+11. In the **Name** field, type **nginx&#8209;plus&#8209;network&#8209;lb&#8209;frontend**.
 
-12. Click <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend configuration</span> in the left column to open the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Backend configuration</span> interface in the right column. Fill in the fields as indicated:
+12. Click **Backend&nbsp;configuration** in the left column to open the **Backend&nbsp;configuration** interface in the right column. Fill in the fields as indicated:
 
-    - **Region** – The GCP region you specified in Step 4. We're using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">us-west1</span>.
-    - **Backends** – With <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Select existing instance groups</span> selected, select <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-instance-group</span> from the drop-down menu
-    - <span style="font-weight:bold; white-space: nowrap;">Backup pool</span> – <span style="color:#666666; font-weight:bolder;">None</span> (the default)
-    - <span style="font-weight:bold; white-space: nowrap;">Failover ratio</span> – <span style="color:#666666; font-weight:bolder;">10</span> (the default)
-    - <span style="font-weight:bold; white-space: nowrap;">Health check</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-http-health-check</span>
-    - <span style="font-weight:bold; white-space: nowrap;">Session affinity</span> – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Client IP</span>
+    - **Region** – The GCP region you specified in Step 4. We're using **us&#8209;west1**.
+    - **Backends** – With **Select&nbsp;existing&nbsp;instance&nbsp;groups** selected, select **nginx&#8209;plus&#8209;lb&#8209;instance&#8209;group** from the drop-down menu
+    - **Backup&nbsp;pool** – **None** (the default)
+    - **Failover&nbsp;ratio** – **10** (the default)
+    - **Health&nbsp;check** – **nginx&#8209;plus&#8209;http&#8209;health&#8209;check**
+    - **Session&nbsp;affinity** – **Client&nbsp;IP**
 
     <img src="/nginx/images/gce-backend-configuration.png" alt="Screenshot of the interface for backend configuration of GCE network load balancer, used during deployment of NGINX Plus as the Google Cloud Platform load balancer." width="862" height="584" class="aligncenter size-full wp-image-47466" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-13. Select <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Frontend configuration</span> in the left column. This opens up the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Frontend configuration</span> interface on the right column.
+13. Select **Frontend&nbsp;configuration** in the left column. This opens up the **Frontend&nbsp;configuration** interface on the right column.
 
-14. Create three <span style="font-weight:bold; white-space: nowrap;">Protocol-IP-Port</span> tuples, each with:
+14. Create three **Protocol&#8209;IP&#8209;Port** tuples, each with:
 
-    - **Protocol** – <span style="color:#666666; font-weight:bolder;">TCP</span>
+    - **Protocol** – **TCP**
     - **IP** – The address you reserved in Step 5, selected from the drop-down menu (if there is more than one address, select the one labeled in parentheses with the name you specified in Step 5)
-    - **Port** – <span style="color:#666666; font-weight:bolder;">80</span>, <span style="color:#666666; font-weight:bolder;">8080</span>, and <span style="color:#666666; font-weight:bolder;">443</span> in the three tuples respectively
+    - **Port** – **80**, **8080**, and **443** in the three tuples respectively
 
 15. Click the <span style="background-color:#3366cc; color:white;"> Create </span> button.
 
@@ -978,7 +978,7 @@ If load balancing is working properly, the unique **Server** field from the inde
 
 To verify that high availability is working:
 
-1. Connect to one of the instances in the <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-lb-instance-group</span> over SSH and run this command to force it offline:
+1. Connect to one of the instances in the **nginx&#8209;plus&#8209;lb&#8209;instance&#8209;group** over SSH and run this command to force it offline:
 
    ```shell
    iptables -A INPUT -p tcp --destination-port 80 -j DROP

--- a/content/nginx/deployment-guides/load-balance-third-party/apache-tomcat.md
+++ b/content/nginx/deployment-guides/load-balance-third-party/apache-tomcat.md
@@ -171,7 +171,7 @@ http {
 }
 ```
 
-You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files <span style="white-space: nowrap; font-weight:bold;">_function_-http.conf</span>, this is an appropriate `include` directive:
+You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files **_function_&#8209;http.conf**, this is an appropriate `include` directive:
 
 ```nginx
 http {
@@ -294,7 +294,7 @@ To configure load balancing, first create a named _upstream group_, which lists 
 
 2. In the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), include two `location` blocks:
 
-   - The first one matches HTTPS requests in which the path starts with <span style="white-space: nowrap; font-weight:bold;">/tomcat-app/</span>, and proxies them to the **tomcat** upstream group we created in the previous step.
+   - The first one matches HTTPS requests in which the path starts with **/tomcat&#8209;app/**, and proxies them to the **tomcat** upstream group we created in the previous step.
 
    - The second one funnels all traffic to the first `location` block, by doing a temporary redirect of all requests for **"http://example.com/"**.
 
@@ -409,7 +409,7 @@ To enable basic caching in <span style="white-space: nowrap;">NGINX Open Source<
 
    Directive documentation: [proxy_cache_path](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path)
 
-2. In the `location` block that matches HTTPS requests in which the path starts with <span style="white-space: nowrap; font-weight:bold;">/tomcat-app/</span>, include the `proxy_cache` directive to reference the cache created in the previous step.
+2. In the `location` block that matches HTTPS requests in which the path starts with **/tomcat&#8209;app/**, include the `proxy_cache` directive to reference the cache created in the previous step.
 
    ```nginx
    # In the 'server' block for HTTPS traffic
@@ -440,11 +440,11 @@ HTTP/2 is fully supported in both <span style="white-space: nowrap;">NGINX Open 
 
 - In <span style="white-space: nowrap;">NGINX Plus R8</span> and later, NGINX Plus supports HTTP/2 by default. (Support for SPDY is deprecated as of that release). Specifically:
 
-  In <span style="white-space: nowrap;">NGINX Plus R11</span> and later, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> package continues to support HTTP/2 by default, but the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package available in previous releases is deprecated by [dynamic modules](https://www.nginx.com/products/nginx/dynamic-modules/).
+  In <span style="white-space: nowrap;">NGINX Plus R11</span> and later, the **nginx&#8209;plus** package continues to support HTTP/2 by default, but the **nginx&#8209;plus&#8209;extras** package available in previous releases is deprecated by [dynamic modules](https://www.nginx.com/products/nginx/dynamic-modules/).
 
-  For <span style="white-space: nowrap;">NGINX Plus R8</span> through R10, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> and <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> packages support HTTP/2 by default.
+  For <span style="white-space: nowrap;">NGINX Plus R8</span> through R10, the **nginx&#8209;plus** and **nginx&#8209;plus&#8209;extras** packages support HTTP/2 by default.
 
-  If using <span style="white-space: nowrap;">NGINX Plus R7</span>, you must install the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-http2</span> package instead of the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> or <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package.
+  If using <span style="white-space: nowrap;">NGINX Plus R7</span>, you must install the **nginx&#8209;plus&#8209;http2** package instead of the **nginx&#8209;plus** or **nginx&#8209;plus&#8209;extras** package.
 
 To enable HTTP/2 support, add the `http2` directive in the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), so that it looks like this:
 
@@ -636,7 +636,7 @@ Health checks are <span style="white-space: nowrap;">out-of-band</span> HTTP req
 
 Because the `health_check` directive is placed in the `location` block, we can enable different health checks for each application.
 
-1. In the `location` block that matches HTTPS requests in which the path starts with <span style="white-space: nowrap; font-weight:bold;">/tomcat-app/</span> (created in [Configuring Basic Load Balancing](#load-balancing-basic)), add the `health_check` directive.
+1. In the `location` block that matches HTTPS requests in which the path starts with **/tomcat&#8209;app/** (created in [Configuring Basic Load Balancing](#load-balancing-basic)), add the `health_check` directive.
 
    Here we configure NGINX Plus to send an <span style="white-space: nowrap;">out-of-band</span> request for the top‑level URI **/** (slash) to each of the servers in the **tomcat** upstream group every 2 seconds, which is more aggressive than the default 5‑second interval. If a server does not respond correctly, it is marked down and NGINX Plus stops sending requests to it until it passes five subsequent health checks in a row. We include the `match` parameter to define a nondefault set of health‑check tests.
 
@@ -719,7 +719,7 @@ The quickest way to configure the module and the built‑in dashboard is to down
 
     Directive documentation: [include](https://nginx.org/en/docs/ngx_core_module.html#include)
 
-    If you are using the conventional configuration scheme and your existing `include` directives use the wildcard notation discussed in [Creating and Modifying Configuration Files](#config-files), you can either add a separate `include` directive for **status.conf** as shown above, or change the name of **status.conf** so it is captured by the wildcard in an existing `include` directive in the `http` block. For example, changing it to <span style="white-space: nowrap; font-weight:bold;">status-http.conf</span> means it is captured by the `include` directive for <span style="white-space: nowrap;">`*-http.conf`</span>.
+    If you are using the conventional configuration scheme and your existing `include` directives use the wildcard notation discussed in [Creating and Modifying Configuration Files](#config-files), you can either add a separate `include` directive for **status.conf** as shown above, or change the name of **status.conf** so it is captured by the wildcard in an existing `include` directive in the `http` block. For example, changing it to **status&#8209;http.conf** means it is captured by the `include` directive for <span style="white-space: nowrap;">`*-http.conf`</span>.
 
 3. Comments in **status.conf** explain which directives you must customize for your deployment. In particular, the default settings in the sample configuration file allow anyone on any network to access the dashboard. We strongly recommend that you restrict access to the dashboard with one or more of the following methods:
 

--- a/content/nginx/deployment-guides/load-balance-third-party/microsoft-exchange.md
+++ b/content/nginx/deployment-guides/load-balance-third-party/microsoft-exchange.md
@@ -371,7 +371,7 @@ To set up the conventional configuration scheme, perform these steps:
 
    Directive documentation: [include](https://nginx.org/en/docs/ngx_core_module.html#include)
 
-   You can also use wildcard notation to read all function‑specific files for either HTTP or TCP traffic into the appropriate context block. For example, if you name all HTTP configuration files <span style="white-space: nowrap; font-weight:bold;">_function_-http.conf</span> and all TCP configuration files <span style="white-space: nowrap; font-weight:bold;">_function_-stream.conf</span> (the filenames we specify in this section conform to this pattern), the wildcarded `include` directives are:
+   You can also use wildcard notation to read all function‑specific files for either HTTP or TCP traffic into the appropriate context block. For example, if you name all HTTP configuration files **_function_&#8209;http.conf** and all TCP configuration files **_function_&#8209;stream.conf** (the filenames we specify in this section conform to this pattern), the wildcarded `include` directives are:
 
    ```nginx
    http {
@@ -383,9 +383,9 @@ To set up the conventional configuration scheme, perform these steps:
    }
    ```
 
-2. In the **/etc/nginx/conf.d** directory, create a new file called <span style="white-space: nowrap; font-weight:bold;">exchange-http.conf</span> for directives that pertain to Exchange HTTP and HTTPS traffic (or substitute the name you chose in Step 1). Copy in the directives from the `http` configuration block in the downloaded configuration file. Remember not to copy the first line <span style="white-space: nowrap;">(`http` `{`)</span> or the closing curly brace (`}`) for the block, because the `http` block you created in Step 1 already has them.
+2. In the **/etc/nginx/conf.d** directory, create a new file called **exchange&#8209;http.conf** for directives that pertain to Exchange HTTP and HTTPS traffic (or substitute the name you chose in Step 1). Copy in the directives from the `http` configuration block in the downloaded configuration file. Remember not to copy the first line <span style="white-space: nowrap;">(`http` `{`)</span> or the closing curly brace (`}`) for the block, because the `http` block you created in Step 1 already has them.
 
-3. Also in the **/etc/nginx/conf.d** directory, create a new file called <span style="white-space: nowrap; font-weight:bold;">exchange-stream.conf</span> for directives that pertain to Exchange TCP traffic (or substitute the name you chose in Step 1). Copy in the directives from the `stream` configuration block in the dowloaded configuration file. Again, do not copy the first line <span style="white-space: nowrap;">(`stream` `{`)</span> or the closing curly brace (`}`).
+3. Also in the **/etc/nginx/conf.d** directory, create a new file called **exchange&#8209;stream.conf** for directives that pertain to Exchange TCP traffic (or substitute the name you chose in Step 1). Copy in the directives from the `stream` configuration block in the dowloaded configuration file. Again, do not copy the first line <span style="white-space: nowrap;">(`stream` `{`)</span> or the closing curly brace (`}`).
 
 For reference purposes, the text of the full configuration files is included in this document:
 
@@ -468,7 +468,7 @@ The directives in the top‑level `stream` configuration block configure TCP loa
     }
     ```
 
-3. This `server` block defines the virtual server that proxies traffic on port 993 to the <span style="white-space: nowrap; font-weight:bold;">exchange-imaps</span> upstream group configured in Step 1.
+3. This `server` block defines the virtual server that proxies traffic on port 993 to the **exchange&#8209;imaps** upstream group configured in Step 1.
 
     ```nginx
     # In the 'stream' block
@@ -481,7 +481,7 @@ The directives in the top‑level `stream` configuration block configure TCP loa
 
    Directive documentation: [listen](https://nginx.org/en/docs/stream/ngx_stream_core_module.html#listen), [proxy_pass](https://nginx.org/en/docs/stream/ngx_stream_proxy_module.html#proxy_pass), [server](https://nginx.org/en/docs/stream/ngx_stream_core_module.html#server), [status_zone](https://nginx.org/en/docs/http/ngx_http_status_module.html#status_zone)
 
-4. This `server` block defines the virtual server that proxies traffic on port 25 to the <span style="white-space: nowrap; font-weight:bold;">exchange-smtp</span> upstream group configured in Step 2. If you wish to change the port number from 25 (for example, to 587), change the `listen` directive.
+4. This `server` block defines the virtual server that proxies traffic on port 25 to the **exchange&#8209;smtp** upstream group configured in Step 2. If you wish to change the port number from 25 (for example, to 587), change the `listen` directive.
 
     ```nginx
     # In the 'stream' block
@@ -615,11 +615,11 @@ HTTP/2 is fully supported in <span style="white-space: nowrap;">NGINX Plus R7</s
 
 In <span style="white-space: nowrap;">NGINX Plus R8</span> and later, NGINX Plus supports HTTP/2 by default, and does not support SPDY:
 
-- In <span style="white-space: nowrap;">NGINX Plus R11</span> and later, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> package continues to support HTTP/2 by default, but the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package available in previous releases is deprecated by [dynamic modules](https://www.nginx.com/products/nginx/dynamic-modules/).
+- In <span style="white-space: nowrap;">NGINX Plus R11</span> and later, the **nginx&#8209;plus** package continues to support HTTP/2 by default, but the **nginx&#8209;plus&#8209;extras** package available in previous releases is deprecated by [dynamic modules](https://www.nginx.com/products/nginx/dynamic-modules/).
 
-- For <span style="white-space: nowrap;">NGINX Plus R8</span> through R10, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> and <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> packages support HTTP/2 by default.
+- For <span style="white-space: nowrap;">NGINX Plus R8</span> through R10, the **nginx&#8209;plus** and **nginx&#8209;plus&#8209;extras** packages support HTTP/2 by default.
 
-If using <span style="white-space: nowrap;">NGINX Plus R7</span>, you must install the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-http2</span> package instead of the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> or <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package.
+If using <span style="white-space: nowrap;">NGINX Plus R7</span>, you must install the **nginx&#8209;plus&#8209;http2** package instead of the **nginx&#8209;plus** or **nginx&#8209;plus&#8209;extras** package.
 
 To enable HTTP/2 support, add the `http2` directive in the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), so that it looks like this:
 
@@ -926,7 +926,7 @@ Exchange CASs interact with various applications used by clients on different ty
       }
       ```
 
-    - Mobile clients like iPhone and Android access the ActiveSync location (<span style="white-space: nowrap; font-weight:bold;">/Microsoft-Server-ActiveSync</span>).
+    - Mobile clients like iPhone and Android access the ActiveSync location (**/Microsoft&#8209;Server&#8209;ActiveSync**).
 
       ```nginx
       # In the 'server' block for HTTPS traffic
@@ -1092,7 +1092,7 @@ The quickest way to configure the module and the built‑in dashboard is to down
    include conf.d/status.conf;
    ```
 
-    If you are using the conventional configuration scheme and your existing `include` directives use the wildcard notation discussed in [Creating and Modifying Configuration Files](#config-files), you can either add a separate `include` directive for **status.conf** as shown above, or change the name of **status.conf** so it is captured by the wildcard in an existing `include` directive in the `http` block. For example, changing it to <span style="white-space: nowrap; font-weight:bold;">status-http.conf</span> means it is captured by the `include` directive for <span style="white-space: nowrap;">`*-http.conf`</span>.
+    If you are using the conventional configuration scheme and your existing `include` directives use the wildcard notation discussed in [Creating and Modifying Configuration Files](#config-files), you can either add a separate `include` directive for **status.conf** as shown above, or change the name of **status.conf** so it is captured by the wildcard in an existing `include` directive in the `http` block. For example, changing it to **status&#8209;http.conf** means it is captured by the `include` directive for <span style="white-space: nowrap;">`*-http.conf`</span>.
 
     Directive documentation: [include](https://nginx.org/en/docs/ngx_core_module.html#include)
 

--- a/content/nginx/deployment-guides/load-balance-third-party/node-js.md
+++ b/content/nginx/deployment-guides/load-balance-third-party/node-js.md
@@ -175,7 +175,7 @@ http {
 
 Directive documentation: [include](https://nginx.org/en/docs/ngx_core_module.html#include)
 
-You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files <span style="white-space: nowrap; font-weight:bold;">_function_-http.conf</span>, this is an appropriate `include` directive:
+You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files **_function_&#8209;http.conf**, this is an appropriate `include` directive:
 
 ```nginx
 http {
@@ -433,13 +433,13 @@ HTTP/2 is fully supported in both NGINX 1.9.5 and later, and NGINX Plus R7 and
 
 - If using NGINX Open Source, note that in version 1.9.5 and later the SPDY module is completely removed from the codebase and replaced with the [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.html) module. After upgrading to version 1.9.5 or later, you can no longer configure NGINX Open Source to use SPDY. If you want to keep using SPDY, you need to compile NGINX Open Source from the sources in the [NGINX 1.8.x branch](https://nginx.org/en/download.html).
 
-- If using NGINX Plus, in R11 and later the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> package supports HTTP/2 by default, and the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package available in previous releases is deprecated by separate [dynamic modules](https://www.nginx.com/products/nginx/modules/) authored by NGINX.
+- If using NGINX Plus, in R11 and later the **nginx&#8209;plus** package supports HTTP/2 by default, and the **nginx&#8209;plus&#8209;extras** package available in previous releases is deprecated by separate [dynamic modules](https://www.nginx.com/products/nginx/modules/) authored by NGINX.
 
-  In NGINX Plus R8 through R10, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> and <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> packages support HTTP/2 by default.
+  In NGINX Plus R8 through R10, the **nginx&#8209;plus** and **nginx&#8209;plus&#8209;extras** packages support HTTP/2 by default.
 
   In NGINX Plus R8 and later, NGINX Plus supports HTTP/2 by default, and does not support SPDY.
 
-    If using NGINX Plus R7, you must install the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-http2</span> package instead of the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> or <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package.
+    If using NGINX Plus R7, you must install the **nginx&#8209;plus&#8209;http2** package instead of the **nginx&#8209;plus** or **nginx&#8209;plus&#8209;extras** package.
 
 To enable HTTP/2 support, add the [http2](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2) directive in the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), so that it looks like this:
 
@@ -459,7 +459,7 @@ To verify that HTTP/2 translation is working, you can use the "HTTP/2 and SPDY i
 
 The full configuration for basic load balancing appears here for your convenience. It goes in the `http` context. The complete file is available for [download](https://www.nginx.com/resource/conf/nodejs-basic.conf) from the NGINX website.
 
-We recommend that you do not copy text directly from this document, but instead use the method described in [Creating and Modifying Configuration Files](#config-files) to include these directives in your configuration – add an `include` directive to the `http` context of the main **nginx.conf** file to read in the contents of <span style="white-space: nowrap; font-weight:bold;">/etc/nginx/conf.d/nodejs-basic.conf</span>.
+We recommend that you do not copy text directly from this document, but instead use the method described in [Creating and Modifying Configuration Files](#config-files) to include these directives in your configuration – add an `include` directive to the `http` context of the main **nginx.conf** file to read in the contents of **/etc/nginx/conf.d/nodejs&#8209;basic.conf**.
 
 ```nginx
 proxy_cache_path /tmp/NGINX_cache/ keys_zone=backcache:10m;
@@ -785,9 +785,9 @@ Parameter documentation: [service](https://nginx.org/en/docs/http/ngx_http_upstr
 
 The full configuration for enhanced load balancing appears here for your convenience. It goes in the `http` context. The complete file is available for [download](https://www.nginx.com/resource/conf/nodejs-enhanced.conf) from the NGINX website.
 
-We recommend that you do not copy text directly from this document, but instead use the method described in [Creating and Modifying Configuration Files](#config-files) to include these directives in your configuration – namely, add an `include` directive to the `http` context of the main **nginx.conf** file to read in the contents of <span style="white-space: nowrap; font-weight:bold;">/etc/nginx/conf.d/nodejs-enhanced.conf</span>.
+We recommend that you do not copy text directly from this document, but instead use the method described in [Creating and Modifying Configuration Files](#config-files) to include these directives in your configuration – namely, add an `include` directive to the `http` context of the main **nginx.conf** file to read in the contents of **/etc/nginx/conf.d/nodejs&#8209;enhanced.conf**.
 
-**Note:** The `api` block in this configuration summary and the [downloadable](https://www.nginx.com/resource/conf/nodejs-enhanced.conf) <span style="white-space: nowrap; font-weight:bold;">nodejs-enhanced.conf</span> file is for the [API method](#reconfiguration-api) of dynamic reconfiguration. If you want to use the [DNS method](#reconfiguration-dns) instead, make the appropriate changes to the block. (You can also remove or comment out the directives for the NGINX Plus API in that case, but they do not conflict with using the DNS method and enable features other than dynamic reconfiguration.)
+**Note:** The `api` block in this configuration summary and the [downloadable](https://www.nginx.com/resource/conf/nodejs-enhanced.conf) **nodejs&#8209;enhanced.conf** file is for the [API method](#reconfiguration-api) of dynamic reconfiguration. If you want to use the [DNS method](#reconfiguration-dns) instead, make the appropriate changes to the block. (You can also remove or comment out the directives for the NGINX Plus API in that case, but they do not conflict with using the DNS method and enable features other than dynamic reconfiguration.)
 
 ```nginx
 proxy_cache_path /tmp/NGINX_cache/ keys_zone=backcache:10m;

--- a/content/nginx/deployment-guides/load-balance-third-party/oracle-e-business-suite.md
+++ b/content/nginx/deployment-guides/load-balance-third-party/oracle-e-business-suite.md
@@ -322,7 +322,7 @@ http {
 
 Directive documentation: [include](https://nginx.org/en/docs/ngx_core_module.html#include)
 
-You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files <span style="white-space: nowrap; font-weight:bold;">_function_-http.conf</span>, this is an appropriate include directive:
+You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files **_function_&#8209;http.conf**, this is an appropriate include directive:
 
 ```nginx
 http {
@@ -505,13 +505,13 @@ HTTP/2 is fully supported in both NGINX 1.9.5 and later, and NGINX Plus R7 and
 
 - If using open source NGINX, note that in version 1.9.5 and later the SPDY module is completely removed from the NGINX codebase and replaced with the [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.html) module. After upgrading to version 1.9.5 or later, you can no longer configure NGINX to use SPDY. If you want to keep using SPDY, you need to compile NGINX from the sources in the [NGINX 1.8 branch](https://nginx.org/en/download.html).
 
-- If using NGINX Plus, in R11 and later the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> package supports HTTP/2 by default, and the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package available in previous releases is deprecated by separate [dynamic modules](https://www.nginx.com/products/nginx/modules/) authored by NGINX.
+- If using NGINX Plus, in R11 and later the **nginx&#8209;plus** package supports HTTP/2 by default, and the **nginx&#8209;plus&#8209;extras** package available in previous releases is deprecated by separate [dynamic modules](https://www.nginx.com/products/nginx/modules/) authored by NGINX.
 
-  In NGINX Plus R8 through R10, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> and <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> packages support HTTP/2 by default.
+  In NGINX Plus R8 through R10, the **nginx&#8209;plus** and **nginx&#8209;plus&#8209;extras** packages support HTTP/2 by default.
 
   In NGINX Plus R8 and later, NGINX Plus supports HTTP/2 by default, and does not support SPDY.
 
-    If using NGINX Plus R7, you must install the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-http2</span> package instead of the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> or <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package.
+    If using NGINX Plus R7, you must install the **nginx&#8209;plus&#8209;http2** package instead of the **nginx&#8209;plus** or **nginx&#8209;plus&#8209;extras** package.
 
 To enable HTTP/2 support, add the `http2` directive in the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), so that it looks like this:
 

--- a/content/nginx/deployment-guides/load-balance-third-party/oracle-weblogic-server.md
+++ b/content/nginx/deployment-guides/load-balance-third-party/oracle-weblogic-server.md
@@ -173,7 +173,7 @@ http {
 }
 ```
 
-You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files <span style="white-space: nowrap; font-weight:bold;">_function_-http.conf</span>, this is an appropriate include directive:
+You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files **_function_&#8209;http.conf**, this is an appropriate include directive:
 
 ```nginx
 http {
@@ -299,7 +299,7 @@ By putting NGINX Open Source or NGINX Plus in front of WebLogic Server servers
 
 2. In the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), include two `location` blocks:
 
-   - The first one matches HTTPS requests in which the path starts with <span style="white-space: nowrap; font-weight:bold;">/weblogic-app/</span>, and proxies them to the **weblogic** upstream group we created in the previous step.
+   - The first one matches HTTPS requests in which the path starts with **/weblogic&#8209;app/**, and proxies them to the **weblogic** upstream group we created in the previous step.
 
    - The second one funnels all traffic to the first `location` block, by doing a temporary redirect of all requests for **"http://example.com/"**.
 
@@ -414,7 +414,7 @@ To create a very simple caching configuration:
 
    Directive documentation: [proxy_cache_path](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path)
 
-2. In the `location` block that matches HTTPS requests in which the path starts with <span style="white-space: nowrap; font-weight:bold;">/weblogic-app/</span>, include the `proxy_cache` directive to reference the cache created in the previous step.
+2. In the `location` block that matches HTTPS requests in which the path starts with **/weblogic&#8209;app/**, include the `proxy_cache` directive to reference the cache created in the previous step.
 
    ```nginx
    # In the 'server' block for HTTPS traffic
@@ -443,13 +443,13 @@ HTTP/2 is fully supported in both NGINX 1.9.5 and later, and NGINX Plus R7 and
 
 - If using NGINX Open Source, note that in version 1.9.5 and later the SPDY module is completely removed from the codebase and replaced with the [HTTP/2](https://nginx.org/en/docs/http/ngx_http_v2_module.html) module. After upgrading to version 1.9.5 or later, you can no longer configure NGINX Open Source to use SPDY. If you want to keep using SPDY, you need to compile NGINX Open Source from the sources in the [NGINX 1.8.x branch](https://nginx.org/en/download.html).
 
-- If using NGINX Plus, in R11 and later the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> package supports HTTP/2 by default, and the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package available in previous releases is deprecated by separate [dynamic modules](https://www.nginx.com/products/nginx/modules/) authored by NGINX.
+- If using NGINX Plus, in R11 and later the **nginx&#8209;plus** package supports HTTP/2 by default, and the **nginx&#8209;plus&#8209;extras** package available in previous releases is deprecated by separate [dynamic modules](https://www.nginx.com/products/nginx/modules/) authored by NGINX.
 
-  In NGINX Plus R8 through R10, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> and <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> packages support HTTP/2 by default.
+  In NGINX Plus R8 through R10, the **nginx&#8209;plus** and **nginx&#8209;plus&#8209;extras** packages support HTTP/2 by default.
 
   In NGINX Plus R8 and later, NGINX Plus supports HTTP/2 by default, and does not support SPDY.
 
-    If using NGINX Plus R7, you must install the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-http2</span> package instead of the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> or <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package.
+    If using NGINX Plus R7, you must install the **nginx&#8209;plus&#8209;http2** package instead of the **nginx&#8209;plus** or **nginx&#8209;plus&#8209;extras** package.
 
 To enable HTTP/2 support, add the `http2` directive in the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), so that it looks like this:
 
@@ -601,7 +601,7 @@ Health checks are out‑of‑band HTTP requests sent to a server at fixed interv
 
 Because the `health_check` directive is placed in the `location` block, we can enable different health checks for each application.
 
-1. In the `location` block that matches HTTPS requests in which the path starts with <span style="white-space: nowrap; font-weight:bold;">/weblogic-app/</span> (created in [Configuring Basic Load Balancing](#load-balancing-basic)), add the `health_check` directive.
+1. In the `location` block that matches HTTPS requests in which the path starts with **/weblogic&#8209;app/** (created in [Configuring Basic Load Balancing](#load-balancing-basic)), add the `health_check` directive.
 
     Here we configure NGINX Plus to send an out‑of‑band request for the URI **/benefits** to each of the servers in the **weblogic** upstream group every 5 seconds (the default frequency). If a server does not respond correctly, it is marked down and NGINX Plus stops sending requests to it until it passes a subsequent health check. We include the `match` parameter to the `health_check` directive to define a nondefault set of health‑check tests.
 
@@ -814,7 +814,7 @@ To enable dynamic reconfiguration of your upstream group of WebLogic Server app 
 
 The full configuration for enhanced load balancing appears here for your convenience. It goes in the `http` context. The complete file is available for [download](https://www.nginx.com/resource/conf/weblogic-enhanced.conf) from the NGINX website.
 
-We recommend that you do not copy text directly from this document, but instead use the method described in [Creating and Modifying Configuration Files](#config-files) to include these directives in your configuration – add an `include` directive to the `http` context of the main **nginx.conf** file to read in the contents of <span style="white-space: nowrap; font-weight:bold;">/etc/nginx/conf.d/weblogic-enhanced.conf</span>.
+We recommend that you do not copy text directly from this document, but instead use the method described in [Creating and Modifying Configuration Files](#config-files) to include these directives in your configuration – add an `include` directive to the `http` context of the main **nginx.conf** file to read in the contents of **/etc/nginx/conf.d/weblogic&#8209;enhanced.conf**.
 
 ```nginx
 proxy_cache_path /tmp/NGINX_cache/ keys_zone=backcache:10m;

--- a/content/nginx/deployment-guides/load-balance-third-party/wildfly.md
+++ b/content/nginx/deployment-guides/load-balance-third-party/wildfly.md
@@ -169,7 +169,7 @@ http {
 
 Directive documentation: [include](https://nginx.org/en/docs/ngx_core_module.html#include)
 
-You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files <span style="white-space: nowrap; font-weight:bold;">_function_-http.conf</span>, this is an appropriate include directive:
+You can also use wildcard notation to reference all files that pertain to a certain function or traffic type in the appropriate context block. For example, if you name all HTTP configuration files **_function_&#8209;http.conf**, this is an appropriate include directive:
 
 ```nginx
 http {
@@ -429,9 +429,9 @@ HTTP/2 is fully supported in both <span style="white-space: nowrap;">NGINX Open 
 
   In [NGINX Plus R11]({{< ref "/nginx/releases.md#r11" >}}) and later, the **nginx-plus** package continues to support HTTP/2 by default, but the **nginx-plus-extras** package available in previous releases is deprecated and replaced by [dynamic modules]({{< ref "/nginx/admin-guide/dynamic-modules/dynamic-modules.md" >}}).
 
-  For <span style="white-space: nowrap;">NGINX Plus R8</span> through R10, the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> and <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> packages support HTTP/2 by default.
+  For <span style="white-space: nowrap;">NGINX Plus R8</span> through R10, the **nginx&#8209;plus** and **nginx&#8209;plus&#8209;extras** packages support HTTP/2 by default.
 
-  If using <span style="white-space: nowrap;">NGINX Plus R7</span>, you must install the <span style="white-space: nowrap; font-weight:bold;">nginx-plus-http2</span> package instead of the <span style="white-space: nowrap; font-weight:bold;">nginx-plus</span> or <span style="white-space: nowrap; font-weight:bold;">nginx-plus-extras</span> package.
+  If using <span style="white-space: nowrap;">NGINX Plus R7</span>, you must install the **nginx&#8209;plus&#8209;http2** package instead of the **nginx&#8209;plus** or **nginx&#8209;plus&#8209;extras** package.
 
 To enable HTTP/2 support, add the `http2` directive in the `server` block for HTTPS traffic that we created in [Configuring Virtual Servers for HTTP and HTTPS Traffic](#virtual-servers), so that it looks like this:
 
@@ -793,7 +793,7 @@ The full configuration for enhanced load balancing appears here for your conveni
 
 We recommend that you do not copy text directly from this document, but instead use the method described in [Creating and Modifying Configuration Files](#config-files) to include these directives in your configuration – add an `include` directive to the `http` context of the main **nginx.conf** file to read in the contents of <span style="white-space: nowrap;">/etc/nginx/conf.d/jboss-enhanced.conf</span>.
 
-**Note:** The `api` block in this configuration summary and the [downloadable](https://www.nginx.com/resource/conf/jboss-enhanced.conf) <span style="white-space: nowrap; font-weight:bold;">jboss-enhanced.conf</span> file is for the [API method](#reconfiguration-api) of dynamic reconfiguration. If you want to use the [DNS method](#reconfiguration-dns) instead, make the appropriate changes to the block. (You can also remove or comment out the directives for the NGINX Plus API in that case, but they do not conflict with using the DNS method and enable features other than dynamic reconfiguration.)
+**Note:** The `api` block in this configuration summary and the [downloadable](https://www.nginx.com/resource/conf/jboss-enhanced.conf) **jboss&#8209;enhanced.conf** file is for the [API method](#reconfiguration-api) of dynamic reconfiguration. If you want to use the [DNS method](#reconfiguration-dns) instead, make the appropriate changes to the block. (You can also remove or comment out the directives for the NGINX Plus API in that case, but they do not conflict with using the DNS method and enable features other than dynamic reconfiguration.)
 
 ```nginx
 proxy_cache_path /tmp/NGINX_cache/ keys_zone=backcache:10m;

--- a/content/nginx/deployment-guides/microsoft-azure/high-availability-standard-load-balancer.md
+++ b/content/nginx/deployment-guides/microsoft-azure/high-availability-standard-load-balancer.md
@@ -71,7 +71,7 @@ These instructions assume you have the following:
 
 - An Azure [account](https://azure.microsoft.com/en-us/free/).
 - An Azure [subscription](https://docs.microsoft.com/en-us/azure/azure-glossary-cloud-terminology?toc=/azure/virtual-network/toc.json#subscription).
-- An Azure [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups), preferably dedicated to the HA solution. In this guide, it is called <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA</span>.
+- An Azure [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/overview#resource-groups), preferably dedicated to the HA solution. In this guide, it is called **NGINX&#8209;Plus&#8209;HA**.
 - An Azure [virtual network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview).
 - Six Azure VMs, four running NGINX Open Source and two running NGINX Plus (in each region where you deploy the solution). You need a paid or trial subscription for each NGINX Plus instance.
 
@@ -100,17 +100,17 @@ With NGINX Open Source and NGINX Plus installed and configured on the Azure VMs
 
 4. On the **Create load balancer** page that opens (to the **Basics** tab), enter the following values:
 
-   - **Subscription** – Name of your subscription (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA-subscription</span> in this guide)
-   - **Resource group** – Name of your resource group (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA</span> in this guide)
-   - **Name** – Name of your Standard Load Balancer (<span style="color:#666666; font-weight:bolder;">lb</span> in this guide)
-   - **Region** – Name selected from the drop‑down menu (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">(US) West US 2</span> in this guide)
-   - **Type** – <span style="color:#666666; font-weight:bolder;">Public</span>
-   - **SKU** – <span style="color:#666666; font-weight:bolder;">Standard</span>
-   - **Public IP address** – <span style="color:#666666; font-weight:bolder;">Create new</span>
-   - **Public IP address name** – Name for the address (<span style="color:#666666; font-weight:bolder;">public\_ip\_lb</span> in this guide)
-   - **Public IP address SKU** – <span style="color:#666666; font-weight:bolder;">Standard</span>
-   - **Availability zone** – <span style="color:#666666; font-weight:bolder;">Zone‑redundant</span>
-   - **Add a public IPv6 address** – <span style="color:#666666; font-weight:bolder;">No</span>
+   - **Subscription** – Name of your subscription (**NGINX&#8209;Plus&#8209;HA&#8209;subscription** in this guide)
+   - **Resource group** – Name of your resource group (**NGINX&#8209;Plus&#8209;HA** in this guide)
+   - **Name** – Name of your Standard Load Balancer (**lb** in this guide)
+   - **Region** – Name selected from the drop‑down menu (**(US)&nbsp;West&nbsp;US&nbsp;2** in this guide)
+   - **Type** – **Public**
+   - **SKU** – **Standard**
+   - **Public IP address** – **Create new**
+   - **Public IP address name** – Name for the address (**public\_ip\_lb** in this guide)
+   - **Public IP address SKU** – **Standard**
+   - **Availability zone** – **Zone‑redundant**
+   - **Add a public IPv6 address** – **No**
 
    <a href="/nginx/images/azure-create-lb-basics.png"><img src="/nginx/images/azure-create-lb-basics.png" alt="Screenshot of the 'Basics' tab for creating an Azure Standard Load Balancer" width="1024" height="902" class="aligncenter size-full wp-image-64979" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
@@ -130,7 +130,7 @@ With NGINX Open Source and NGINX Plus installed and configured on the Azure VMs
 
 1. If you are not already on the **Load balancers** page, click **Load balancers** in the left navigation column.
 
-2. Click the name of the load balancer in the **Name** column of the table (<span style="color:#666666; font-weight:bolder;">lb</span> in this guide).
+2. Click the name of the load balancer in the **Name** column of the table (**lb** in this guide).
 
    <a href="/nginx/images/azure-create-lb-load-balancers.png"><img src="/nginx/images/azure-create-lb-load-balancers.png" alt="Screenshot of Azure 'Load Balancers' page" width="1024" height="393" class="aligncenter size-full wp-image-64976https://www.nginx.com/wp-content/uploads/2020/09/Azure-create-lb-select-Backend-pools.png" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
@@ -139,61 +139,61 @@ With NGINX Open Source and NGINX Plus installed and configured on the Azure VMs
 
    <a href="/nginx/images/azure-create-lb-select-backend-pools.png"><img src="/nginx/images/azure-create-lb-select-backend-pools.png" alt="Screenshot of selecting 'Backend pools' on details page for an Azure Standard Load Balancer" width="1024" height="543" class="aligncenter size-full wp-image-64975" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
-4. On the <span style="white-space: nowrap; font-weight:bold;">lb | Backend Pools</span> page that opens, click **<span style="color:#4d9bdc;">+</span> Add** in the upper left corner of the main pane.
+4. On the **lb&nbsp;|&nbsp;Backend&nbsp;Pools** page that opens, click **<span style="color:#4d9bdc;">+</span> Add** in the upper left corner of the main pane.
 
-5. On the <span style="white-space: nowrap; font-weight:bold;">Add backend pool</span> page that opens, enter the following values, then click the <span style="background-color:#137ad1; color:white;"> Add </span> button:
+5. On the **Add&nbsp;backend&nbsp;pool** page that opens, enter the following values, then click the <span style="background-color:#137ad1; color:white;"> Add </span> button:
 
-   - **Name** – Name of the new backend pool (<span style="color:#666666; font-weight:bolder;">lb\_backend_pool</span> in this guide)
-   - **IP version** – <span style="color:#666666; font-weight:bolder;">IPv4</span>
-   - **Virtual machines** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-plus-1</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-plus-2</span>
+   - **Name** – Name of the new backend pool (**lb\_backend_pool** in this guide)
+   - **IP version** – **IPv4**
+   - **Virtual machines** – **ngx&#8209;plus&#8209;1** and **ngx&#8209;plus&#8209;2**
 
    <a href="/nginx/images/azure-create-lb-add-backend-pool.png"><img src="/nginx/images/azure-create-lb-add-backend-pool.png" alt="Screenshot of Azure 'Add backend pool' page for Standard Load Balancer" width="1024" height="891" class="aligncenter size-full wp-image-64974" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
    After a few moments the virtual machines appear in the new backend pool.
 
-6. Click **Health probes** in the left navigation column, and then **<span style="color:#4d9bdc;">+</span> Add** in the upper left corner of the main pane on the <span style="white-space: nowrap; font-weight:bold;">lb | Health probes</span> page that opens.
+6. Click **Health probes** in the left navigation column, and then **<span style="color:#4d9bdc;">+</span> Add** in the upper left corner of the main pane on the **lb&nbsp;|&nbsp;Health&nbsp;probes** page that opens.
 
-7. On the <span style="white-space: nowrap; font-weight:bold;">Add health probe</span> page that opens, enter the following values, then click the <span style="background-color:#137ad1; color:white; white-space: nowrap;"> OK </span> button.
+7. On the **Add&nbsp;health&nbsp;probe** page that opens, enter the following values, then click the <span style="background-color:#137ad1; color:white; white-space: nowrap;"> OK </span> button.
 
-   - **Name** – Name of the new backend pool (<span style="color:#666666; font-weight:bolder;">lb\_probe</span> in this guide)
-   - **Protocol** – <span style="color:#666666; font-weight:bolder;">HTTP</span> or <span style="color:#666666; font-weight:bolder;">HTTPS</span>
-   - **Port** – <span style="color:#666666; font-weight:bolder;">80</span> or <span style="color:#666666; font-weight:bolder;">443</span>
-   - **Path** – <span style="color:#666666; font-weight:bolder;">/</span>
-   - **Interval** – <span style="color:#666666; font-weight:bolder;">5</span>
-   - **Unhealthy threshold** – <span style="color:#666666; font-weight:bolder;">2</span>
+   - **Name** – Name of the new backend pool (**lb\_probe** in this guide)
+   - **Protocol** – **HTTP** or **HTTPS**
+   - **Port** – **80** or **443**
+   - **Path** – **/**
+   - **Interval** – **5**
+   - **Unhealthy threshold** – **2**
 
    <a href="/nginx/images/azure-create-lb-add-health-probe.png"><img src="/nginx/images/azure-create-lb-add-health-probe.png" alt="Screenshot of Azure 'Add health probe' page for Standard Load Balancer" width="1024" height="650" class="aligncenter size-full wp-image-64973" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
-   After a few moments the new probe appears in the table on the <span style="white-space: nowrap; font-weight:bold;">lb | Health probes</span> page. This probe queries the NGINX Plus landing page every five seconds to check whether NGINX Plus is running.
+   After a few moments the new probe appears in the table on the **lb&nbsp;|&nbsp;Health&nbsp;probes** page. This probe queries the NGINX Plus landing page every five seconds to check whether NGINX Plus is running.
 
-8. Click <span style="white-space: nowrap; font-weight:bold;">Load balancing rules</span> in the left navigation column, and then **<span style="color:#4d9bdc;">+</span> Add** in the upper left corner of the main pane on the <span style="white-space: nowrap; font-weight:bold;">lb | Load balancing rules</span> page that opens.
+8. Click **Load&nbsp;balancing&nbsp;rules** in the left navigation column, and then **<span style="color:#4d9bdc;">+</span> Add** in the upper left corner of the main pane on the **lb&nbsp;|&nbsp;Load&nbsp;balancing&nbsp;rules** page that opens.
 
-9. On the <span style="white-space: nowrap; font-weight:bold;">Add load balancing rule</span> page that opens, enter or select the following values, then click the <span style="background-color:#137ad1; color:white;"> OK </span> button.
+9. On the **Add&nbsp;load&nbsp;balancing&nbsp;rule** page that opens, enter or select the following values, then click the <span style="background-color:#137ad1; color:white;"> OK </span> button.
 
-   - **Name** – Name of the rule (<span style="color:#666666; font-weight:bolder;">lb\_rule</span> in this guide)
-   - **IP version** – <span style="color:#666666; font-weight:bolder;">IPv4</span>
-   - **Frontend IP address** – The Standard Load Balancer's public IP address, as reported in the <span style="white-space: nowrap; font-weight:bold;">Public IP address</span> field on the **Overview** tag of the Standard Load Balancer's page (for an example, see [Step 3](#slb-configure-lb-overview) above); in this guide it is <span style="color:#666666; font-weight:bolder; white-space: nowrap;">51.143.107.x (LoadBalancerFrontEnd)</span>
-   - **Protocol** – <span style="color:#666666; font-weight:bolder;">TCP</span>
-   - **Port** – <span style="color:#666666; font-weight:bolder;">80</span>
-   - **Backend port** – <span style="color:#666666; font-weight:bolder;">80</span>
-   - **Backend pool** – <span style="color:#666666; font-weight:bolder;">lb_backend</span>
-   - **Health probe** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">lb_probe (HTTP:80)</span>
-   - **Session persistence** – <span style="color:#666666; font-weight:bolder;">None</span>
-   - **Idle timeout (minutes)** – <span style="color:#666666; font-weight:bolder;">4</span>
-   - **TCP reset** – <span style="color:#666666; font-weight:bolder;">Disabled</span>
-   - **Floating IP (direct server return)** – <span style="color:#666666; font-weight:bolder;">Disabled</span>
-   - **Create implicit outbound rules** – <span style="color:#666666; font-weight:bolder;">Yes</span>
+   - **Name** – Name of the rule (**lb\_rule** in this guide)
+   - **IP version** – **IPv4**
+   - **Frontend IP address** – The Standard Load Balancer's public IP address, as reported in the **Public&nbsp;IP&nbsp;address** field on the **Overview** tag of the Standard Load Balancer's page (for an example, see [Step 3](#slb-configure-lb-overview) above); in this guide it is **51.143.107.x&nbsp;(LoadBalancerFrontEnd)**
+   - **Protocol** – **TCP**
+   - **Port** – **80**
+   - **Backend port** – **80**
+   - **Backend pool** – **lb_backend**
+   - **Health probe** – **lb_probe&nbsp;(HTTP:80)**
+   - **Session persistence** – **None**
+   - **Idle timeout (minutes)** – **4**
+   - **TCP reset** – **Disabled**
+   - **Floating IP (direct server return)** – **Disabled**
+   - **Create implicit outbound rules** – **Yes**
 
    <a href="/nginx/images/azure-create-lb-add-load-balancing-rule.png"><img src="/nginx/images/azure-create-lb-add-load-balancing-rule.png" alt="Screenshot of Azure 'Add load balancing rule' page for Standard Load Balancer" width="1024" height="1032" class="aligncenter size-full wp-image-64972" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
-   After a few moments the new rule appears in the table on the <span style="white-space: nowrap; font-weight:bold;">lb | Load balancing rules</span> page.
+   After a few moments the new rule appears in the table on the **lb&nbsp;|&nbsp;Load&nbsp;balancing&nbsp;rules** page.
 
 <span id="slb-verify-operation"></span>
 ### Verifying Correct Operation
 
-1. To verify that Standard Load Balancer is working correctly, open a new browser window and navigate to the IP address for the Standard Load Balancer front end, which appears in the <span style="white-space: nowrap; font-weight:bold;">Public IP address</span> field on the **Overview** tab of the load balancer's page on the dashboard (for an example, see [Step 3](#slb-configure-lb-overview) of _Configuring the Standard Load Balancer_).
+1. To verify that Standard Load Balancer is working correctly, open a new browser window and navigate to the IP address for the Standard Load Balancer front end, which appears in the **Public&nbsp;IP&nbsp;address** field on the **Overview** tab of the load balancer's page on the dashboard (for an example, see [Step 3](#slb-configure-lb-overview) of _Configuring the Standard Load Balancer_).
 
-2. The default <span style="white-space: nowrap; font-weight:bold;">Welcome to nginx!</span> page indicates that the Standard Load Balancer has successfully forwarded a request to one of the two NGINX Plus instances.
+2. The default **Welcome&nbsp;to&nbsp;nginx!** page indicates that the Standard Load Balancer has successfully forwarded a request to one of the two NGINX Plus instances.
 
    <img src="/nginx/images/azure-create-lb-welcome-to-nginx.png" alt="Screenshot of 'Welcome to nginx!' page that verifies correct configuration of an Azure Standard Load Balancer" width="1024" height="328" class="aligncenter size-full wp-image-64971" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -210,42 +210,42 @@ Once you’ve tested that the Standard Load Balancer has been correctly deployed
 
 In this case, you need to set up Azure Traffic Manager for DNS‑based global server load balancing (GSLB) among the regions. The involves creating a DNS name for the Standard Load Balancer and registering it as an endpoint in Traffic Manager.
 
-1. Navigate to the <span style="white-space: nowrap; font-weight:bold;">Public IP addresses</span> page. (One way is to enter <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Public IP addresses</span> in the search field of the Azure title bar and select that value in the **Services** section of the resulting drop‑down menu.)
+1. Navigate to the **Public&nbsp;IP&nbsp;addresses** page. (One way is to enter **Public&nbsp;IP&nbsp;addresses** in the search field of the Azure title bar and select that value in the **Services** section of the resulting drop‑down menu.)
 
-2. Click the name of the Standard Load Balancer's public IP address in the **Name** column of the table (here it is <span style="color:#666666; font-weight:bolder;">public\_ip_lb</span>).
+2. Click the name of the Standard Load Balancer's public IP address in the **Name** column of the table (here it is **public\_ip_lb**).
 
    <a href="/nginx/images/azure-create-lb-public-ip-addresses.png"><img src="/nginx/images/azure-create-lb-public-ip-addresses.png" alt="Screenshot of Azure 'Public IP addresses' page" width="1024" height="600" class="aligncenter size-full wp-image-64970" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
 3. On the **public\_ip_lb** page that opens, click **Configuration** in the left navigation column.
 
-4. Enter the DNS name for the Standard Load Balancer in the <span style="white-space: nowrap; font-weight:bold;">DNS name label</span> field. In this guide, we're accepting the default, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">public-ip-dns</span>.
+4. Enter the DNS name for the Standard Load Balancer in the **DNS&nbsp;name&nbsp;label** field. In this guide, we're accepting the default, **public&#8209;ip&#8209;dns**.
 
    <a href="/nginx/images/azure-create-lb-public-ip-lb.png"><img src="/nginx/images/azure-create-lb-public-ip-lb.png" alt="Screenshot of Azure page for public IP address of a Standard Load Balancer" width="1024" height="465" class="aligncenter size-full wp-image-64969" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
-5. Navigate to the <span style="white-space: nowrap; font-weight:bold;">Traffic Manager profiles</span> tab. (One way is to enter <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Traffic Manager profiles</span> in the search field of the Azure title bar and select that value in the **Services** section of the resulting drop‑down menu.)
+5. Navigate to the **Traffic&nbsp;Manager&nbsp;profiles** tab. (One way is to enter **Traffic&nbsp;Manager&nbsp;profiles** in the search field of the Azure title bar and select that value in the **Services** section of the resulting drop‑down menu.)
 
 6. Click **<span style="color:#4d9bdc;">+</span> Add** in the upper left corner of the page.
 
-7. On the <span style="white-space: nowrap; font-weight:bold;">Create Traffic Manager profile</span> page that opens, enter or select the following values and click the <span style="background-color:#137ad1; color:white; white-space: nowrap;"> Create </span> button.
+7. On the **Create&nbsp;Traffic&nbsp;Manager&nbsp;profile** page that opens, enter or select the following values and click the <span style="background-color:#137ad1; color:white; white-space: nowrap;"> Create </span> button.
 
-   - **Name** – Name of the profile (<span style="color:#666666; font-weight:bolder;">ngx</span> in this guide)
-   - **Routing method** – <span style="color:#666666; font-weight:bolder;">Performance</span>
-   - **Subscription** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA-subscription</span> in this guide
-   - **Resource group** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA</span> in this guide
+   - **Name** – Name of the profile (**ngx** in this guide)
+   - **Routing method** – **Performance**
+   - **Subscription** – **NGINX&#8209;Plus&#8209;HA&#8209;subscription** in this guide
+   - **Resource group** – **NGINX&#8209;Plus&#8209;HA** in this guide
 
    _Azure-create-lb-create-Traffic-Manager-profile_
    <a href="/nginx/images/azure-create-trafficmgr-create-tm-profile.png"><img src="/nginx/images/azure-create-trafficmgr-create-tm-profile.png" alt="Screenshot of Azure 'Create Traffic Manager profile' page" width="1024" height="581" class="aligncenter size-full wp-image-64968" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
-8. It takes a few moments to create the profile. When it appears in the table on the <span style="white-space: nowrap; font-weight:bold;">Traffic Manager profiles</span> page, click its name in the **Name** column.
+8. It takes a few moments to create the profile. When it appears in the table on the **Traffic&nbsp;Manager&nbsp;profiles** page, click its name in the **Name** column.
 
 9. On the **ngx** page that opens, click **Endpoints** in the left navigation column, then **<span style="color:#4d9bdc;">+</span> Add** in the main part of the page.
 
 10. On the **Add endpoint** window that opens, enter or select the following values and click the <span style="background-color:#137ad1; color:white;"> Add </span> button.
 
-    - **Type** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Azure endpoint</span>
-    - **Name** – Endpoint name (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">ep-lb-west-us</span> in this guide)
-    - **Target resource type** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Public IP address</span>
-    - **Public IP address** – Name of the Standard Load Balancer's public IP address (<span style="color:#666666; font-weight:bolder;">public\_ip_lb (51.143.107.x)</span> in this guide)
+    - **Type** – **Azure&nbsp;endpoint**
+    - **Name** – Endpoint name (**ep&#8209;lb&#8209;west&#8209;us** in this guide)
+    - **Target resource type** – **Public&nbsp;IP&nbsp;address**
+    - **Public IP address** – Name of the Standard Load Balancer's public IP address (**public\_ip_lb (51.143.107.x)** in this guide)
     - **Custom Header settings** – None in this guide
 
     <a href="/nginx/images/azure-create-trafficmgr-add-endpoint.png"><img src="/nginx/images/azure-create-trafficmgr-add-endpoint.png" alt="Screenshot of Azure 'Add endpoint' page" width="1024" height="578" class="aligncenter size-full wp-image-64967" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
@@ -276,15 +276,15 @@ Assign the following names to the VMs, and then install the indicated NGINX soft
 
 - Four NGINX Open Source VMs:
   - **App 1**:
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-1</span>
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-2</span>
+    - **ngx-oss-app1-1**
+    - **ngx-oss-app1-2**
   - **App 2**:
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-1</span>
-    - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-2</span>
+    - **ngx-oss-app2-1**
+    - **ngx-oss-app2-2**
 
 - Two NGINX Plus VMs:
-  - <span style="color:#666666; font-weight:bolder">ngx-plus-1</span>
-  - <span style="color:#666666; font-weight:bolder">ngx-plus-2</span>
+  - **ngx-plus-1**
+  - **ngx-plus-2**
 
 **Note:** The two NGINX Plus VMs must have a public IP address with same SKU type as the Standard Load Balancer you are creating (in this guide, **Standard**).  Instructions are included in our deployment guide, [Creating Microsoft Azure Virtual Machines for NGINX Open Source and NGINX Plus]({{< ref "virtual-machines-for-nginx.md" >}}).
 
@@ -300,11 +300,11 @@ For the purposes of this guide, you configure the NGINX Open Source VMs as web s
 Complete the instructions on all four web servers:
 
 - Running **App 1**:
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-1</span>
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app1-2</span>
+  - **ngx-oss-app1-1**
+  - **ngx-oss-app1-2**
 - Running **App 2**:
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-1</span>
-  - <span style="color:#666666; font-weight:bolder">ngx-oss-app2-2</span>
+  - **ngx-oss-app2-1**
+  - **ngx-oss-app2-2**
 
 <span id="configure-load-balancers"></span>
 ### Configuring NGINX Plus on the Load Balancers
@@ -313,7 +313,7 @@ For the purposes of this guide, you configure the NGINX Plus VMs as load balanc
 
 <span style="white-space: nowrap;">Step-by-step</span> instructions are provided in our deployment guide, <a href="../../setting-up-nginx-demo-environment#nginx-plus">Setting Up an NGINX Demo Environment</a>.
 
-Complete the instructions on both <span style="color:#666666; font-weight:bolder">ngx-plus-1</span> and <span style="color:#666666; font-weight:bolder">ngx-plus-2</span>.
+Complete the instructions on both **ngx-plus-1** and **ngx-plus-2**.
 
 ### Revision History
 

--- a/content/nginx/deployment-guides/microsoft-azure/virtual-machines-for-nginx.md
+++ b/content/nginx/deployment-guides/microsoft-azure/virtual-machines-for-nginx.md
@@ -23,7 +23,7 @@ These instructions assume you have:
 
 - An Azure [account](https://azure.microsoft.com/en-us/free/).
 - An Azure [subscription](https://docs.microsoft.com/en-us/azure/azure-glossary-cloud-terminology?toc=/azure/virtual-network/toc.json#subscription).
-- An Azure [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups). In this guide, it is called <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA</span>.
+- An Azure [resource group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups). In this guide, it is called **NGINX&#8209;Plus&#8209;HA**.
 - An Azure [virtual network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview).
 - If using the instructions in [Automating Installation with Ansible](#automate-ansible), basic Linux system administration skills, including installation of Linux software from vendor‑supplied packages, and file creation and editing.
 
@@ -48,25 +48,25 @@ In addition, to install NGINX software by following the linked instructions, you
    <span id="create-vm_Basics"></span>
 4. In the **Create a virtual machine** window that opens, enter the requested information on the **Basics** tab. In this guide, we're using the following values:
 
-   - **Subscription** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA-subscription</span>
-   - **Resource group** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA</span>
-   - **Virtual machine name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-plus-1</span>
+   - **Subscription** – **NGINX&#8209;Plus&#8209;HA&#8209;subscription**
+   - **Resource group** – **NGINX&#8209;Plus&#8209;HA**
+   - **Virtual machine name** – **ngx&#8209;plus&#8209;1**
 
-     The value <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-plus-1</span> is one of the six used for VMs in [Active-Active HA for NGINX Plus on Microsoft Azure Using the Azure Standard Load Balancer]({{< ref "high-availability-standard-load-balancer.md" >}}). See <a href="#create-vm_list">Step 7</a> below for the other instance names.
+     The value **ngx&#8209;plus&#8209;1** is one of the six used for VMs in [Active-Active HA for NGINX Plus on Microsoft Azure Using the Azure Standard Load Balancer]({{< ref "high-availability-standard-load-balancer.md" >}}). See <a href="#create-vm_list">Step 7</a> below for the other instance names.
 
-   - **Region** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">(US) West US 2</span>
-   - **Availability options** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">No infrastructure redundancy required</span>
+   - **Region** – **(US)&nbsp;West&nbsp;US&nbsp;2**
+   - **Availability options** – **No&nbsp;infrastructure&nbsp;redundancy&nbsp;required**
 
      This option is sufficient for a demo like the one in this guide. For production deployments, you might want to select a more robust option; we recommend deploying a copy of each VM in a different Availability Zone. For more information, see the [Azure documentation](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
-   - **Image** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Ubuntu Server 18.04 LTS</span>
-   - **Azure Spot instance** – <span style="color:#666666; font-weight:bolder;">No</span>
-   - **Size** – <span style="color:#666666; font-weight:bolder;">B1s</span> (click <span style="color:#2d89d6; white-space: nowrap;">Select size</span> to access the <span style="font-weight:bold; white-space: nowrap;">Select a VM size</span> window, click the **B1s** row, and click the <span style="background-color:#137ad1; color:white;"> Select </span> button to return to the **Basics** tab)
-   - **Authentication type** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">SSH public key</span>
-   - **Username** – <span style="color:#666666; font-weight:bolder;">nginx_azure</span>
-   - **SSH public key source** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Generate new key pair</span> (the other choices on the drop‑down menu are to use an existing key stored in Azure or an existing public key)
-   - **Key pair name** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx_key</span>
-   - **Public inbound ports** – <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Allow selected ports</span>
-   - **Select inbound ports** – Select from the drop-down menu: <span style="color:#666666; font-weight:bolder; white-space: nowrap;">SSH (22)</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">HTTP (80)</span>, plus <span style="color:#666666; font-weight:bolder; white-space: nowrap;">HTTPS (443)</span> if you plan to configure NGINX and NGINX Plus for SSL/TLS
+   - **Image** – **Ubuntu&nbsp;Server&nbsp;18.04&nbsp;LTS**
+   - **Azure Spot instance** – **No**
+   - **Size** – **B1s** (click <span style="color:#2d89d6; white-space: nowrap;">Select size</span> to access the **Select&nbsp;a&nbsp;VM&nbsp;size** window, click the **B1s** row, and click the <span style="background-color:#137ad1; color:white;"> Select </span> button to return to the **Basics** tab)
+   - **Authentication type** – **SSH&nbsp;public&nbsp;key**
+   - **Username** – **nginx_azure**
+   - **SSH public key source** – **Generate&nbsp;new&nbsp;key&nbsp;pair** (the other choices on the drop‑down menu are to use an existing key stored in Azure or an existing public key)
+   - **Key pair name** – **nginx_key**
+   - **Public inbound ports** – **Allow&nbsp;selected&nbsp;ports**
+   - **Select inbound ports** – Select from the drop-down menu: **SSH&nbsp;(22)** and **HTTP&nbsp;(80)**, plus **HTTPS&nbsp;(443)** if you plan to configure NGINX and NGINX Plus for SSL/TLS
 
    <a href="/nginx/images/azure-create-vm-basics.png"><img src="/nginx/images/azure-create-vm-basics.png" alt="screenshot of 'Basics' tab on Azure 'Create a virtual machine' page" width="1024" height="1168" class="aligncenter size-full wp-image-64995" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
@@ -75,11 +75,11 @@ In addition, to install NGINX software by following the linked instructions, you
 
    For simplicity, we recommend allocating **Standard** public IP addresses for all six VMs used in the deployment. At the time of initial publication of this guide, the hourly cost for six such VMs was only $0.008 more than for six VMs with Basic addresses; for current pricing, see the [Microsoft documentation](https://azure.microsoft.com/en-us/pricing/details/ip-addresses/).
 
-   To allocate a **Standard** public IP address, open the **Networking** tab on the **Create a virtual machine** window. Click <span style="color:#2d89d6; white-space: nowrap;">Create new</span> below the **Public IP** field. In the <span style="font-weight:bold; white-space: nowrap;">Create public IP address</span> column that opens at right, click the **Standard** radio button under **SKU**. You can change the value in the **Name** field; here we are accepting the default created by Azure, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-plus-1-ip</span>. Click the <span style="background-color:#137ad1; color:white; font-weight:bold;"> OK </span> button.
+   To allocate a **Standard** public IP address, open the **Networking** tab on the **Create a virtual machine** window. Click <span style="color:#2d89d6; white-space: nowrap;">Create new</span> below the **Public IP** field. In the **Create&nbsp;public&nbsp;IP&nbsp;address** column that opens at right, click the **Standard** radio button under **SKU**. You can change the value in the **Name** field; here we are accepting the default created by Azure, **ngx&#8209;plus&#8209;1&#8209;ip**. Click the ** OK ** button.
 
    <a href="/nginx/images/azure-create-vm-networking.png"><img src="/nginx/images/azure-create-vm-networking.png" alt="screenshot of 'Networking' tab on Azure 'Create a virtual machine' page" width="1024" height="718" class="aligncenter size-full wp-image-64994" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
-6. At this point, you have the option of selecting nondefault values on the **Disks**, **Networking**, **Management**, **Advanced**, and **Tags** tabs. For a demo like the one in this guide, for example, selecting <span style="color:#666666; font-weight:bolder;">Standard HDD</span> for <span style="white-space: nowrap;">OS disk type</span> on the **Disks** tab saves money compared to the default, <span style="color:#666666; font-weight:bolder;">Premium SSD</span>. You might also want to create or apply tags to this VM, on the **Tags** tab.
+6. At this point, you have the option of selecting nondefault values on the **Disks**, **Networking**, **Management**, **Advanced**, and **Tags** tabs. For a demo like the one in this guide, for example, selecting **Standard HDD** for <span style="white-space: nowrap;">OS disk type</span> on the **Disks** tab saves money compared to the default, **Premium SSD**. You might also want to create or apply tags to this VM, on the **Tags** tab.
 
    When you have completed your changes on all tabs, click the <span style="background-color:#137ad1; color:white; white-space: nowrap;"> Review + create </span> button at the bottom of the **Create a virtual machine** page.
 
@@ -87,7 +87,7 @@ In addition, to install NGINX software by following the linked instructions, you
 
    To change any settings, open the appropriate tab. If the settings are correct, click the <span style="background-color:#137ad1; color:white;"> Create </span> button.
 
-   If you chose in [Step 4](#create-vm_Basics) to generate a new key pair, a <span style="white-space: nowrap; font-weight:bold;">Generate new key pair</span> window pops up. Click the <span style="background-color:#137ad1; color:white; white-space: nowrap;"> Download key and create private resource </span> button.
+   If you chose in [Step 4](#create-vm_Basics) to generate a new key pair, a **Generate&nbsp;new&nbsp;key&nbsp;pair** window pops up. Click the <span style="background-color:#137ad1; color:white; white-space: nowrap;"> Download key and create private resource </span> button.
 
    <a href="/nginx/images/azure-create-vm-validation-passed.png"><img src="/nginx/images/azure-create-vm-validation-passed.png" alt="screenshot of validation message on Azure 'Create a virtual machine' page" width="1024" height="954" class="aligncenter size-full image-64993" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
@@ -98,16 +98,16 @@ In addition, to install NGINX software by following the linked instructions, you
    <span id="create-vm_list"></span>
 7. If you are following these instructions to create the six VMs used in [Active-Active HA for NGINX Plus on Microsoft Azure Using the Azure Standard Load Balancer]({{< ref "high-availability-standard-load-balancer.md" >}}), their names are as follows:
 
-   - <span style="color:#666666; font-weight:bolder;">ngx-plus-1</span>
-   - <span style="color:#666666; font-weight:bolder;">ngx-plus-2</span>
-   - <span style="color:#666666; font-weight:bolder;">ngx-oss-app1-1</span>
-   - <span style="color:#666666; font-weight:bolder;">ngx-oss-app1-2</span>
-   - <span style="color:#666666; font-weight:bolder;">ngx-oss-app2-1</span>
-   - <span style="color:#666666; font-weight:bolder;">ngx-oss-app2-2</span>
+   - **ngx-plus-1**
+   - **ngx-plus-2**
+   - **ngx-oss-app1-1**
+   - **ngx-oss-app1-2**
+   - **ngx-oss-app2-1**
+   - **ngx-oss-app2-2**
 
-   For <span style="color:#666666; font-weight:bolder;">ngx-plus-2</span>, it is probably simplest to repeat Steps 2 through 6 above (or purchase a second prebuilt VM in the [Microsoft Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=NGINX%20Plus)).
+   For **ngx-plus-2**, it is probably simplest to repeat Steps 2 through 6 above (or purchase a second prebuilt VM in the [Microsoft Azure Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=NGINX%20Plus)).
 
-   For the NGINX Open Source VMs, you can create them individually using Steps 2 through 6. Alternatively, create them based on an Azure image. To do so, follow Steps 2 through 6 above to create a source VM (naming it <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-oss</span>), [install the NGINX Open Source software](#install-nginx) on it, and then follow the instructions in [Optional: Creating an NGINX Open Source Image](#create-nginx-oss-image).
+   For the NGINX Open Source VMs, you can create them individually using Steps 2 through 6. Alternatively, create them based on an Azure image. To do so, follow Steps 2 through 6 above to create a source VM (naming it **nginx&#8209;oss**), [install the NGINX Open Source software](#install-nginx) on it, and then follow the instructions in [Optional: Creating an NGINX Open Source Image](#create-nginx-oss-image).
 
 <span id="connect-vm"></span>
 ## Connecting to a Virtual Machine
@@ -118,7 +118,7 @@ To install and configure NGINX Open Source or NGINX Plus on a VM, you need to o
 
    <a href="/nginx/images/azure-create-vm-virtual-machines.png"><img src="/nginx/images/azure-create-vm-virtual-machines.png" alt="screenshot of Azure 'Virtual machines' page with list of VMs" width="1024" height="396" class="aligncenter size-full wp-image-64991" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
-2. On the page that opens (<span style="white-space: nowrap; font-weight:bold;">ngx-plus-1</span> in this guide), note the VM's public IP address (in the <span style="white-space: nowrap; font-weight:bold;">Public IP address</span> field in the right column).
+2. On the page that opens (**ngx&#8209;plus&#8209;1** in this guide), note the VM's public IP address (in the **Public&nbsp;IP&nbsp;address** field in the right column).
 
    <a href="/nginx/images/azure-create-vm-ngx-plus-1.png"><img src="/nginx/images/azure-create-vm-ngx-plus-1.png" alt="screenshot of details page for 'ngx-plus-1' VM in Azure" width="1024" height="363" class="aligncenter size-full wp-image-64990" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 
@@ -130,8 +130,8 @@ To install and configure NGINX Open Source or NGINX Plus on a VM, you need to o
 
    where
 
-   - `<private-key-file>` is the name of the file containing the private key paired with the public key you entered in the <span style="white-space: nowrap; font-weight:bold;">SSH public key</span> field in <a href="#create-vm_Basics">Step 4</a> of _Creating a Microsoft Azure Virtual Machine_.
-   - `<username>` is the name you entered in the **Username** field in <a href="#create-vm_Basics">Step 4</a> of _Creating a Microsoft Azure Virtual Machine_ (in this guide it is <span style="color:#666666; font-weight:bolder;">nginx_azure</span>).
+   - `<private-key-file>` is the name of the file containing the private key paired with the public key you entered in the **SSH&nbsp;public&nbsp;key** field in <a href="#create-vm_Basics">Step 4</a> of _Creating a Microsoft Azure Virtual Machine_.
+   - `<username>` is the name you entered in the **Username** field in <a href="#create-vm_Basics">Step 4</a> of _Creating a Microsoft Azure Virtual Machine_ (in this guide it is **nginx_azure**).
    - `<public-IP-address>` is the address you looked up in the previous step.
 
 <span id="install-nginx"></span>
@@ -169,7 +169,7 @@ NGINX publishes a unified Ansible role for NGINX Open Source and NGINX Plus on 
    ansible-galaxy install nginxinc.nginx
    ```
 
-4. (NGINX Plus only) Copy the <span style="white-space: nowrap; font-weight:bold;">nginx-repo.key</span> and <span style="white-space: nowrap; font-weight:bold;">nginx-repo.crt</span> files provided by NGINX to <span style="white-space: nowrap; font-weight:bold;">~/.ssh/ngx-certs/</span>.
+4. (NGINX Plus only) Copy the **nginx&#8209;repo.key** and **nginx&#8209;repo.crt** files provided by NGINX to **~/.ssh/ngx&#8209;certs/**.
 
 5. Create a file called **playbook.yml** with the following contents:
 
@@ -196,7 +196,7 @@ To streamline the process of installing NGINX Open Source on multiple VMs, you c
 
 2. Navigate to the **Virtual machines** page, if you are not already there.
 
-2. In the list of VMs, click the name of the one to use as a source image (in this guide, we have called it <span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-oss</span>). Remember that NGINX Open Source needs to be installed on it already.
+2. In the list of VMs, click the name of the one to use as a source image (in this guide, we have called it **ngx&#8209;oss**). Remember that NGINX Open Source needs to be installed on it already.
 
 3. On the page than opens, click the **Capture** icon in the top navigation bar.
 
@@ -207,10 +207,10 @@ To streamline the process of installing NGINX Open Source on multiple VMs, you c
    Then select the following values:
 
    - **Name** – Keep the current value.
-   - **Resource group** – Select the appropriate resource group from the drop‑down menu. Here it is <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX-Plus-HA</span>.
+   - **Resource group** – Select the appropriate resource group from the drop‑down menu. Here it is **NGINX&#8209;Plus&#8209;HA**.
    - **Automatically delete this virtual machine after creating the image** – We recommend checking the box, since you can't do anything more with the image anyway.
-   - **Zone resiliency** – <span style="color:#666666; font-weight:bolder;">On</span>.
-   - **Type the virtual machine name** – Name of the source VM (<span style="color:#666666; font-weight:bolder; white-space: nowrap;">ngx-oss</span> in this guide).
+   - **Zone resiliency** – **On**.
+   - **Type the virtual machine name** – Name of the source VM (**ngx&#8209;oss** in this guide).
 
    Click the <span style="background-color:#137ad1; color:white;"> Create </span> button.
 
@@ -220,7 +220,7 @@ To streamline the process of installing NGINX Open Source on multiple VMs, you c
 
 It takes a few moments for the image to be created. When it's ready, you can create VMs from it with NGINX Open Source already installed.
 
-1. Navigate to the **Images** page. (One method is to type <span style="color:#666666; font-weight:bolder;">images</span> in the search box in the Microsoft Azure header bar and select that value in the **Services** section of the resulting drop‑down menu.)
+1. Navigate to the **Images** page. (One method is to type **images** in the search box in the Microsoft Azure header bar and select that value in the **Services** section of the resulting drop‑down menu.)
 
    <a href="/nginx/images/azure-create-image-images.png"><img src="/nginx/images/azure-create-image-images.png" alt="screenshot of Azure 'Images' page" width="1024" height="349" class="aligncenter size-full wp-image-64987" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 

--- a/content/nginx/deployment-guides/migrate-hardware-adc/citrix-adc-configuration.md
+++ b/content/nginx/deployment-guides/migrate-hardware-adc/citrix-adc-configuration.md
@@ -327,7 +327,7 @@ NGINX Plus and Citrix ADC handle high availability (HA) in similar but slightly
 
 Citrix ADC handles the monitoring and failover of the VIP in a proprietary way.
 
- For [on‑premises deployments]({{< ref "nginx/admin-guide/high-availability/ha-keepalived.md" >}}), NGINX Plus uses a separate software package called <span style="white-space: nowrap; font-weight:bold;">**nginx-ha-keepalived**</span> to handle the VIP and the failover process for an active‑passive pair of NGINX Plus servers. The package implements the VRRP protocol to handle the VIP. Limited [active‑active]({{< ref "nginx/admin-guide/high-availability/ha-keepalived-nodes.md" >}}) scenarios are also possible with the <span style="white-space: nowrap; font-weight:bold;">nginx-ha-keepalived</span> package.
+ For [on‑premises deployments]({{< ref "nginx/admin-guide/high-availability/ha-keepalived.md" >}}), NGINX Plus uses a separate software package called ****nginx&#8209;ha&#8209;keepalived**** to handle the VIP and the failover process for an active‑passive pair of NGINX Plus servers. The package implements the VRRP protocol to handle the VIP. Limited [active‑active]({{< ref "nginx/admin-guide/high-availability/ha-keepalived-nodes.md" >}}) scenarios are also possible with the **nginx&#8209;ha&#8209;keepalived** package.
 
 Solutions for high availability of NGINX Plus in cloud environments are also available, including these:
 

--- a/content/nginx/deployment-guides/migrate-hardware-adc/f5-big-ip-configuration.md
+++ b/content/nginx/deployment-guides/migrate-hardware-adc/f5-big-ip-configuration.md
@@ -99,7 +99,7 @@ In addition to these networking concepts, there are two other important technolo
 
   <span style="white-space: nowrap;">BIG-IP LTM</span> uses a built‑in HA mechanism to handle the failover.
 
-  For [on‑premises deployments]({{< ref "nginx/admin-guide/high-availability/ha-keepalived.md" >}}), NGINX Plus uses a separate software package called <span style="white-space: nowrap; font-weight:bold;">**nginx-ha-keepalived**</span> to handle the VIP and the failover process for an active‑passive pair of NGINX Plus servers. The package implements the VRRP protocol to handle the VIP. Limited [active‑active]({{< ref "nginx/admin-guide/high-availability/ha-keepalived-nodes.md" >}}) scenarios are also possible with the <span style="white-space: nowrap; font-weight:bold;">nginx-ha-keepalived</span> package.
+  For [on‑premises deployments]({{< ref "nginx/admin-guide/high-availability/ha-keepalived.md" >}}), NGINX Plus uses a separate software package called ****nginx&#8209;ha&#8209;keepalived**** to handle the VIP and the failover process for an active‑passive pair of NGINX Plus servers. The package implements the VRRP protocol to handle the VIP. Limited [active‑active]({{< ref "nginx/admin-guide/high-availability/ha-keepalived-nodes.md" >}}) scenarios are also possible with the **nginx&#8209;ha&#8209;keepalived** package.
 
   Solutions for high availability of NGINX Plus in cloud environments are also available, including these:
 

--- a/content/nginx/deployment-guides/nginx-plus-high-availability-chef.md
+++ b/content/nginx/deployment-guides/nginx-plus-high-availability-chef.md
@@ -27,9 +27,9 @@ To set up the highly available active/passive cluster, we’re using the [HA sol
 
 ## Modifying the NGINX Cookbook
 
-First we set up the Chef files for installing of the NGINX Plus HA package (<span style="white-space: nowrap; font-weight:bold">nginx-ha-keepalived</span>) and creating the `keepalived` configuration file, **keepalive.conf**.
+First we set up the Chef files for installing of the NGINX Plus HA package (**nginx&#8209;ha&#8209;keepalived**) and creating the `keepalived` configuration file, **keepalive.conf**.
 
-1. Modify the existing **plus_package** recipe to include package and configuration templates for the HA solution, by adding the following code to the bottom of the **plus_package.rb** file (per the instructions in the previous post, the file is in the <span style="white-space: nowrap; font-weight:bold">~/chef-zero/playground/cookbooks/nginx/recipes</span> directory).
+1. Modify the existing **plus_package** recipe to include package and configuration templates for the HA solution, by adding the following code to the bottom of the **plus_package.rb** file (per the instructions in the previous post, the file is in the **~/chef&#8209;zero/playground/cookbooks/nginx/recipes** directory).
 
     We are using the **eth1** interface on each NGINX host, which makes the code a bit more complicated than if we used **eth0**. In case you are using **eth0**, the relevant code appears near the top of the file, commented out.
 
@@ -37,7 +37,7 @@ First we set up the Chef files for installing of the NGINX Plus HA package (<sp
 
     - It looks up the IP address of the **eth1** interface on the node where NGINX Plus is being installed, and assigns the value to the `origip` variable so it can be passed to the template.
     - It finds the other node in the HA pair by using Chef’s `search` function to iterate through all Chef nodes, then looks up the IP address for that node’s **eth1** interface and assigns the address to the `ha_pair_ips` variable.
-    - It installs the <span style="white-space: nowrap; font-weight:bold">nginx-ha-keepalived</span> package, registers the `keepalived` service with Chef, and generates the **keepalived.conf** configuration file as a template, passing in the values of the `origip` and `ha_pair_ips` variables.
+    - It installs the **nginx&#8209;ha&#8209;keepalived** package, registers the `keepalived` service with Chef, and generates the **keepalived.conf** configuration file as a template, passing in the values of the `origip` and `ha_pair_ips` variables.
 
     ```nginx
      if node['nginx']['enable_ha_mode'] == 'true'
@@ -102,7 +102,7 @@ First we set up the Chef files for installing of the NGINX Plus HA package (<sp
 
     You can download the [full recipe file](https://www.nginx.com/resource/conf/plus_package.rb-chef-recipe) from the NGINX, Inc. website.
 
-2. Create the Chef template for creating **keepalived.conf**, by copying the following content to a new template file, **nginx_plus_keepalived.conf.erb**, in the <span style="white-space: nowrap; font-weight:bold">~/chef-zero/playground/cookbooks/nginx/templates/default</span> directory.
+2. Create the Chef template for creating **keepalived.conf**, by copying the following content to a new template file, **nginx_plus_keepalived.conf.erb**, in the **~/chef&#8209;zero/playground/cookbooks/nginx/templates/default** directory.
 
     We’re using a combination of variables and attributes to pass the necessary information to **keepalived.conf**. We’ll set the attributes in the next step. Here we set the two variables in the template file to the host IP addresses that were set with the `variables` directive in the **plus_package.rb** recipe (modified in the previous step):
 
@@ -186,7 +186,7 @@ First we set up the Chef files for installing of the NGINX Plus HA package (<sp
 
     ```
 
-3. Create a role that sets attributes used in the recipe and template files created in the previous steps, by copying the following contents to a new role file, **nginx_plus_ha.rb** in the <span style="white-space: nowrap; font-weight:bold">~/chef-zero/playground/roles</span> directory.
+3. Create a role that sets attributes used in the recipe and template files created in the previous steps, by copying the following contents to a new role file, **nginx_plus_ha.rb** in the **~/chef&#8209;zero/playground/roles** directory.
 
     Four attributes need to be set, and in the role we set the following three:
 
@@ -290,13 +290,13 @@ Now we bootstrap the nodes and get them ready for the installation. Note that th
 
     `
 
-2. Create a local copy of the node definition file, which we’ll edit as appropriate for the node we bootstrapped in the previous step, <span style="white-space: nowrap; font-weight:bold">chef-test-1</span>:
+2. Create a local copy of the node definition file, which we’ll edit as appropriate for the node we bootstrapped in the previous step, **chef&#8209;test&#8209;1**:
 
     ```nginx
     root@chef-server:~/chef-zero/playground# knife node show chef-test-1 --format json > nodes/chef-test-1.json
     ```
 
-3. Edit <span style="white-space: nowrap; font-weight:bold">chef-test-1.json</span> to have the following contents. In particular, we’re updating the run list and setting the `ha_primary` attribute, as required for the HA deployment.
+3. Edit **chef&#8209;test&#8209;1.json** to have the following contents. In particular, we’re updating the run list and setting the `ha_primary` attribute, as required for the HA deployment.
 
     ```json
     {
@@ -323,7 +323,7 @@ Now we bootstrap the nodes and get them ready for the installation. Note that th
     Updated Node chef-test-1!
     ```
 
-5. Log in on the <span style="white-space: nowrap; font-weight:bold">chef-test-1</span> node and run the <span style="white-space: nowrap;">`chef-client`</span> command to get everything configured:
+5. Log in on the **chef&#8209;test&#8209;1** node and run the <span style="white-space: nowrap;">`chef-client`</span> command to get everything configured:
 
     ```text
     username@chef-test-1:~$ <span style="color:#66ff99; font-weight: bold;">sudo chef-client</span>
@@ -616,7 +616,7 @@ Enter your password:
 
 10.100.10.102 Chef Client finished, 18/50 resources updated in 10 seconds`
 
-If we look at **keepalived.conf** at this point, we see that there is a peer set in the `unicast_peer` section. But the following command shows that <span style="white-space: nowrap; font-weight:bold">chef-test-2</span>, which we intend to be the secondary node, is also assigned the VIP (10.100.10.50). This is because we haven’t yet updated the Chef configuration on <span style="white-space: nowrap; font-weight:bold">chef-test-1</span> to make its `keepalived` aware of the secondary node.
+If we look at **keepalived.conf** at this point, we see that there is a peer set in the `unicast_peer` section. But the following command shows that **chef&#8209;test&#8209;2**, which we intend to be the secondary node, is also assigned the VIP (10.100.10.50). This is because we haven’t yet updated the Chef configuration on **chef&#8209;test&#8209;1** to make its `keepalived` aware of the secondary node.
 
     username@chef-test-2:~$ ip addr show eth1
     3: eth1:  mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
@@ -630,7 +630,7 @@ If we look at **keepalived.conf** at this point, we see that there is a peer set
 
 ### Synchronizing the Nodes
 
-To make `keepalived` on <span style="white-space: nowrap; font-weight:bold">chef-test-1</span> aware of <span style="white-space: nowrap; font-weight:bold">chef-test-2</span> and its IP address, we rerun the <span style="white-space: nowrap;">`chef-client`</span> command on <span style="white-space: nowrap; font-weight:bold">chef-test-1</span>:
+To make `keepalived` on **chef&#8209;test&#8209;1** aware of **chef&#8209;test&#8209;2** and its IP address, we rerun the <span style="white-space: nowrap;">`chef-client`</span> command on **chef&#8209;test&#8209;1**:
 
 ```text
 username@chef-test-1:~$ <span style="color:#66ff99; font-weight: bold;">sudo chef-client</span>
@@ -741,7 +741,7 @@ Chef Client finished, 2/47 resources updated in 05 seconds
 
 ```
 
-We see that <span style="white-space: nowrap; font-weight:bold">chef-test-1</span> is still assigned the VIP:
+We see that **chef&#8209;test&#8209;1** is still assigned the VIP:
 
   ```nginx
   username@chef-test-1:~$ ip addr show eth1
@@ -755,7 +755,7 @@ We see that <span style="white-space: nowrap; font-weight:bold">chef-test-1</spa
          valid_lft forever preferred_lft forever
   ```
 
-And <span style="white-space: nowrap; font-weight:bold">chef-test-2</span>, as the secondary node, is now assigned only its physical IP address:
+And **chef&#8209;test&#8209;2**, as the secondary node, is now assigned only its physical IP address:
 
   ```nginx
   username@chef-test-2:~$ ip addr show eth1

--- a/content/nginx/deployment-guides/setting-up-nginx-demo-environment.md
+++ b/content/nginx/deployment-guides/setting-up-nginx-demo-environment.md
@@ -21,7 +21,7 @@ Some commands require `root` privilege. If appropriate for your environment, pre
 <span id="nginx-oss"></span>
 ## Configuring NGINX Open Source for web serving
 
-The steps in this section configure an NGINX Open Source instance as a web server to return a page like the following, which specifies the server name, address, and other information. The page is defined in the <span style="white-space: nowrap; font-weight:bold;">demo-index.html</span> configuration file you create in Step 4 below.
+The steps in this section configure an NGINX Open Source instance as a web server to return a page like the following, which specifies the server name, address, and other information. The page is defined in the **demo&#8209;index.html** configuration file you create in Step 4 below.
 
    <a href="/nginx/images/aws-nlb-app1.png"><img src="/nginx/images/aws-nlb-app1.png" alt="" width="1024" height="491" class="aligncenter size-full wp-image-54839" style="border:2px solid #666666; padding:2px; margin:2px;" /></a>
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/active-directory-federation-services.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/active-directory-federation-services.md
@@ -50,11 +50,11 @@ The instructions assume you have the following:
 
 Create an AD FS application for NGINX Plus:
 
-1. Open the AD FS Management window. In the navigation column on the left, right‑click on the **Application Groups** folder and select <span style="white-space: nowrap; font-weight:bold;">Add Application Group</span> from the drop‑down menu.
+1. Open the AD FS Management window. In the navigation column on the left, right‑click on the **Application Groups** folder and select **Add&nbsp;Application&nbsp;Group** from the drop‑down menu.
 
-   The <span style="white-space: nowrap; font-weight:bold;">Add Application Group Wizard</span> window opens. The left navigation column shows the steps you will complete to add an application group.
+   The **Add&nbsp;Application&nbsp;Group&nbsp;Wizard** window opens. The left navigation column shows the steps you will complete to add an application group.
 
-2. In the **Welcome** step, type the application group name in the **Name** field. Here we are using <span style="color:#666666; font-weight:bolder;">ADFSSSO</span>. In the **Template** field, select **Server application** under <span style="color:#293aa3; font-weight:bolder;">Standalone applications</span>. Click the <span style="background-color:#e1e1e1; white-space: nowrap; font-weight: bolder"> Next > </span> button.
+2. In the **Welcome** step, type the application group name in the **Name** field. Here we are using **ADFSSSO**. In the **Template** field, select **Server application** under **Standalone applications**. Click the <span style="background-color:#e1e1e1; white-space: nowrap; font-weight: bolder"> Next > </span> button.
 
    <img src="/nginx/images/adfs-sso-welcome.png" alt="" width="734" height="597" class="aligncenter size-full wp-image-62013" />
 
@@ -63,7 +63,7 @@ Create an AD FS application for NGINX Plus:
 
    1. Make a note of the value in the **Client Identifier** field. You will add it to the NGINX Plus configuration in [Step 4 of _Configuring NGINX Plus_](#nginx-plus-variables).<br/>
 
-   2. In the **Redirect URI** field, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch**. Here we’re using <span style="white-space: nowrap; color:#666666; font-weight:bolder;">https://my-nginx.example.com:443/\_codexch</span>. Click the <span style="background-color:#e1e1e1; white-space: nowrap; font-weight: bolder"> Add </span> button.
+   2. In the **Redirect URI** field, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch**. Here we’re using **https://my&#8209;nginx.example.com:443/\_codexch**. Click the <span style="background-color:#e1e1e1; white-space: nowrap; font-weight: bolder"> Add </span> button.
 
       **Notes:**
 
@@ -75,7 +75,7 @@ Create an AD FS application for NGINX Plus:
    <img src="/nginx/images/adfs-sso-server-application.png" alt="" width="860" height="523" class="aligncenter size-full wp-image-62012" />
 
    <span id="ad-fs-configure-application-credentials"></span>
-4. In the <span style="white-space: nowrap; font-weight:bold;">Configure Application Credentials</span> step, click the <span style="white-space: nowrap; font-weight:bold;">Generate a shared secret</span> checkbox. Make a note of the secret that AD FS generates (perhaps by clicking the <span style="white-space: nowrap; font-weight:bold;">Copy to clipboard</span> button and pasting the clipboard content into a file). You will add the secret to the NGINX Plus configuration in [Step 4 of _Configuring NGINX Plus_](#nginx-plus-variables). Click the <span style="background-color:#e1e1e1; white-space: nowrap; font-weight: bolder"> Next > </span> button.
+4. In the **Configure&nbsp;Application&nbsp;Credentials** step, click the **Generate&nbsp;a&nbsp;shared&nbsp;secret** checkbox. Make a note of the secret that AD FS generates (perhaps by clicking the **Copy&nbsp;to&nbsp;clipboard** button and pasting the clipboard content into a file). You will add the secret to the NGINX Plus configuration in [Step 4 of _Configuring NGINX Plus_](#nginx-plus-variables). Click the <span style="background-color:#e1e1e1; white-space: nowrap; font-weight: bolder"> Next > </span> button.
 
    <img src="/nginx/images/adfs-sso-configure-application-credentials.png" alt="" width="750" height="432" class="aligncenter size-full wp-image-62011" />
 
@@ -87,7 +87,7 @@ Create an AD FS application for NGINX Plus:
 
 Configure NGINX Plus as the OpenID Connect relying party:
 
-1. Create a clone of the [<span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span>](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
+1. Create a clone of the [**nginx&#8209;openid&#8209;connect**](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
 
    ```shell
    git clone https://github.com/nginxinc/nginx-openid-connect
@@ -150,7 +150,7 @@ In a browser, enter the address of your NGINX Plus instance and try to log in u
 <span id="troubleshooting"></span>
 ## Troubleshooting
 
-See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the <span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span> repository on GitHub.
+See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the **nginx&#8209;openid&#8209;connect** repository on GitHub.
 
 ### Revision History
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/cognito.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/cognito.md
@@ -59,7 +59,7 @@ Create a new application for NGINX Plus in the Cognito GUI:
 
    <img src="/nginx/images/cognito-sso-your-user-pools.png" alt="" width="1024" height="212" class="aligncenter size-full wp-image-63792" />
 
-3. In the **Create a user pool** window that opens, type a value in the **Pool name** field (in this guide, it's <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-pool</span>), then click the <span style=" color:#479bd4; font-weight: bold; white-space: nowrap;">Review defaults</span> button.
+3. In the **Create a user pool** window that opens, type a value in the **Pool name** field (in this guide, it's **nginx&#8209;plus&#8209;pool**), then click the <span style=" color:#479bd4; font-weight: bold; white-space: nowrap;">Review defaults</span> button.
 
    <img src="/nginx/images/cognito-sso-create-name-tab.png" alt="" width="1024" height="808" class="aligncenter size-full wp-image-63953" />
 
@@ -70,11 +70,11 @@ Create a new application for NGINX Plus in the Cognito GUI:
 
 5. On the **App clients** tab which opens, click <span style=" color:#479bd4; font-weight: bolder; white-space: nowrap;">Add an app client</span>.
 
-6. On the **Which app clients will have access to this user pool?** window which opens, enter a value (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app</span>) in the <span style="white-space: nowrap; font-weight:bold;">App client name</span> field. Make sure the <span style="white-space: nowrap; font-weight:bold;">Generate client secret</span> box is checked, then click the <span style="background-color:#479bd4; color:white; white-space: nowrap;"> Create app client </span> button.
+6. On the **Which app clients will have access to this user pool?** window which opens, enter a value (in this guide, **nginx&#8209;plus&#8209;app**) in the **App&nbsp;client&nbsp;name** field. Make sure the **Generate&nbsp;client&nbsp;secret** box is checked, then click the <span style="background-color:#479bd4; color:white; white-space: nowrap;"> Create app client </span> button.
 
    <img src="/nginx/images/cognito-sso-create-app-clients-tab.png" alt="" width="1024" height="942" class="aligncenter size-full wp-image-63788" />
 
-7. On the confirmation page which opens, click <span style="color:#479bd4; font-weight:bold; white-space: nowrap;">Return to pool details</span> to return to the **Review** tab. On that tab click the <span style="background-color:#479bd4; color:white; white-space: nowrap;"> Create pool </span> button at the bottom. (The screenshot in [Step 4](#cognito-review-tab) shows the button.)
+7. On the confirmation page which opens, click **Return&nbsp;to&nbsp;pool&nbsp;details** to return to the **Review** tab. On that tab click the <span style="background-color:#479bd4; color:white; white-space: nowrap;"> Create pool </span> button at the bottom. (The screenshot in [Step 4](#cognito-review-tab) shows the button.)
 
    <span id="cognito-pool-id"></span>
 8. On the details page which opens to confirm the new user pool was successfully created, make note of the value in the **Pool Id** field; you will add it to the NGINX Plus configuration in [Step 3 of _Configuring NGINX Plus_](#nginx-plus-variables).
@@ -82,36 +82,36 @@ Create a new application for NGINX Plus in the Cognito GUI:
    <img src="/nginx/images/cognito-sso-config-general-settings-tab.png" alt="'General settings' tab in Amazon Cognito GUI" width="1024" height="435" class="aligncenter size-full wp-image-63787" />
 
    <span id="cognito-users"></span>
-9. Click <span style="white-space: nowrap; font-weight:bold;">Users and groups</span> in the left navigation column. In the interface that opens, designate the users (or group of users, on the **Groups** tab) who will be able to use SSO for the app being proxied by NGINX Plus. For instructions, see the Cognito documentation about [creating users](https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-create-user-accounts.html), [importing users](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-using-import-tool.html), or [adding a group](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-user-groups.html).
+9. Click **Users&nbsp;and&nbsp;groups** in the left navigation column. In the interface that opens, designate the users (or group of users, on the **Groups** tab) who will be able to use SSO for the app being proxied by NGINX Plus. For instructions, see the Cognito documentation about [creating users](https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-create-user-accounts.html), [importing users](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-using-import-tool.html), or [adding a group](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-user-groups.html).
 
    <img src="/nginx/images/cognito-sso-config-users-tab.png" alt="'Users and groups' tab in Amazon Cognito GUI" width="1023" height="466" class="aligncenter size-full wp-image-63786" />
 
-10. Click **App clients** in the left navigation bar. On the tab that opens, click the <span style=" color:#479bd4; font-weight: bold; white-space: nowrap;">Show Details</span> button in the box labeled with the app client name (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-app</span>).
+10. Click **App clients** in the left navigation bar. On the tab that opens, click the <span style=" color:#479bd4; font-weight: bold; white-space: nowrap;">Show Details</span> button in the box labeled with the app client name (in this guide, **nginx&#8209;plus&#8209;app**).
 
     <img src="/nginx/images/cognito-sso-config-app-clients-tab.png" alt="'App clients' tab in Amazon Cognito GUI" width="1024" height="497" class="aligncenter size-full wp-image-63785" />
 
     <span id="cognito-app-client-id-secret"></span>
-11. On the details page that opens, make note of the values in the <span style="white-space: nowrap; font-weight:bold;">App client id</span> and <span style="white-space: nowrap; font-weight:bold;">App client secret</span> fields. You will add them to the NGINX Plus configuration in [Step 3 of _Configuring NGINX Plus_](#nginx-plus-variables).
+11. On the details page that opens, make note of the values in the **App&nbsp;client&nbsp;id** and **App&nbsp;client&nbsp;secret** fields. You will add them to the NGINX Plus configuration in [Step 3 of _Configuring NGINX Plus_](#nginx-plus-variables).
 
     <img src="/nginx/images/cognito-sso-config-app-clients-details.png" alt="" width="1024" height="672" class="aligncenter size-full wp-image-63784" />
 
-12. Click <span style="white-space: nowrap; font-weight:bold;">App client settings</span> in the left navigation column. In the tab that opens, perform the following steps:
+12. Click **App&nbsp;client&nbsp;settings** in the left navigation column. In the tab that opens, perform the following steps:
 
-    1. In the <span style="white-space: nowrap; font-weight:bold;">Enabled Identity Providers</span> section, click the <span style="white-space: nowrap; font-weight:bold;">Cognito User Pool</span> checkbox (the **Select all** box gets checked automatically).
-    2. In the **Callback URL(s)** field of the <span style="white-space: nowrap; font-weight:bold;">Sign in and sign out URLs</span> section, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch**. Here we’re using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">https://my-nginx-plus.example.com:443/_codexch</span>.
+    1. In the **Enabled&nbsp;Identity&nbsp;Providers** section, click the **Cognito&nbsp;User&nbsp;Pool** checkbox (the **Select all** box gets checked automatically).
+    2. In the **Callback URL(s)** field of the **Sign&nbsp;in&nbsp;and&nbsp;sign&nbsp;out&nbsp;URLs** section, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch**. Here we’re using **https://my&#8209;nginx&#8209;plus.example.com:443/_codexch**.
 
        **Notes:**
 
        - For production, we strongly recommend that you use SSL/TLS (port 443).
        - The port number is mandatory even when you're using the default port for HTTP (80) or HTTPS (443).
 
-    3. In the **OAuth 2.0** section, click the <span style="white-space: nowrap; font-weight:bold;">Authorization code grant</span> checkbox under <span style="white-space: nowrap; font-weight:bold;">Allowed OAuth Flows</span> and the **email**, **openid**, and **profile** checkboxes under <span style="white-space: nowrap; font-weight:bold;">Allowed OAuth Scopes</span>.
+    3. In the **OAuth 2.0** section, click the **Authorization&nbsp;code&nbsp;grant** checkbox under **Allowed&nbsp;OAuth&nbsp;Flows** and the **email**, **openid**, and **profile** checkboxes under **Allowed&nbsp;OAuth&nbsp;Scopes**.
     4. Click the <span style="background-color:#479bd4; color:white; white-space: nowrap;"> Save changes </span> button.
 
     <img src="/nginx/images/cognito-sso-config-app-client-settings-tab.png" alt="" width="1024" height="1181" class="aligncenter size-full wp-image-63783" />
 
     <span id="cognito-domain-name"></span>
-13. Click **Domain name** in the left navigation column. In the tab that opens, type a domain prefix in the **Domain prefix** field under <span style="white-space: nowrap; font-weight:bold;">Amazon Cognito domain</span> (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">my-nginx-plus</span>). Click the <span style="background-color:#479bd4; color:white; white-space: nowrap;"> Save changes </span> button.
+13. Click **Domain name** in the left navigation column. In the tab that opens, type a domain prefix in the **Domain prefix** field under **Amazon&nbsp;Cognito&nbsp;domain** (in this guide, **my&#8209;nginx&#8209;plus**). Click the <span style="background-color:#479bd4; color:white; white-space: nowrap;"> Save changes </span> button.
 
     <img src="/nginx/images/cognito-sso-config-domain-name-tab.png" alt="" width="1024" height="817" class="aligncenter size-full wp-image-63782" />
 
@@ -120,7 +120,7 @@ Create a new application for NGINX Plus in the Cognito GUI:
 
 Configure NGINX Plus as the OpenID Connect relying party:
 
-1. Create a clone of the [<span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span>](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
+1. Create a clone of the [**nginx&#8209;openid&#8209;connect**](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
 
    ```shell
    git clone https://github.com/nginxinc/nginx-openid-connect
@@ -135,12 +135,12 @@ Configure NGINX Plus as the OpenID Connect relying party:
    <span id="nginx-plus-variables"></span>
 3. In your preferred text editor, open **/etc/nginx/conf.d/frontend.conf**. Change the second parameter of each of the following [set](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html#set) directives to the specified value.
 
-   The `<My-Cognito-Domain-Name>` variable is the full value in the **Domain prefix** field in [Step 13 of _Configuring Amazon Cognito_](#cognito-domain-name). In this guide it is <span style="color:#666666; font-weight:bolder; white-space: nowrap;">https://my-nginx-plus.auth.us-east-2.amazoncognito.com</span>.
+   The `<My-Cognito-Domain-Name>` variable is the full value in the **Domain prefix** field in [Step 13 of _Configuring Amazon Cognito_](#cognito-domain-name). In this guide it is **https://my&#8209;nginx&#8209;plus.auth.us&#8209;east&#8209;2.amazoncognito.com**.
 
    - `set $oidc_authz_endpoint` – `<My-Cognito-Domain-Name>/oauth2/authorize`
    - `set $oidc_token_endpoint` – `<My-Cognito-Domain-Name>/oauth2/token`
-   - `set $oidc_client` – Value in the <span style="white-space: nowrap; font-weight:bold;">App client id</span> field from [Step 11 of _Configuring Amazon Cognito_](#cognito-app-client-id-secret) (in this guide, `2or4cs8bjo1lkbq6143tqp6ist`)
-   - `set $oidc_client_secret` – Value in the <span style="white-space: nowrap; font-weight:bold;">App client secret</span> field from [Step 11 of _Configuring Amazon Cognito_](#cognito-app-client-id-secret) (in this guide, `1k63m3nrcnu...`)
+   - `set $oidc_client` – Value in the **App&nbsp;client&nbsp;id** field from [Step 11 of _Configuring Amazon Cognito_](#cognito-app-client-id-secret) (in this guide, `2or4cs8bjo1lkbq6143tqp6ist`)
+   - `set $oidc_client_secret` – Value in the **App&nbsp;client&nbsp;secret** field from [Step 11 of _Configuring Amazon Cognito_](#cognito-app-client-id-secret) (in this guide, `1k63m3nrcnu...`)
    - `set $oidc_hmac_key` – A unique, long, and secure phrase
 
 4. Configure the JWK file. The file's URL is
@@ -154,7 +154,7 @@ Configure NGINX Plus as the OpenID Connect relying party:
 
    In this guide, the URL is
 
-   <span style="color:#666666; font-weight:bolder; white-space: nowrap;">https://cognito-idp.us-east-2.amazonaws.com/us-east-2_mLoGHJpOs/.well-known/jwks.json</span>.
+   **https://cognito&#8209;idp.us&#8209;east&#8209;2.amazonaws.com/us&#8209;east&#8209;2_mLoGHJpOs/.well&#8209;known/jwks.json**.
 
    The method for configuring the JWK file depends on which version of NGINX Plus you are using:
 
@@ -187,7 +187,7 @@ In a browser, enter the address of your NGINX Plus instance and try to log in u
 <span id="troubleshooting"></span>
 ## Troubleshooting
 
-See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the <span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span> repository on GitHub.
+See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the **nginx&#8209;openid&#8209;connect** repository on GitHub.
 
 ### Revision History
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/keycloak.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/keycloak.md
@@ -60,15 +60,15 @@ Create a Keycloak client for NGINX Plus in the Keycloak GUI:
    <span id="keycloak-client-id"></span>
 3. On the **Add Client** page that opens, enter or select these values, then click the <span style="background-color:#009edc; color:white;"> Save </span> button.
 
-   - **Client ID** – The name of the application for which you're enabling SSO (Keycloak refers to it as the “client”). Here we're using <span style="white-space: nowrap; color:#666666; font-weight:bolder;">NGINX-Plus</span>.
-   - **Client Protocol** – <span style="white-space: nowrap; color:#666666; font-weight:bolder;">openid-connect</span>.
+   - **Client ID** – The name of the application for which you're enabling SSO (Keycloak refers to it as the “client”). Here we're using **NGINX&#8209;Plus**.
+   - **Client Protocol** – **openid&#8209;connect**.
 
    <img src="/nginx/images/keycloak-add-client.png" alt="" width="1024" height="490" class="aligncenter size-full wp-image-62013" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
 4. On the **NGINX Plus** page that opens, enter or select these values on the <span style="color:#48a5e2;">Settings</span> tab:
 
-   - **Access Type** – <span style="color:#666666; font-weight:bolder;">confidential</span>
-   - **Valid Redirect URIs** – The URI of the NGINX Plus instance, including the port number, and ending in **/\_codexch** (in this guide it is <span style="color:#666666; font-weight:bolder; white-space: nowrap;">https://my-nginx.example.com:443/_codexch</span>)
+   - **Access Type** – **confidential**
+   - **Valid Redirect URIs** – The URI of the NGINX Plus instance, including the port number, and ending in **/\_codexch** (in this guide it is **https://my&#8209;nginx.example.com:443/_codexch**)
 
      **Notes:**
 
@@ -84,14 +84,14 @@ Create a Keycloak client for NGINX Plus in the Keycloak GUI:
 
 6. Click the <span style="color:#48a5e2;">Roles</span> tab, then click the **Add Role** button in the upper right corner of the page that opens.
 
-7. On the **Add Role** page that opens, type a value in the **Role Name** field (here it is <span style="white-space: nowrap; color:#666666; font-weight:bolder;">nginx-keycloak-role</span>) and click the <span style="background-color:#009edc; color:white;"> Save </span> button.
+7. On the **Add Role** page that opens, type a value in the **Role Name** field (here it is **nginx&#8209;keycloak&#8209;role**) and click the <span style="background-color:#009edc; color:white;"> Save </span> button.
 
    <img src="/nginx/images/keycloak-add-role.png" alt="" width="1024" height="480" class="aligncenter size-full wp-image-62006" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
 8. In the left navigation column, click **Users**. On the **Users** page that opens, either click the name of an existing user, or click the **Add user** button in the upper right corner to create a new user. For complete instructions, see the [Keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#user-management).
 
    <span id="keycloak-users"></span>
-9. On the management page for the user (here, <span style="color:#666666; font-weight:bolder;">user01</span>), click the <span style="white-space: nowrap; color:#48a5e2;">Role Mappings</span> tab. On the page that opens, select <span style="white-space: nowrap; color:#666666; font-weight:bolder;">NGINX-Plus</span> on the **Client Roles** drop‑down menu. Click <span style="white-space: nowrap; color:#666666; font-weight:bolder;">nginx-keycloak-role</span> in the **Available Roles** box, then click the **Add selected** button below the box. The role then appears in the **Assigned Roles** and **Effective Roles** boxes, as shown in the screenshot.
+9. On the management page for the user (here, **user01**), click the <span style="white-space: nowrap; color:#48a5e2;">Role Mappings</span> tab. On the page that opens, select **NGINX&#8209;Plus** on the **Client Roles** drop‑down menu. Click **nginx&#8209;keycloak&#8209;role** in the **Available Roles** box, then click the **Add selected** button below the box. The role then appears in the **Assigned Roles** and **Effective Roles** boxes, as shown in the screenshot.
 
    <img src="/nginx/images/keycloak-role-mappings-tab.png" alt="" width="1024" height="526" class="aligncenter size-full wp-image-62008" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
@@ -101,7 +101,7 @@ Create a Keycloak client for NGINX Plus in the Keycloak GUI:
 
 Configure NGINX Plus as the OpenID Connect relying party:
 
-1. Create a clone of the [<span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span>](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
+1. Create a clone of the [**nginx&#8209;openid&#8209;connect**](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
 
    ```shell
    git clone https://github.com/nginxinc/nginx-openid-connect
@@ -165,7 +165,7 @@ In a browser, enter the address of your NGINX Plus instance and try to log in u
 <span id="troubleshooting"></span>
 ## Troubleshooting
 
-See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the <span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span> repository on GitHub.
+See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the **nginx&#8209;openid&#8209;connect** repository on GitHub.
 
 ### Revision History
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/onelogin.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/onelogin.md
@@ -48,15 +48,15 @@ Create a new application for NGINX Plus in the OneLogin GUI:
 
    <img src="/nginx/images/onelogin-sso-add-app-button.png" alt="" width="1024" height="306" class="aligncenter size-full wp-image-62013" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-3. On the **Find Applications** page that opens, type <span style="color:#666666; font-weight:bolder; white-space: nowrap;">OpenID Connect</span> in the search box. Click on the **OpenID Connect (OIDC)** row that appears.
+3. On the **Find Applications** page that opens, type **OpenID&nbsp;Connect** in the search box. Click on the **OpenID Connect (OIDC)** row that appears.
 
    <img src="/nginx/images/onelogin-sso-find-applications-page.png" alt="" width="1024" height="344" class="aligncenter size-full wp-image-62012" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-4. On the **Add OpenId Connect (OIDC)** page that opens, change the value in the **Display Name** field to <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus</span> and click the <span style="white-space: nowrap; background-color:#1694c1; color:white;"> Save </span> button.
+4. On the **Add OpenId Connect (OIDC)** page that opens, change the value in the **Display Name** field to **NGINX&nbsp;Plus** and click the <span style="white-space: nowrap; background-color:#1694c1; color:white;"> Save </span> button.
 
    <img src="/nginx/images/onelogin-sso-add-oidc-page.png" alt="" width="1024" height="380" class="aligncenter size-full wp-image-62011" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
-5. When the save completes, a new set of choices appears in the left navigation bar. Click **Configuration**. In the **Redirect URI's** field, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch** (in this guide it is <span style="color:#666666; font-weight:bolder; white-space: nowrap;">https://my-nginx.example.com:443/_codexch</span>). Then click the <span style="white-space: nowrap; background-color:#1694c1; color:white;"> Save </span> button.
+5. When the save completes, a new set of choices appears in the left navigation bar. Click **Configuration**. In the **Redirect URI's** field, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch** (in this guide it is **https://my&#8209;nginx.example.com:443/_codexch**). Then click the <span style="white-space: nowrap; background-color:#1694c1; color:white;"> Save </span> button.
 
    **Notes:**
 
@@ -66,12 +66,12 @@ Create a new application for NGINX Plus in the OneLogin GUI:
    <img src="/nginx/images/onelogin-sso-configuration-tab.png" alt="" width="1024" height="576" class="aligncenter size-full wp-image-62010" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
    <span id="onelogin-client-id-secret"></span>
-6. When the save completes, click **SSO** in the left navigation bar. Click <span style="color:#1694c1; font-weight:bolder; white-space: nowrap;">Show client secret</span> below the **Client Secret** field. Record the values in the **Client ID** and **Client Secret** fields. You will add them to the NGINX Plus configuration in [Step 4 of _Configuring NGINX Plus_](#nginx-plus-variables).
+6. When the save completes, click **SSO** in the left navigation bar. Click **Show&nbsp;client&nbsp;secret** below the **Client Secret** field. Record the values in the **Client ID** and **Client Secret** fields. You will add them to the NGINX Plus configuration in [Step 4 of _Configuring NGINX Plus_](#nginx-plus-variables).
 
    <img src="/nginx/images/onelogin-sso-sso-tab.png" alt="" width="1024" height="449" class="aligncenter size-full wp-image-62009" style="border:2px solid #666666; padding:2px; margin:2px;" />
 
    <span id="onelogin-roles"></span>
-7. Assign users to the application (in this guide, <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus</span>) to enable them to access it for SSO. OneLogin recommends using [roles](https://onelogin.service-now.com/kb_view_customer.do?sysparm_article=KB0010606) for this purpose. You can access the **Roles** page under <span style="white-space: nowrap; background-color:#000000; color:white;"> Users </span> in the title bar.
+7. Assign users to the application (in this guide, **NGINX&nbsp;Plus**) to enable them to access it for SSO. OneLogin recommends using [roles](https://onelogin.service-now.com/kb_view_customer.do?sysparm_article=KB0010606) for this purpose. You can access the **Roles** page under <span style="white-space: nowrap; background-color:#000000; color:white;"> Users </span> in the title bar.
 
    <img src="/nginx/images/onelogin-sso-roles-page.png" alt="" width="1024" height="275" class="aligncenter size-full wp-image-62006" style="border:2px solid #666666; padding:2px; margin:2px;" />
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/ping-identity.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/ping-identity.md
@@ -56,30 +56,30 @@ Create a new application for NGINX Plus:
 
 1. Log in to your Ping Identity account. The administrative dashboard opens automatically. In this guide, we show the PingOne for Enterprise dashboard, and for brevity refer simply to ”PingOne”.
 
-2. Click <span style="white-space: nowrap; background-color:#595f66; color:white"> APPLICATIONS </span> in the title bar, and on the **My Applications** page that opens, click **OIDC** and then the <span style="white-space: nowrap; font-weight:bold;">+ Add Application</span> button.
+2. Click <span style="white-space: nowrap; background-color:#595f66; color:white"> APPLICATIONS </span> in the title bar, and on the **My Applications** page that opens, click **OIDC** and then the **+&nbsp;Add&nbsp;Application** button.
 
    <img src="/nginx/images/pingidentity-sso-my-applications-empty.png" alt="" width="1024" height="355" class="aligncenter size-full" />
 
-3. The <span style="white-space: nowrap; font-weight:bold;">Add OIDC Application</span> window pops up. Click the <span style="white-space: nowrap; color:#4a95c7;">ADVANCED CONFIGURATION</span> box, and then the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
+3. The **Add&nbsp;OIDC&nbsp;Application** window pops up. Click the <span style="white-space: nowrap; color:#4a95c7;">ADVANCED CONFIGURATION</span> box, and then the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
 
    <img src="/nginx/images/pingidentity-sso-add-oidc-application.png" alt="" width="956" height="662" class="aligncenter size-full" />
 
-4. In section 1 (PROVIDE DETAILS ABOUT YOUR APPLICATION), type a name in the **APPLICATION NAME** field and a short description in the **SHORT DESCRIPTION** field. Here, we're using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">nginx-plus-application</span> and <span style="color:#666666; font-weight:bolder; white-space: nowrap;">NGINX Plus</span>. Choose a value from the **CATEGORY** drop‑down menu; here we’re using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Information Technology</span>. You can also add an icon if you wish. Click the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
+4. In section 1 (PROVIDE DETAILS ABOUT YOUR APPLICATION), type a name in the **APPLICATION NAME** field and a short description in the **SHORT DESCRIPTION** field. Here, we're using **nginx&#8209;plus&#8209;application** and **NGINX&nbsp;Plus**. Choose a value from the **CATEGORY** drop‑down menu; here we’re using **Information&nbsp;Technology**. You can also add an icon if you wish. Click the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
 
    <img src="/nginx/images/pingidentity-sso-section1.png" alt="" width="954" height="665" class="aligncenter size-full" />
 
 5. In section 2 (AUTHORIZATION SETTINGS), perform these steps:
 
-   1. Under **GRANTS**, click both <span style="color:#666666; font-weight:bolder; white-space: nowrap;">Authorization Code</span> and <span style="color:#666666; font-weight:bolder;">Implicit</span>.<br/>
-   2. Under **CREDENTIALS**, click the <span style="white-space: nowrap; font-weight:bold;">+ Add Secret</span> button. PingOne creates a client secret and opens the **CLIENT SECRETS** field to display it, as shown in the screenshot. To see the actual value of the secret, click the eye icon.<br/>
+   1. Under **GRANTS**, click both **Authorization&nbsp;Code** and **Implicit**.<br/>
+   2. Under **CREDENTIALS**, click the **+&nbsp;Add&nbsp;Secret** button. PingOne creates a client secret and opens the **CLIENT SECRETS** field to display it, as shown in the screenshot. To see the actual value of the secret, click the eye icon.<br/>
    3.	Click the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
 
    <img src="/nginx/images/pingidentity-sso-section2.png" alt="" width="959" height="1054" class="aligncenter size-full" />
 
 6. In section 3 (SSO FLOW AND AUTHENTICATION SETTINGS):
 
-   1. In the <span style="white-space: nowrap; font-weight:bold;">START SSO URL</span> field, type the URL where users access your application. Here we’re using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">https://example.com</span>.
-   2. In the **REDIRECT URIS** field, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch**. Here we’re using <span style="color:#666666; font-weight:bolder; white-space: nowrap;">https://my-nginx-plus.example.com:443/\_codexch</span> (the full value is not visible in the screenshot).
+   1. In the **START&nbsp;SSO&nbsp;URL** field, type the URL where users access your application. Here we’re using **https://example.com**.
+   2. In the **REDIRECT URIS** field, type the URI of the NGINX Plus instance including the port number, and ending in **/\_codexch**. Here we’re using **https://my&#8209;nginx&#8209;plus.example.com:443/\_codexch** (the full value is not visible in the screenshot).
 
       **Notes:**
 
@@ -88,34 +88,34 @@ Create a new application for NGINX Plus:
 
    <img src="/nginx/images/pingidentity-sso-section3.png" alt="" width="1024" height="781" class="aligncenter size-full" />
 
-7. In section 4 (DEFAULT USER PROFILE ATTRIBUTE CONTRACT), optionally add attributes to the required <span style="color:#666666; font-weight:bolder;">sub</span> and <span style="color:#666666; font-weight:bolder;">idpid</span> attributes, by clicking the <span style="white-space: nowrap; font-weight:bold;">+ Add Attribute</span> button. We’re not adding any in this example. When finished, click the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
+7. In section 4 (DEFAULT USER PROFILE ATTRIBUTE CONTRACT), optionally add attributes to the required **sub** and **idpid** attributes, by clicking the **+&nbsp;Add&nbsp;Attribute** button. We’re not adding any in this example. When finished, click the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
 
    <img src="/nginx/images/pingidentity-sso-section4.png" alt="" width="1024" height="532" class="aligncenter size-full" />
 
-8. In section 5 (CONNECT SCOPES), click the circled plus-sign on the <span style="white-space: nowrap; font-weight:bold;">OpenID Profile (profile)</span> and <span style="white-space: nowrap; font-weight:bold;">OpenID Profile Email (email)</span> scopes in the <span style="white-space: nowrap; font-weight:bold;">LIST OF SCOPES</span> column. They are moved to the **CONNECTED SCOPES** column, as shown in the screenshot. Click the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
+8. In section 5 (CONNECT SCOPES), click the circled plus-sign on the **OpenID&nbsp;Profile&nbsp;(profile)** and **OpenID&nbsp;Profile&nbsp;Email&nbsp;(email)** scopes in the **LIST&nbsp;OF&nbsp;SCOPES** column. They are moved to the **CONNECTED SCOPES** column, as shown in the screenshot. Click the <span style="background-color:#4a95c7; color:white;"> Next </span> button.
 
    <img src="/nginx/images/pingidentity-sso-section5.png" alt="" width="960" height="451" class="aligncenter size-full" />
 
-9. In section 6 (ATTRIBUTE MAPPING), map attributes from your identity repository to the claims available to the application. The one attribute you must map is **sub**, and here we have selected the value <span style="color:#666666; font-weight:bolder;">Email</span> from the drop‑down menu (the screenshot is abridged for brevity).
+9. In section 6 (ATTRIBUTE MAPPING), map attributes from your identity repository to the claims available to the application. The one attribute you must map is **sub**, and here we have selected the value **Email** from the drop‑down menu (the screenshot is abridged for brevity).
 
    <img src="/nginx/images/pingidentity-sso-section6.png" alt="" width="959" height="863" class="aligncenter size-full" />
 
    <span id="ping-group-access"></span>
-10. In section 7 (GROUP ACCESS), select the groups that will have access to the application, by clicking the circled plus-sign on the corresponding boxes in the **AVAILABLE GROUPS** column. The boxes move to the **ADDED GROUPS** column. As shown in the screenshot we have selected the two default groups, <span style="color:#666666; font-weight:bolder;">Domain Administrators@directory</span> and <span style="color:#666666; font-weight:bolder;">Users@directory</span>.
+10. In section 7 (GROUP ACCESS), select the groups that will have access to the application, by clicking the circled plus-sign on the corresponding boxes in the **AVAILABLE GROUPS** column. The boxes move to the **ADDED GROUPS** column. As shown in the screenshot we have selected the two default groups, **Domain Administrators@directory** and **Users@directory**.
 
     Click the <span style="background-color:#4fb97a; color:white;"> Done </span> button.
 
     <img src="/nginx/images/pingidentity-sso-section7.png" alt="" width="959" height="516" class="aligncenter size-full" />
 
-11. You are returned to the **My Applications** window, which now includes a row for <span style="white-space: nowrap; font-weight:bold;">nginx-plus-application</span>. Click the toggle switch at the right end of the row to the “on” position, as shown in the screenshot. Then click the “expand” icon at the end of the row, to display the application’s details.
+11. You are returned to the **My Applications** window, which now includes a row for **nginx&#8209;plus&#8209;application**. Click the toggle switch at the right end of the row to the “on” position, as shown in the screenshot. Then click the “expand” icon at the end of the row, to display the application’s details.
 
     <img src="/nginx/images/pingidentity-sso-my-applications-new-app.png" alt="" width="1024" height="408" class="aligncenter size-full" />
 
     <span id="ping-client-id-secrets"></span>
 12. On the page that opens, make note of the values in the following fields on the **Details** tab. You will add them to the NGINX Plus configuration in [Step 4 of _Configuring NGINX Plus_](#nginx-plus-variables).
 
-    - **CLIENT ID** (in the screenshot, <span style="white-space: nowrap; color:#666666; font-weight:bolder;">28823604-83c5-4608-88da-c73fff9c607a</span>)
-    - **CLIENT SECRETS** (in the screenshot, <span style="white-space: nowrap; color:#666666; font-weight:bolder;">7GMKILBofxb...</span>); click on the eye icon to view the actual value
+    - **CLIENT ID** (in the screenshot, **28823604&#8209;83c5&#8209;4608&#8209;88da&#8209;c73fff9c607a**)
+    - **CLIENT SECRETS** (in the screenshot, **7GMKILBofxb...**); click on the eye icon to view the actual value
 
     <img src="/nginx/images/pingidentity-sso-my-applications-details.png" alt="" width="1024" height="963" class="aligncenter size-full" />
 
@@ -124,7 +124,7 @@ Create a new application for NGINX Plus:
 
 Configure NGINX Plus as the OpenID Connect relying party:
 
-1. Create a clone of the [<span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span>](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
+1. Create a clone of the [**nginx&#8209;openid&#8209;connect**](https://github.com/nginxinc/nginx-openid-connect) GitHub repository.
 
    ```shell
    git clone https://github.com/nginxinc/nginx-openid-connect
@@ -190,7 +190,7 @@ In a browser, enter the address of your NGINX Plus instance and try to log in u
 <span id="troubleshooting"></span>
 ## Troubleshooting
 
-See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the <span style="white-space: nowrap; font-weight:bold;">nginx-openid-connect</span> repository on GitHub.
+See the [**Troubleshooting**](https://github.com/nginxinc/nginx-openid-connect#troubleshooting) section at the **nginx&#8209;openid&#8209;connect** repository on GitHub.
 
 ### Revision History
 


### PR DESCRIPTION
### Proposed changes

This PR removes `<span>` tags that were used for bolding and non-breaking spaces and hyphens -- and replaces them with standard Markdown formatting.