### PR TITLE
Remove NGINX Unit from home landing page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -47,9 +47,3 @@ Learn how to deliver, manage, and protect your applications using F5 NGINX produ
     Infrastructure-as-a-Service (IaaS) version of NGINX Plus for your Microsoft Azure application stack
   {{</card >}}
 {{</card-section>}}
-
-{{<card-section showAsCards="true" title="More NGINX Products">}}
-  {{<card title="NGINX Unit" titleUrl="https://unit.nginx.org/" brandIcon="NGINX-Unit-product-icon.svg" isLanding="true">}}
-    Dynamic app server that can run beside NGINX, NGINX Plus, or on its own
-  {{</card >}}
-{{</card-section>}}


### PR DESCRIPTION
### Proposed changes

- Remove NGINX unit from being promoted

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
