### PR TITLE
NGF: Fix small link to subsection

### DIFF
--- a/content/includes/ngf/installation/nginx-plus/docker-registry-secret.md
+++ b/content/includes/ngf/installation/nginx-plus/docker-registry-secret.md
@@ -2,7 +2,7 @@
 docs: "DOCS-000"
 ---
 
-{{< note >}} If you would rather pull the NGINX Plus image and push to a private registry, you can skip this specific step and instead follow [this step]({{< ref "/ngf/install/nginx-plus.md#pulling-an-image-for-local-use" >}}). {{< /note >}}
+{{< note >}} If you would rather pull the NGINX Plus image and push to a private registry, you can skip this specific step and instead follow [this step]({{< ref "/ngf/install/nginx-plus.md#pull-an-image-for-local-use" >}}). {{< /note >}}
 
 If the `nginx-gateway` namespace does not yet exist, create it:
 


### PR DESCRIPTION
Fix small link to subsection.

Subsection in question: https://docs.nginx.com/nginx-gateway-fabric/installation/nginx-plus-jwt/#pull-an-image-for-local-use