### PR TITLE
fix: remove NSP warning

### DIFF
--- a/content/nginxaas-azure/quickstart/security-controls/certificates.md
+++ b/content/nginxaas-azure/quickstart/security-controls/certificates.md
@@ -164,8 +164,6 @@ For more information on using NGINX to secure traffic to upstream servers, refer
 
 If you want to disable public access to your key vault, you can configure a [Network Security Perimeter (NSP)](https://learn.microsoft.com/en-us/azure/private-link/network-security-perimeter-concepts). This will allow you to configure access rules to allow NGINXaaS to fetch certificates from your key vault while ensuring all other public access is denied.
 
-{{< call-out "note" >}} Network Security Perimeter is currently in public preview. Refer to [Azure's NSP documentation](https://learn.microsoft.com/en-us/azure/private-link/network-security-perimeter-concepts) for details on its current capabilities. {{< /call-out >}}
-
 1. Follow [Azure's documentation on prerequisites](https://learn.microsoft.com/en-us/azure/private-link/create-network-security-perimeter-portal#prerequisites) to ensure you are registed to create an NSP.
 1. In the Search box, enter **Network Security Perimeters** and select **Network Security Perimeters** from the search results.
 1. Select {{< fa "plus">}}**Create**.


### PR DESCRIPTION
### Proposed changes

This note is no longer needed. From https://learn.microsoft.com/en-us/azure/private-link/network-security-perimeter-concepts:

> Network security perimeter is now generally available in all Azure public cloud regions.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
