### PR TITLE
Add JWT license deployment steps for Config Sync Groups; clarify NIM instance group support

### DIFF
--- a/content/includes/licensing-and-reporting/apply-jwt.md
+++ b/content/includes/licensing-and-reporting/apply-jwt.md
@@ -5,8 +5,12 @@ file:
   - content/nap-waf/v5/admin-guide/install.md
 ---
 
-1. Copy the license file to `/etc/nginx/license.jwt` on Linux or `/usr/local/etc/nginx/license.jwt` on FreeBSD for each NGINX Plus instance.
-2. Reload NGINX:
+1. Copy the license file to:
+
+   - `/etc/nginx/license.jwt` on Linux
+   - `/usr/local/etc/nginx/license.jwt` on FreeBSD
+
+1. Reload NGINX:
 
    ```shell
    systemctl reload nginx

--- a/content/includes/licensing-and-reporting/deploy-jwt-with-csgs.md
+++ b/content/includes/licensing-and-reporting/deploy-jwt-with-csgs.md
@@ -6,7 +6,7 @@ file:
 
 1. In the NGINX One Console, go to **Manage > Config Sync Groups**, then select your group.
    
-   If you haven't created a Config Sync Group yet, see [Manage Config Sync Groups](https://docs.nginx.com/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups/) for setup instructions.
+   If you haven't created a Config Sync Group yet, see [Manage Config Sync Groups]({{< ref "/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups.md" >}}) for setup instructions.
 2. Select the **Configuration** tab, then choose **Edit Configuration**.
 3. Select **Add File**, then choose **New Configuration File**.
 4. In the **File name** field, enter:

--- a/content/includes/licensing-and-reporting/deploy-jwt-with-csgs.md
+++ b/content/includes/licensing-and-reporting/deploy-jwt-with-csgs.md
@@ -1,0 +1,17 @@
+---
+docs:
+file:
+  - content/solutions/about-subscription-licenses.md
+---
+
+1. In the NGINX One Console, go to **Manage > Config Sync Groups**, then select your group.
+   
+   If you haven't created a Config Sync Group yet, see [Manage Config Sync Groups](https://docs.nginx.com/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups/) for setup instructions.
+2. Select the **Configuration** tab, then choose **Edit Configuration**.
+3. Select **Add File**, then choose **New Configuration File**.
+4. In the **File name** field, enter:
+   - On Linux: `/etc/nginx/license.jwt`  
+   - On FreeBSD: `/usr/local/etc/nginx/license.jwt`  
+   The name must be exact.
+5. Paste the contents of your JWT license file into the editor.
+6. Select **Next** to preview the diff, then **Save and Publish** to apply the update.

--- a/content/solutions/about-subscription-licenses.md
+++ b/content/solutions/about-subscription-licenses.md
@@ -58,7 +58,7 @@ Each method ensures your NGINX Plus instances have access to the required licens
 
 ### Deploy with a Config Sync Group (Recommended)
 
-If you're using the [NGINX One Console]({{< ref "/nginx-one/getting-started.md" >}}), the easiest way to manage your JWT license is with a [Config Sync Group](https://docs.nginx.com/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups/). This method lets you:
+If you're using the [NGINX One Console]({{< ref "/nginx-one/getting-started.md" >}}), the easiest way to manage your JWT license is with a [Config Sync Group]({{< ref "/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups.md" >}}). This method lets you:
 
 - Avoid manual file copying
 - Keep your fleet consistent

--- a/content/solutions/about-subscription-licenses.md
+++ b/content/solutions/about-subscription-licenses.md
@@ -16,6 +16,10 @@ Starting with NGINX Plus R33, all **NGINX Plus instances require a valid JSON We
 
 ## Important changes
 
+If you have multiple subscriptions, you’ll also have multiple JWT licenses. You can assign each NGINX Plus instance to the license you prefer. NGINX combines usage reporting across all licensed instances.
+
+This feature is available in NGINX Instance Manager 2.20 and later.
+
 ### NGINX Plus won't start if:
 
 - The JWT license is missing or invalid.

--- a/content/solutions/about-subscription-licenses.md
+++ b/content/solutions/about-subscription-licenses.md
@@ -14,14 +14,14 @@ We’re updating NGINX Plus to align with F5’s entitlement and visibility poli
 
 Starting with NGINX Plus R33, all **NGINX Plus instances require a valid JSON Web Token (JWT) license**. This license is tied to your subscription (not individual instances) and is used to validate your subscription and automatically send usage reports to F5's licensing endpoint (`product.connect.nginx.com`), as required by your subscription agreement. In offline environments, usage reporting is [routed through NGINX Instance Manager]({{< ref "nim/disconnected/report-usage-disconnected-deployment.md" >}}).
 
-### Important changes
+## Important changes
 
-##### NGINX Plus won't start if:
+### NGINX Plus won't start if:
 
 - The JWT license is missing or invalid.
 - The JWT license expired over 90 days ago.
 
-##### NGINX Plus will **stop processing traffic** if:
+### NGINX Plus will **stop processing traffic** if:
 
 - It can't submit an initial usage report to F5's licensing endpoint or NGINX Instance Manager.
 
@@ -41,17 +41,48 @@ When installing or upgrading to NGINX Plus R33 or later, take the following step
 
 ---
 
-## Add the JWT license {#add-jwt}
-
-Before you install or upgrade to NGINX Plus R33 or later, make sure to:
-
-### Download the license from MyF5 {#download-jwt}
+## Download the license from MyF5 {#download-jwt}
 
 {{< include "licensing-and-reporting/download-jwt-from-myf5.md" >}}
 
-### Copy the license to each NGINX Plus instance
+---
 
-{{< include "licensing-and-reporting/apply-jwt.md" >}}
+## Deploy the JWT license
+
+After you download the JWT license, you can deploy it to your NGINX Plus instances using either of the following methods:
+
+- Use a **Config Sync Group** if you're managing instances with the NGINX One Console (recommended)
+- Copy the license manually to each instance
+
+Each method ensures your NGINX Plus instances have access to the required license file.
+
+### Deploy with a Config Sync Group (Recommended)
+
+If you're using the [NGINX One Console]({{< ref "/nginx-one/getting-started.md" >}}), the easiest way to manage your JWT license is with a [Config Sync Group](https://docs.nginx.com/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups/). This method lets you:
+
+- Avoid manual file copying
+- Keep your fleet consistent
+- Automatically apply updates to new NGINX Plus instances
+
+To deploy the JWT license with a Config Sync Group:
+
+{{< include "/licensing-and-reporting/deploy-jwt-with-csgs.md" >}}
+
+Your JWT license now syncs to all NGINX Plus instances in the group.
+
+When your subscription renews and a new JWT license is issued, update the file in the Config Sync Group to apply the change across your fleet.  
+
+New instances added to the group automatically inherit the license.
+
+{{< call-out "note" "If you’re using NGINX Instance Manager" "" >}}
+If you're using NGINX Instance Manager instead of the NGINX One Console, the equivalent feature is called an *instance group*. You can manage your JWT license in the same way by adding or updating the file in the instance group. For details, see [Manage instance groups]({{< ref "/nim/nginx-instances/manage-instance-groups.md" >}}).
+{{< /call-out >}}
+
+### Copy the license manually
+
+If you're not using NGINX One, copy the JWT license file to each NGINX Plus instance manually.
+
+{{< include "/licensing-and-reporting/apply-jwt.md" >}}
 
 ### Custom paths {#custom-paths}
 


### PR DESCRIPTION
## Summary

This update adds instructions for deploying the JWT license using Config Sync Groups in the NGINX One Console. It also improves the overall structure and clarity of the **About Subscription Licenses** topic by:

- Separating the license download steps into their own H2 section
- Introducing the two deployment workflows (Config Sync Group and manual copy) under a shared H2 with separate H3s
- Leading with the recommended method (Config Sync Group) to highlight the scalable, centralized approach
- Preserving the manual copy method as an alternative for users not using NGINX One
- Adding a callout for users of **NGINX Instance Manager**, noting that instance groups offer similar functionality

## Why

- Improve discoverability and clarity of the preferred deployment workflow
- Reduce friction for users trying to deploy JWTs across a fleet
- Align with product terminology (e.g., "Config Sync Group," "instance group")
- Support disconnected environments using NGINX Instance Manager

## Related links

- [Manage Config Sync Groups – NGINX One docs](https://docs.nginx.com/nginx-one/nginx-configs/config-sync-groups/manage-config-sync-groups/)
- [Manage instance groups – NGINX Instance Manager docs](https://docs.nginx.com/nginx-instance-manager/nginx-instances/manage-instance-groups/)
- Closes #491 