### PR TITLE
fix: replace incorrect 'NGINX One' labels with 'NGINX One Console' where appropriate

### DIFF
--- a/content/agent/installation-upgrade/container-environments/docker-images.md
+++ b/content/agent/installation-upgrade/container-environments/docker-images.md
@@ -116,7 +116,7 @@ docker run --name nginx-agent -d nginx-agent
 
 ### Enable the gRPC interface
 
-To connect your NGINX Agent container to your NGINX One or NGINX Instance Manager instance, you must enable the gRPC interface. To do this, you must edit the NGINX Agent configuration file, *nginx-agent.conf*. For example:
+To connect your NGINX Agent container to your NGINX One Console or NGINX Instance Manager instance, you must enable the gRPC interface. To do this, you must edit the NGINX Agent configuration file, *nginx-agent.conf*. For example:
 
 ```yaml
 server:

--- a/content/includes/agent/architecture.md
+++ b/content/includes/agent/architecture.md
@@ -8,7 +8,7 @@ files:
 The figure shows:
 
 - An NGINX instance running on bare metal, virtual machine or container
-- NGINX One Cloud Console includes:
+- NGINX One Console includes:
 
   - Command Server to manage NGINX configurations, push new/updated configuration files remotely, and perform integrity tests.
   - OpenTelemetry (OTel) Receiver that receives observability data from connected Agent instances.
@@ -16,7 +16,7 @@ The figure shows:
 - An NGINX Agent process running on the NGINX instance. NGINX Agent is responsible for:
 
   - Watching, applying, validating, automatically roll back to last good configuration if issues are detected.
-  - Embedding an OpenTelemetry Collector, collecting metrics from NGINX processes, host system performance data, then securely passing metric data to NGINX One Cloud Console.
+  - Embedding an OpenTelemetry Collector, collecting metrics from NGINX processes, host system performance data, then securely passing metric data to NGINX One Console.
 
 - Collection and monitoring of host metrics (CPU usage, Memory utilization, Disk I/O) by the Agent OTel collector.
-- Collected data is made available on NGINX One Cloud Console for monitoring, alerting, troubleshooting, and capacity planning purposes.
+- Collected data is made available on NGINX One Console for monitoring, alerting, troubleshooting, and capacity planning purposes.

--- a/content/includes/nginx-one/add-file/new-ssl-bundle.md
+++ b/content/includes/nginx-one/add-file/new-ssl-bundle.md
@@ -4,8 +4,8 @@ docs:
 
 First you can select the toggle to allow NGINX One Console to manage the new certificate or bundle.
 
-In the screen that appears, you can add a certificate name. If you don't add a name, NGINX One will add a name for you, based on the expiration date for the certificate.
-
+In the screen that appears, you can add a certificate name. If you don't add a name, NGINX One Console will add a name for you, based on the expiration date for the certificate.   
+<!-- review this  -->
 You can add certificates in the following formats:
 
 - **SSL Certificate and Key**

--- a/content/includes/use-cases/monitoring/n1c-dashboard-overview.md
+++ b/content/includes/use-cases/monitoring/n1c-dashboard-overview.md
@@ -15,10 +15,10 @@ Navigating the dashboard:
 </span>
 
 {{<bootstrap-table "table table-striped table-bordered">}}
-**NGINX One dashboard metrics**
+**NGINX One Console dashboard metrics**
 | Metric | Description | Details |
 |---|---|---|
-| <i class="fas fa-heartbeat"></i> **Instance availability** | Understand the operational status of your NGINX instances. | - **Online**: The NGINX instance is actively connected and functioning properly. <br> - **Offline**: NGINX Agent is connected but the NGINX instance isn't running, isn't installed, or can't communicate with NGINX Agent. <br> - **Unavailable**: The connection between NGINX Agent and NGINX One has been lost or the instance has been decommissioned. <br> - **Unknown**: The current state can't be determined at the moment. |
+| <i class="fas fa-heartbeat"></i> **Instance availability** | Understand the operational status of your NGINX instances. | - **Online**: The NGINX instance is actively connected and functioning properly. <br> - **Offline**: NGINX Agent is connected but the NGINX instance isn't running, isn't installed, or can't communicate with NGINX Agent. <br> - **Unavailable**: The connection between NGINX Agent and NGINX One Console has been lost or the instance has been decommissioned. <br> - **Unknown**: The current state can't be determined at the moment. |
 | <i class="fas fa-code-branch"></i> **NGINX versions by instance** | See which NGINX versions are in use across your instances. | |
 | <i class="fas fa-desktop"></i> **Operating systems** | Find out which operating systems your instances are running on. | |
 | <i class="fas fa-certificate"></i> **Certificates** | Monitor the status of your SSL certificates to know which are expiring soon and which are still valid. | |

--- a/content/mesh/releases/release-notes-0.9.0.md
+++ b/content/mesh/releases/release-notes-0.9.0.md
@@ -2,7 +2,7 @@
 title: Release Notes 0.9.0
 draft: false
 toc: true
-description: Release information for F5 GINX Service Mesh, a configurable, low‑latency
+description: Release information for F5 NGINX Service Mesh, a configurable, low‑latency
   infrastructure layer designed to handle a high volume of network‑based interprocess
   communication among application infrastructure services using application programming
   interfaces (APIs).  Lists of new features and known issues are provided.

--- a/content/nginx-one/agent/metrics/configure-otel-metrics.md
+++ b/content/nginx-one/agent/metrics/configure-otel-metrics.md
@@ -27,7 +27,7 @@ You can validate that metrics are successfully exported by using the methods bel
 
 - **NGINX One dashboard**
 
-   - When an instance has connected to NGINX One Console [See: Connect to NGINX One Console]({{< ref "/nginx-one/connect-instances/add-instance.md" >}}), you should see metrics showing on the NGINX One Dashboard.
+   - When an instance has connected to NGINX One Console [See: Connect to NGINX One Console]({{< ref "/nginx-one/connect-instances/add-instance.md" >}}), you should see metrics showing on the NNGINX One Console Dashboard.
 
 - **Agent logs**
 


### PR DESCRIPTION
Reviewed multiple documentation files and replaced instances of "NGINX One" with "NGINX One Console" where appropriate—specifically when referring to the management interface or API


Testing:

         ------Verified that all changes are in Markdown content only
         ------No structural or logic-level changes were made