### PR TITLE
fix: Remove remaining old-style call-out

### DIFF
--- a/content/nginx-one/k8s/add-ngf-helm.md
+++ b/content/nginx-one/k8s/add-ngf-helm.md
@@ -108,7 +108,11 @@ helm install ngf .  \
 
 {{%tab name="NGINX Plus"%}}
 
-{{< note >}} If applicable, replace the F5 Container registry `private-registry.nginx.com` with your internal registry for your NGINX Plus image, and replace `nginx-plus-registry-secret` with your Secret name containing the registry credentials. If your NGINX Plus JWT Secret has a different name than the default `nplus-license`, then define that name using the `nginx.usage.secretName` flag. {{< /note >}}
+{{< call-out "note" >}} 
+
+If applicable, replace the F5 Container registry `private-registry.nginx.com` with your internal registry for your NGINX Plus image, and replace `nginx-plus-registry-secret` with your Secret name containing the registry credentials. If your NGINX Plus JWT Secret has a different name than the default `nplus-license`, then define that name using the `nginx.usage.secretName` flag. 
+
+{{< /call-out >}}
 
 To install the chart into the **nginx-gateway** namespace, run the following command:
 


### PR DESCRIPTION
### Proposed changes

This call-out was missed in a recent fix: multiple instances existed in the same file.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
