### PR TITLE
Added H2 "Enable NGINX metrics reporting" to N1 GSG

### DIFF
--- a/content/nginx-one/getting-started.md
+++ b/content/nginx-one/getting-started.md
@@ -184,6 +184,8 @@ The `install` script writes an `nginx-agent.conf` file to the `/etc/nginx-agent/
 
 ---
 
+## Enable NGINX metrics reporting {#enable-nginx-metrics-reporting}
+
 The NGINX One Console dashboard relies on APIs for NGINX Plus and NGINX Open Source Stub Status to report traffic and system metrics. The following sections show you how to enable those metrics.
 
 ### Enable NGINX Plus API


### PR DESCRIPTION
### Proposed changes

This PR:

- Restores the H2 heading "Enable NGINX metrics reporting" to the NGINX One Getting Started guide. This heading existed at one point, but disappeared. Users have shared the link to this section, which was broken. This PR fixes the link. 

<img width="1102" height="450" alt="image" src="https://github.com/user-attachments/assets/2ec18a72-5d01-4549-8316-1722f50e1be5" />
