### PR TITLE
Moved slack notification direct into job instead of dispatch for security

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -79,16 +79,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions: read-all
     steps:
-      - name: Trigger 'Slack notification for new theme release' workflow in 'nginx-hugo-theme' repo.
-        run: |
-           curl -L \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.THEME_SLACK_FLOW_PAT }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${{ secrets.OWNER }}/${{ secrets.REPO }}/dispatches" \
-              -d "{\"event_type\": \"trigger-slack-notification\", \"client_payload\": {\"previewURL\": \"${{ env.PREVIEW_URL }}\",  \"author\": \"${{ github.event.client_payload.author}}\", \"tag_name\": \"${{ github.event.client_payload.tag_name }}\", \"release_name\": \"${{ github.event.client_payload.release_name }}\"}}"
+      - name: Send notification
+        uses:  8398a7/action-slack@1750b5085f3ec60384090fb7c52965ef822e869e # v3.18.0
+        with: 
+          status: custom
+          custom_payload: |
+            {
+                username: 'Github',
+                mention: 'channel',
+                attachments: [{
+                  title: `New theme release - ${{ github.event.client_payload.release_name }}`,
+                  color: '#009223',
+                  fields: [
+                  {
+                    title: 'Tag',
+                    value: ${{ github.event.client_payload.tag_name }},
+                    short: true
+                  },
+                  {
+                    title: 'Author',
+                    value: ${{ github.event.client_payload.author }},
+                    short: true
+                  },
+                  {
+                    title: 'Preview URL',
+                    value: ${{ env.PREVIEW_URL }},
+                    short: true
+                  }]
+                }]
+            }
     env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_FRIENDS_OF_DOCS }}
       PREVIEW_URL: ${{ needs.call-docs-build-push.outputs.PREVIEW_URL }}
 
 


### PR DESCRIPTION
Moved the slack code to `documentation` repo to reduce threat vector from repo dispatch.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have rebased my branch onto main
- [x] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [x] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have ensured that documentation content adheres to [the style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md)
- [x] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] I have ensured that existing tests pass after adding my changes
- [x] If applicable, I have updated [`README.md`](https://github.com/nginx/documentation/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/documentation/blob/main/CHANGELOG.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](https://github.com/nginx/documentation/blob/main/templates/style-guide.md) for guidance about placeholder content.