### PR TITLE
feat: Add placeholder landing pages for NAP

### DIFF
--- a/content/nap-dos/_index.md
+++ b/content/nap-dos/_index.md
@@ -1,9 +1,45 @@
 ---
-description: "F5 NGINX App Protect DoS provides behavioral DoS detection and mitigation."
+# The title is the product name
 title: F5 NGINX App Protect DoS
+# The URL is the base of the deployed path, becoming "docs.nginx.com/<url>/<other-pages>"
 url: /nginx-app-protect-dos/
+# The cascade directive applies its nested parameters down the page tree until overwritten
 cascade:
-  logo: "NGINX-App-Protect-DoS-product-icon.svg"
+  # The logo file is resolved from the theme, in the folder /static/images/icons/
+  logo: NGINX-App-Protect-DoS-product-icon.svg
+# The subtitle displays directly underneath the heading of a given page
+nd-subtitle: Enhance Security, Automate Defense, and Accelerate Protection with NGINX
+# Indicates that this is a custom landing page
+nd-landing-page: true
+# Types have a 1:1 relationship with Hugo archetypes, so you shouldn't need to change this
+nd-content-type: landing-page
+# Intended for internal catalogue and search, case sensitive:
+# Agent, N4Azure, NIC, NIM, NGF, NAP-DOS, NAP-WAF, NGINX One, NGINX+, Solutions, Unit
+nd-product: NAP-DOS
 ---
 
-Request your [free 30‑day trial](https://www.nginx.com/free-trial-request) today.
+## About
+Achieve comprehensive protection against DoS and DDoS attacks for your apps and APIs with a multi-layered, adaptive, automated mitigation strategy for DevOps environments. 
+
+Running natively on NGINX Plus and NGINX Ingress Controller, NGINX App Protect DoS is platform-agnostic and supports deployment options ranging from edge load balancers to individual pods in Kubernetes clusters.
+
+## Featured content
+[//]: # "You can add a maximum of three cards: any extra will not display."
+[//]: # "One card will take full width page: two will take half width each. Three will stack like an inverse pyramid."
+[//]: # "Some examples of content could be the latest release note, the most common install path, and a popular new feature."
+
+{{<card-layout>}}
+  {{<card-section showAsCards="true" isFeaturedSection="true">}}
+    {{<card title="Deployment" titleUrl="/nginx-app-protect-dos/deployment-guide/learn-about-deployment/">}}
+      Read how to install and upgrade NGINX App Protect DoS
+    {{</card>}}
+    <!-- The titleURL and icon are both optional -->
+    <!-- Lucide icon names can be found at https://lucide.dev/icons/ -->
+    {{<card title="Troubleshooting" titleUrl="/nginx-app-protect-dos/troubleshooting-guide/how-to-troubleshoot/">}}
+      Learn how to debug NGINX App Protect DoS
+    {{</card>}}
+    {{<card title="Releases" titleUrl="/nginx-app-protect-dos/releases/">}}
+      Review changelogs for NGINX App Protect DoS
+    {{</card>}}
+  {{</card-section>}}
+{{</card-layout>}}

--- a/content/nap-waf/_index.md
+++ b/content/nap-waf/_index.md
@@ -1,9 +1,42 @@
 ---
-description: Modern app security solution that works seamlessly in DevOps environments.
+# The title is the product name
 title: F5 NGINX App Protect WAF
-weight: 100
+# The URL is the base of the deployed path, becoming "docs.nginx.com/<url>/<other-pages>"
 url: /nginx-app-protect-waf/
+# The cascade directive applies its nested parameters down the page tree until overwritten
 cascade:
+  # The logo file is resolved from the theme, in the folder /static/images/icons/
   logo: NGINX-App-Protect-WAF-product-icon.svg
+# The subtitle displays directly underneath the heading of a given page
+nd-subtitle:  Secure, automate, and scale modern apps and APIs with a platform-agnostic WAF 
+# Indicates that this is a custom landing page
+nd-landing-page: true
+# Types have a 1:1 relationship with Hugo archetypes, so you shouldn't need to change this
+nd-content-type: landing-page
+# Intended for internal catalogue and search, case sensitive:
+# Agent, N4Azure, NIC, NIM, NGF, NAP-DOS, NAP-WAF, NGINX One, NGINX+, Solutions, Unit
+nd-product: NAP-WAF
 ---
 
+## About
+
+Defend your applications and APIs with a software security solution that seamlessly integrates into DevOps environments as a lightweight web application firewall (WAF), layer 7 denial-of-service (DoS) protection, bot protection, API security, and threat intelligence services. F5 NGINX App Protect delivers consistent protection across distributed architectures and hybrid environments.
+
+## Featured content
+[//]: # "You can add a maximum of three cards: any extra will not display."
+[//]: # "One card will take full width page: two will take half width each. Three will stack like an inverse pyramid."
+[//]: # "Some examples of content could be the latest release note, the most common install path, and a popular new feature."
+
+{{<card-layout>}}
+  {{<card-section showAsCards="true" isFeaturedSection="true">}}
+    {{<card title="Administration Guide" titleUrl="/nginx-app-protect-waf/v5/admin-guide/overview/">}}
+      Read the use cases and technical specifications for NGINX App Protect WAF
+    {{</card>}}
+    {{<card title="Installing NGINX App Protect WAF" titleUrl="/nginx-app-protect-waf/v5/admin-guide/install/">}}
+      Install NGINX App Protect WAF in a virtual environment
+    {{</card>}}
+    {{<card title="Releases" titleUrl="/nginx-app-protect-waf/v5/releases/">}}
+      Review the latest changes to NGINX App Protect WAF
+    {{</card>}}
+  {{</card-section>}}
+{{</card-layout>}}

--- a/content/nginx-one/k8s/add-ngf-helm.md
+++ b/content/nginx-one/k8s/add-ngf-helm.md
@@ -23,7 +23,6 @@ You also need:
 - Administrator access to a Kubernetes cluster.
 - If you use [Helm](https://helm.sh) and [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl), install them locally.
 
-
 ### Create a data plane key
 
 {{< include "/nginx-one/how-to/generate-data-plane-key.md" >}}
@@ -57,7 +56,11 @@ helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
 
 {{%tab name="NGINX Plus"%}}
 
-{{< note >}} If applicable, replace the F5 Container registry `private-registry.nginx.com` with your internal registry for your NGINX Plus image, and replace `nginx-plus-registry-secret` with your Secret name containing the registry credentials. If your NGINX Plus JWT Secret has a different name than the default `nplus-license`, then define that name using the `nginx.usage.secretName` flag. {{< /note >}}
+{{< call-out "note" >}} 
+
+If applicable, replace the F5 Container registry `private-registry.nginx.com` with your internal registry for your NGINX Plus image, and replace `nginx-plus-registry-secret` with your Secret name containing the registry credentials. If your NGINX Plus JWT Secret has a different name than the default `nplus-license`, then define that name using the `nginx.usage.secretName` flag. 
+
+{{< /call-out >}}
 
 To install the latest stable release of NGINX Gateway Fabric in the **nginx-gateway** namespace, run the following command:
 


### PR DESCRIPTION
### Proposed changes

This commit adds placeholder landing pages for NGINX App Protect WAF & DoS: there is much more coherent landing page as part of the formal refactor. These changes exist to unblock Mainframe, a new theme design, from releasing. It also addresses a call-out regression.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
