### PR TITLE
Remove external nic sitemap ref

### DIFF
--- a/static/sitemap_index.xml
+++ b/static/sitemap_index.xml
@@ -4,9 +4,6 @@
       <loc>https://docs.nginx.com/sitemap.xml</loc>
     </sitemap>
     <sitemap>
-      <loc>https://docs.nginx.com/nginx-ingress-controller/sitemap.xml</loc>
-    </sitemap>
-    <sitemap>
       <loc>https://unit.nginx.org/sitemap.xml</loc>
     </sitemap>
   </sitemapindex>


### PR DESCRIPTION
Remove external nic sitemap ref. This allows coveo to properly update it's index, now that nic is part of the `documentation` repo.