### PR TITLE
docs(nim): remove closed "Won’t Fix" issues from Known Issues

### DIFF
--- a/content/nim/releases/known-issues.md
+++ b/content/nim/releases/known-issues.md
@@ -50,22 +50,6 @@ After the restart you will see the line “loading CVE data from file” in the 
 
 ---
 
-### {{% icon-bug %}} New warning message when no usage data or report is available {#46022}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-| Issue ID       | Status |
-|----------------|--------|
-| 46022 | Won't be resolved  |
-{{</bootstrap-table>}}
-
-#### Description
-
-Users now see a warning message when they click the **Send Usage To F5** button if no new usage data or report is available. The message reads:
-
-> "Usage data is not available at the moment. Please try submitting usage details again later."
-
----
-
 
 ## 2.19.1
 
@@ -457,44 +441,8 @@ The list of Threat Campaigns will disappear when scrolling down, preventing the 
 #### Workaround
 
 Threat Campaign versions can be published with the API using the route: `api/platform/v1/security/publish`
-
 ---
 
-### {{% icon-bug %}} When upgrading to Instance Manager 2.10, there may be warnings from the Ingestion service {#42133}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 42133 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-When upgrading to 2.10 you may see a warning like the below message for the NGINX Management Suite Ingestion service. It can be safely ignored.
-
-```none
-[WARN] #011/usr/bin/nms-ingestion               #011start/start.go:497                 #011error checking migrations Mismatched migration version for ClickHouse, expected 39 migrations to be applied, currently have only 44 migrations applied.
-```
-
----
-
-### {{% icon-bug %}} When upgrading to Instance Manager 2.10, the API does not return lastDeploymentDetails for existing configurations {#42119}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 42119 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-After upgrading to Instance Manager 2.10, the API does not return lastDeploymentDetails for existing configuration blocks. This is then reflected as "Invalid Date" in the UI (See #42108).
-
-#### Workaround
-
-Republish the configuration for the affected configuration blocks.
 
 ---
 
@@ -503,75 +451,11 @@ Republish the configuration for the affected configuration blocks.
 
 November 17, 2022
 
-### {{% icon-bug %}} App Protect Policies page fails when deployed via Helm chart {#38782}
+---
 
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 38782 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-When installing NGINX Instance Manager on Kubernetes via Helm Chart, the App Protect page shows an error banner, and no default policies are displayed.
 
 ---
 
-### {{% icon-bug %}} Config deployment could fail when referencing remote cert inside allowed directories {#38596}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 38596 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-Deploying NGINX config with references to remote cert that resides in allowed directories could fail, with the following error:
-`BIO_new_file() failed (SSL: error:02001002:system library:fopen:No such file or directory`.
-
-This can also be diagnosed with log entries in `/var/log/nginx-agent/agent.log`, noting the removal of the referenced certificate.
-
-#### Workaround
-
-- Add the referenced cert to NMS as managed certificate and publish the config again.
-- Move the referenced remote certificate to a directory that's not in the allowed directory list.
-
----
-
-### {{% icon-bug %}} Unreferenced NGINX App Protect policy file in /etc/nms {#38488}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 38488 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-When using NGINX Instance Manager with App Protect policies, previously referenced policies in the NGINX configuration may not be removed after they are no longer referenced in the NGINX config.
-
-#### Workaround
-
-Unreferenced policy files may be removed manually from /etc/nms.
-
----
-
-### {{% icon-bug %}} HTTP version schema returns incorrect value in Advanced metrics module {#38041}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 38041 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-The values currently populated for http.version_schema are incorrect. The response is "4" for HTTP traffic and "6" for HTTPS traffic.
 
 ---
 
@@ -599,50 +483,6 @@ For example, in the NGINX App Protect WAF JSON declarative policy, these referen
 ## 2.5.0
 
 October 04, 2022
-
-### {{% icon-bug %}} Aux data fails to upload if the size is greater than 3145728 characters {#37498}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 37498 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-Updating a config with an aux data file exceeding 3145728 characters fails with a validation error similar to the following example:
-
-Request body has an error: doesn't match the schema: Error at "/auxFiles/files/3/contents": maximum string length is 3145728
-
----
-
-### {{% icon-bug %}} "Deployment Not Found" error when publishing NGINX config to NATS server {#37437}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 37437 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-Occasionally, when publishing an NGINX config to a NATS server, the system returns a `Deployment Not Found` error, and the `nms.log` file includes the error `http failure with code '131043': <nil>`.
-
-#### Workaround
-
-Remove the existing NATs working directory and restart the NMS Data Plane Manager (`nms-dpm`) service as root.
-
-{{< call-out "caution"  >}}Restarting the `nms-dpm` service is disruptive and may result in the loss of event data. You should schedule a maintenance window for restarting the service.{{< /call-out >}}
-
-```bash
-rm -rf /var/lib/nms/streaming
-systemctl restart nms-dpm
-```
-
----
-
 
 ## 2.3.0
 
@@ -678,22 +518,6 @@ filterBy=<dimension-name>!= ''
 
 May 25, 2022
 
-### {{% icon-bug %}} Giving long names (255+ characters) to certificates causes internal error {#34185}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 34185 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-When adding certificates, an internal error (error code: 134018) is returned if the name given for the certificate exceeds 255 characters.
-
-#### Workaround
-
-Use a name that is 255 or fewer characters.
 
 ---
 
@@ -702,52 +526,6 @@ Use a name that is 255 or fewer characters.
 
 April 05, 2022
 
-### {{% icon-bug %}} An unexpected number of instances are shown after upgrading nginx-agent to 2.1.0 {#33307}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 33307 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-After upgrading to NGINX Instance Manager 2.1.0, and updating nginx-agent from platform packaging, duplicate instances may appear on the Instance overview page. This issue is caused by a change in how the NGINX Agent generates the `system_uid`.
-
-#### Workaround
-
-You can safely delete the older entries or wait for them to expire.
-
----
-
-### {{% icon-bug %}} “No such process” error occurs when publishing a configuration {#33160}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 33160 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-When publishing a configuration, you might encounter an error similar to the following example:
-
-``` text
-config action failed: Config apply failed (write): no such process
-```
-
-This error can occur when there is a desyncronization between the NGINX Agent and NGINX PID, often after manually restarting NGINX when the Agent is running.
-
-#### Workaround
-
-Restart the NGINX Agent:
-
-``` bash
-sudo systemctl restart nginx-agent
-```
-
 ---
 
 
@@ -755,18 +533,6 @@ sudo systemctl restart nginx-agent
 
 December 21, 2021
 
-### {{% icon-bug %}} NGINX App Protect WAF blocks NGINX Instance Manager from publishing configurations {#32718}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 32718 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-NGINX Instance Manager does not currently support managing NGINX App Protect WAF instances. NGINX App Protect WAF may block attempts to publish configurations to NGINX App Protect WAF instances.
 
 ---
 
@@ -787,44 +553,3 @@ In the web interface, when uploading a config file that's larger than 50 MB (max
 
 Keep config files under 50 MB.
 
----
-
-### {{% icon-bug %}} CentOS 7, RHEL 7, and Amazon Linux 2 package managers allow unsupported NGINX/NGINX Plus versions {#28758}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 28758 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-When installing on CentOS 7, RHEL 7, and Amazon Linux 2, the package manager doesn't prevent installing NGINX Instance Manager with unsupported versions of NGINX or NGINX Plus. As a consequence, it is possible that `nms-instance-manager` is installed without an NGINX gateway. Resulting in a less than optimal experience.
-
-#### Workaround
-
-Install a supported version of NGINX (v1.18 or later) or NGINX Plus (R22 or later). See the [Technical Specifications]({{< ref "nim/fundamentals/tech-specs.md" >}}) guide for details.
-
----
-
-### {{% icon-bug %}} gRPC errors occur when starting NGINX Instance Manager {#28683}
-
-{{<bootstrap-table "table table-striped table-bordered">}}
-
-| Issue ID       | Status |
-|----------------|--------|
-| 28683 | Won't be resolved  |
-
-{{</bootstrap-table>}}
-#### Description
-
-  When starting NGINX Instance Manager, you may see errors similar to the following in `/etc/nginx/conf.d/nms-http.conf:227`:
-
-  ```text
-  nginx[1234]: nginx: [emerg] unknown directive "grpc_socket_keepalive"
-  ```
-
-#### Workaround
-
-Make sure your version of NGINX is v1.18 or later.


### PR DESCRIPTION
## Summary
This PR cleans up the **Known Issues** for NGINX Instance Manager by removing entries that were incorrectly labeled as **“Won’t Fix.”**

## Background
- After auditing against Jira, we confirmed these items were either:
  - **Fixed in later versions**, or
  - **No longer reproducible**, and one did not warrant a release note.
- Their presence in the Known Issues doc as “Won’t Fix” was **incorrect** and created noise for readers.

## Changes
- Removed all incorrectly labeled “Won’t Fix” entries from `nim/releases/known-issues.md`.
- Kept the page focused on **current, actionable issues** with valid workarounds or verified resolution info.

## Removed Issues (for traceability)
- 46022, 42133, 42119, 38782, 38596, 38488, 38041, 37498, 37437, 34185, 33307, 33160, 32718, 28758, 28683

## Outcome
- Improves accuracy and user trust by reflecting actual product status.
- Reduces maintenance overhead by removing obsolete items.
- Closes #1010 