### PR TITLE
feat: Fix erroneous upgrade link

### DIFF
--- a/content/includes/nic/installation/create-custom-resources.md
+++ b/content/includes/nic/installation/create-custom-resources.md
@@ -30,9 +30,10 @@ kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v{{<
 
 {{%tab name="Install CRDs after cloning the repo"%}}
 
-{{< call-out "note" >}} If you are installing the CRDs this way, ensure you have first cloned the repository. {{< /call-out >}}
+{{< call-out "note" >}} 
 
-{{< call-out "note" >}} Please make sure to read the steps outlined in [Upgrade to V4](https://docs.nginx.com/nginx-ingress-controller/installation/installing-nic/upgrade-to-v4/#update-custom-resource-apiversion) before running the CRD upgrade and perform the steps if applicable.
+Read the steps outlined in [Upgrade from 3.x to 4.x]({{< ref "/nic/installation/upgrade-version.md#upgrade-from-3x-to-4x" >}}) before running the CRD upgrade and perform the steps if applicable.
+
 {{< /call-out >}}
 
 


### PR DESCRIPTION
### Proposed changes

This commit fixes a production URL link in NGINX Ingress Controller's instructions which should have been a Hugo reference shortcode.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
