### PR TITLE
Fix: Root urls in nic need nginx-ingress-controller prefix

### DIFF
--- a/content/nic/configuration/_index.md
+++ b/content/nic/configuration/_index.md
@@ -1,4 +1,5 @@
 ---
 title: Configuration
 weight: 1400
+url: /nginx-ingress-controller/configuration
 ---

--- a/content/nic/installation/_index.md
+++ b/content/nic/installation/_index.md
@@ -2,6 +2,7 @@
 title: Installation
 description:
 weight: 400
+url: /nginx-ingress-controller/installation
 menu:
   docs:
     parent: NGINX Ingress Controller

--- a/content/nic/logging-and-monitoring/_index.md
+++ b/content/nic/logging-and-monitoring/_index.md
@@ -2,6 +2,7 @@
 title: Logging And Monitoring
 description:
 weight: 1500
+url: /nginx-ingress-controller/logging-and-monitoring
 menu:
   docs:
     parent: NGINX Ingress Controller

--- a/content/nic/overview/_index.md
+++ b/content/nic/overview/_index.md
@@ -2,6 +2,7 @@
 title: Overview
 description:
 weight: 100
+url: /nginx-ingress-controller/overview
 menu:
   docs:
     parent: NGINX Ingress Controller

--- a/content/nic/troubleshooting/_index.md
+++ b/content/nic/troubleshooting/_index.md
@@ -2,6 +2,7 @@
 title: Troubleshooting
 description:
 weight: 1800
+url: /nginx-ingress-controller/troubleshooting
 menu:
   docs:
     parent: NGINX Ingress Controller


### PR DESCRIPTION
Fix: Root urls in nic need nginx-ingress-controller prefix. This were previously defaulting to `nic` instead of `nginx-ingress-controller`, as it matched the directory name without a specific url.