### PR TITLE
feat: Add sni related config options to jwt policy

### DIFF
--- a/content/nic/configuration/policy-resource.md
+++ b/content/nic/configuration/policy-resource.md
@@ -419,12 +419,14 @@ This feature is implemented using the NGINX Plus directive [auth_jwt_key_request
 {{< /note >}}
 
 {{% table %}}
-|Field | Description | Type | Required |
-| ---| ---| ---| --- |
-|``jwksURI`` | The remote URI where the request will be sent to retrieve JSON Web Key set| ``string`` | Yes |
-|``keyCache`` | Enables in-memory caching of JWKS (JSON Web Key Sets) that are obtained from the ``jwksURI`` and sets a valid time for expiration. | ``string`` | Yes |
-|``realm`` | The realm of the JWT. | ``string`` | Yes |
-|``token`` | The token specifies a variable that contains the JSON Web Token. By default the JWT is passed in the ``Authorization`` header as a Bearer Token. JWT may be also passed as a cookie or a part of a query string, for example: ``$cookie_auth_token``. Accepted variables are ``$http_``, ``$arg_``, ``$cookie_``. | ``string`` | No |
+|Field | Description | Type | Required | Default |
+| ---| ---| ---| --- | --- |
+|``jwksURI`` | The remote URI where the request will be sent to retrieve JSON Web Key set| ``string`` | Yes | -- |
+|``keyCache`` | Enables in-memory caching of JWKS (JSON Web Key Sets) that are obtained from the ``jwksURI`` and sets a valid time for expiration. | ``string`` | Yes | -- |
+|``realm`` | The realm of the JWT. | ``string`` | Yes | -- |
+|``token`` | The token specifies a variable that contains the JSON Web Token. By default the JWT is passed in the ``Authorization`` header as a Bearer Token. JWT may be also passed as a cookie or a part of a query string, for example: ``$cookie_auth_token``. Accepted variables are ``$http_``, ``$arg_``, ``$cookie_``. | ``string`` | No | -- |
+|``sniEnabled`` | Enables SNI (Server Name Indication) for the JWT policy. This is useful when the remote server requires SNI to serve the correct certificate. | ``bool`` | No | `false` |
+|``sniName`` | The SNI name to use when connecting to the remote server. If not set, the hostname from the ``jwksURI`` will be used. | ``string`` | No | -- |
 {{% /table %}}
 
 {{< note >}}


### PR DESCRIPTION
### Proposed changes

Adds two new configuration options to the NIC / jwt policy options: `sniEnabled` and `sniName`.

Functionality PR for the underlying code is https://github.com/nginx/kubernetes-ingress/pull/7993.

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [x] I have rebased my branch onto main
- [x] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [x] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have ensured that documentation content adheres to [the style guide](/documentation/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](/README.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](/documentation/style-guide.md) for guidance about placeholder content.