### PR TITLE
fix: Expose Agent config options

### DIFF
--- a/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
+++ b/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
@@ -49,8 +49,7 @@ sudo docker run \
   --env=NGINX_AGENT_LOG_LEVEL=debug \
   -d agent
 ```
-<details>
-<summary>NGINX Agent configuration options</summary>
+### NGINX Agent configuration options
 
 {{< bootstrap-table "table table-striped table-bordered" >}}
 | **Environment Variable**                         | **Command-Line Option**                             | **Description**                                                                                              | **Default Value**                                      |
@@ -84,4 +83,3 @@ sudo docker run \
 | NGINX_AGENT_COLLECTOR_EXTENSIONS_TLS_KEY      | --collector-extensions-health-tls-key           | File path for TLS key used when connecting with OTel health server.                                           | N/A                                                    |
 | NGINX_AGENT_COLLECTOR_PROCESSORS_BATCH_SEND_BATCH_TIMEOUT    | --collector-processors-batch-send-batch-timeout                                               | Maximum time duration for sending batch data metrics regardless of size.                                      | 200ms
 {{< /bootstrap-table >}}                             |%
-</details>

--- a/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
+++ b/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
@@ -49,7 +49,9 @@ sudo docker run \
   --env=NGINX_AGENT_LOG_LEVEL=debug \
   -d agent
 ```
-### NGINX Agent configuration options
+
+<details open="true">
+<summary>NGINX Agent configuration options</summary>
 
 {{< bootstrap-table "table table-striped table-bordered" >}}
 | **Environment Variable**                         | **Command-Line Option**                             | **Description**                                                                                              | **Default Value**                                      |
@@ -83,3 +85,4 @@ sudo docker run \
 | NGINX_AGENT_COLLECTOR_EXTENSIONS_TLS_KEY      | --collector-extensions-health-tls-key           | File path for TLS key used when connecting with OTel health server.                                           | N/A                                                    |
 | NGINX_AGENT_COLLECTOR_PROCESSORS_BATCH_SEND_BATCH_TIMEOUT    | --collector-processors-batch-send-batch-timeout                                               | Maximum time duration for sending batch data metrics regardless of size.                                      | 200ms
 {{< /bootstrap-table >}}                             |%
+</details>

--- a/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
+++ b/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
@@ -83,4 +83,4 @@ sudo docker run \
 | NGINX_AGENT_COLLECTOR_EXTENSIONS_TLS_CERT     | --collector-extensions-health-tls-cert          | TLS Certificate file path for communication with OTel health server.                                         | N/A                                                    |
 | NGINX_AGENT_COLLECTOR_EXTENSIONS_TLS_KEY      | --collector-extensions-health-tls-key           | File path for TLS key used when connecting with OTel health server.                                           | N/A                                                    |
 | NGINX_AGENT_COLLECTOR_PROCESSORS_BATCH_SEND_BATCH_TIMEOUT    | --collector-processors-batch-send-batch-timeout                                               | Maximum time duration for sending batch data metrics regardless of size.                                      | 200ms
-{{< /bootstrap-table >}}                             |%
+{{< /bootstrap-table >}}

--- a/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
+++ b/content/nginx-one/agent/configure-instance-reporting/configuration-overview.md
@@ -50,8 +50,7 @@ sudo docker run \
   -d agent
 ```
 
-<details open="true">
-<summary>NGINX Agent configuration options</summary>
+### NGINX Agent configuration options
 
 {{< bootstrap-table "table table-striped table-bordered" >}}
 | **Environment Variable**                         | **Command-Line Option**                             | **Description**                                                                                              | **Default Value**                                      |
@@ -85,4 +84,3 @@ sudo docker run \
 | NGINX_AGENT_COLLECTOR_EXTENSIONS_TLS_KEY      | --collector-extensions-health-tls-key           | File path for TLS key used when connecting with OTel health server.                                           | N/A                                                    |
 | NGINX_AGENT_COLLECTOR_PROCESSORS_BATCH_SEND_BATCH_TIMEOUT    | --collector-processors-batch-send-batch-timeout                                               | Maximum time duration for sending batch data metrics regardless of size.                                      | 200ms
 {{< /bootstrap-table >}}                             |%
-</details>


### PR DESCRIPTION
### Proposed changes

Problem. From an internal user who tested the process. "I almost missed these configuration options"

Proposed solution: Expose table of NGINX Agent configuration options.
Location: https://docs.nginx.com/nginx-one/agent/configure-instance-reporting/configuration-overview/#configuration-via-environment-variables

### Checklist

Before merging a pull request, run through this checklist and mark each as complete.

- [ ] I have read the [contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)
- [ ] I have rebased my branch onto main
- [ ] I have ensured my PR is targeting the main branch and pulling from my branch from my own fork
- [ ] I have ensured that the commit messages adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] I have ensured that documentation content adheres to [the style guide](/documentation/style-guide.md)
- [ ] If the change involves potentially sensitive changes[^1], I have assessed the possible impact
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] I have ensured that existing tests pass after adding my changes
- [ ] If applicable, I have updated [`README.md`](/README.md)

[^1]: Potentially sensitive changes include anything involving code, personally identify information (PII), live URLs or significant amounts of new or revised documentation. Please refer to [our style guide](/documentation/style-guide.md) for guidance about placeholder content.