### PR TITLE
feat: adds helm docs for startup probe in NIC

### DIFF
--- a/content/nic/installation/installing-nic/installation-with-helm.md
+++ b/content/nic/installation/installing-nic/installation-with-helm.md
@@ -432,6 +432,14 @@ The following tables lists the configurable parameters of the NGINX Ingress Cont
 | **controller.readyStatus.enable** | Enables the readiness endpoint `"/nginx-ready"`. The endpoint returns a success code when NGINX has loaded all the config after the startup. This also configures a readiness probe for the Ingress Controller pods that uses the readiness endpoint. | true |
 | **controller.readyStatus.port** | The HTTP port for the readiness endpoint. | 8081 |
 | **controller.readyStatus.initialDelaySeconds** | The number of seconds after the Ingress Controller pod has started before readiness probes are initiated. | 0 |
+| **controller.startupStatus.enable** | Enables the startup probe for the Ingress Controller. | false |
+| **controller.startupStatus.port** | The port where the startup endpoint is exposed. This is a required field if `controller.startupStatus.enable` is set to true. | N/A |
+| **controller.startupStatus.path** | The path to the startup endpoint. This is a required field if `controller.startupStatus.enable` is set to true. | N/A |
+| **controller.startupStatus.initialDelaySeconds** | The number of seconds after the Ingress Controller pod has started before startup probes are initiated. | N/A |
+| **controller.startupStatus.periodSeconds** | The number of seconds between each startup probe. | N/A |
+| **controller.startupStatus.timeoutSeconds** | The number of seconds after which the startup probe times out. | N/A |
+| **controller.startupStatus.successThreshold** | Minimum consecutive successes for the probe to be considered successful. | N/A |
+| **controller.startupStatus.failureThreshold** | When a probe fails, Kubernetes will try failureThreshold times before giving up. | N/A |
 | **controller.enableLatencyMetrics** | Enable collection of latency metrics for upstreams. Requires `prometheus.create`. | false |
 | **controller.minReadySeconds** | Specifies the minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available. [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) | 0 |
 | **controller.autoscaling.enabled** | Enables HorizontalPodAutoscaling. | false |


### PR DESCRIPTION
### Proposed changes

- Add helm documentation for the feature implemented in https://github.com/nginx/kubernetes-ingress/pull/8011

Problem: Give a brief overview of the problem or feature being addressed.

Solution: Explain the approach you took to implement the solution, highlighting any significant design decisions or
considerations.

Testing: Describe any testing that you did.

Please focus on (optional): If you any specific areas where you would like reviewers to focus their attention or provide
specific feedback, add them here.

If this PR addresses an [issue](https://github.com/nginx/documentation/issues) on GitHub, ensure that you link to it here:

Closes #ISSUE

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [x] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have rebased my branch onto main
- [ ] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [x] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] I have ensured that documentation content adheres to [the style guide](/documentation/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](/README.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](/documentation/style-guide.md) for guidance about placeholder content.