### PR TITLE
fix: N1C update glossary description on front doc page

### DIFF
--- a/content/nginx-one/_index.md
+++ b/content/nginx-one/_index.md
@@ -60,7 +60,7 @@ F5 NGINX One Console makes it easy to manage NGINX instances across locations an
       Manage your NGINX fleet over REST
     {{</card>}}
     {{<card title="Glossary" titleUrl="/nginx-one/glossary/" >}}
-      See latest updates: New features, improvements, and bug fixes
+      Includes NGINX-specific security alert labels
     {{</card>}}
     {{<card title="Changelog" titleUrl="/nginx-one/changelog/" icon="clock-alert">}}
       See latest updates: New features, improvements, and bug fixes


### PR DESCRIPTION
### Proposed changes

N1C front page. Glossary description not correct. (Accidental duplicate of changelog description)

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
