### PR TITLE
Add http_auth_jwt module to cryptographic boundary definition within 'NGINX Plus FIPS Compliance' document

### DIFF
--- a/content/nginx/fips-compliance-nginx-plus.md
+++ b/content/nginx/fips-compliance-nginx-plus.md
@@ -31,7 +31,7 @@ This statement uses the following terms:
 
 - **Cryptographic module**: The OpenSSL software, comprised of libraries of FIPS‑validated algorithms that can be used by other applications.
 
-- **Cryptographic boundary**: The operational functions that use FIPS‑validated algorithms. For NGINX Plus, the cryptographic boundary includes all functionality that is implemented by the [http_ssl](http://nginx.org/en/docs/http/ngx_http_ssl_module.html), [http_v2](http://nginx.org/en/docs/http/ngx_http_v2_module.html), [stream_ssl](http://nginx.org/en/docs/stream/ngx_stream_ssl_module.html), and [mail_ssl](http://nginx.org/en/docs/mail/ngx_mail_ssl_module.html) modules. These modules implement SSL and TLS operations for inbound and outbound connections which use HTTP, HTTP/2, TCP, and mail protocols.
+- **Cryptographic boundary**: The operational functions that use FIPS‑validated algorithms. For NGINX Plus, the cryptographic boundary includes all functionality that is implemented by the [http_ssl](http://nginx.org/en/docs/http/ngx_http_ssl_module.html), [http_v2](http://nginx.org/en/docs/http/ngx_http_v2_module.html), [stream_ssl](http://nginx.org/en/docs/stream/ngx_stream_ssl_module.html), [mail_ssl](http://nginx.org/en/docs/mail/ngx_mail_ssl_module.html), and [http_auth_jwt](http://nginx.org/en/docs/http/ngx_http_auth_jwt_module.html) modules. These modules implement SSL and TLS operations for inbound and outbound connections which use HTTP, HTTP/2, TCP, and mail protocols.
 
 - **NGINX Plus**: The NGINX Plus software application developed by NGINX, Inc. and delivered in binary format from NGINX servers.
 


### PR DESCRIPTION
### Proposed changes

Problem: The cryptographic boundary definition within the 'NGINX Plus FIPS Compliance' document does not include the http_auth_jwt module. This leads to concern that the operational function of the http_auth_jwt module is not fips compliance.

Solution: Add the http_auth_jwt module to the cryptographic boundary definition within the 'NGINX Plus FIPS compliance' document.

Testing: NA

Closes service console case 00857454 - https://f5.lightning.force.com/lightning/r/Case/500Po00000rGPaRIAW/view
