### PR TITLE
feat: draft cards for NGINX Plus docs

### DIFF
--- a/content/nginx/_index.md
+++ b/content/nginx/_index.md
@@ -43,8 +43,8 @@ NGINX Plus adds a range of premium features to address enterprise needs.
     {{<card title="Set up HTTP load balancing" titleUrl="/admin-guide/load-balancer/http-load-balancer/" >}}
       Keep your servers running.
     {{</ card >}}
-    {{<card title="Set up a Web server" titleUrl="/nginx/admin-guide/web-server/web-server/" >}}
-      Configure NGINX as a Web server.
+    {{<card title="Set up a web server" titleUrl="/nginx/admin-guide/web-server/web-server/" >}}
+      Configure NGINX as a web server.
     {{</card>}}
     {{<card title="Secure with Single Sign-On" titleUrl="/nginx/admin-guide/security-controls/configuring-oidc/">}}
       Set up Open ID connect with identity providers.


### PR DESCRIPTION
### Proposed changes

Add use case blocks and cards to NGINX Plus doc front page
- Required to 'unblock' coming mainframe release

This is a "quick and (possibly) dirty" PR
- We may want to juggle / rename some/all of the cards
- We want to feature key functionality in "Featured content"
   - We can also highlight other functionality under "More information"

Here's a link to the proposed changes to the N plus home page: https://frontdoor-test-docs.nginx.com/previews/docs/994/nginx 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
