### PR TITLE
Adds a callout to NIC installation with helm

### DIFF
--- a/content/nic/installation/installing-nic/installation-with-helm.md
+++ b/content/nic/installation/installing-nic/installation-with-helm.md
@@ -20,6 +20,8 @@ The [Helm chart parameters](#helm-chart-parameters) lists the parameters that ca
 - A [Kubernetes Version Supported by NGINX Ingress Controller]({{< ref "/nic/technical-specifications.md#supported-kubernetes-versions" >}})
 - Helm 3.0+.
 
+{{< call-out "note" >}} Helm version 3.18.5 has a [bug that returns an error when charts are referenced on a remote https url](https://github.com/helm/helm/issues/31136). Use versions up to 3.18.4 until they fix it. {{< /call-out >}}
+
 If you would like to use NGINX Plus, there are few options: you will need to update the `controller.image.repository` field of `values-plus.yaml` accordingly.
 
 - [Download NGINX Ingress Controller from the F5 Registry]({{< ref "/nic/installation/nic-images/registry-download.md" >}})


### PR DESCRIPTION
We ran into an issue where helm version 3.18.5 is broken because NIC charts reference definitions using an https URL. Helm rejects any reference that's not a file:// scheme in that version, so linting fails.

The helm team is aware of the bug and a fix is expected in the next week. Next release should work as previously.

### Proposed changes

A callout to the NIC installation / helm page advising users to not use 3.18.5 version due to a bug (also linked).

<img width="676" height="588" alt="image" src="https://github.com/user-attachments/assets/17913a52-31f7-4bb5-a01b-e139c17a6276" />


### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
