### PR TITLE
Removed Sec Mon compatibility table

### DIFF
--- a/content/nim/nginx-app-protect/security-monitoring/set-up-app-protect-instances.md
+++ b/content/nim/nginx-app-protect/security-monitoring/set-up-app-protect-instances.md
@@ -22,12 +22,8 @@ Complete the following prerequisites before proceeding with the steps in this gu
 
 1. If you are new to NGINX App Protect WAF, follow the instructions in the installation and configuration guides to get up and running:
 
-   - [Install NGINX App Protect WAF]({{< ref "/nap-waf/v4/admin-guide/install.md" >}}) on one or more data plane instances. Each data plane instance must have connectivity to the NGINX Instance Manager host.
-   - [Configure NGINX App Protect WAF]({{< ref "/nap-waf/v4//configuration-guide/configuration.md#policy-configuration-overview" >}}) according to your needs on each of the data plane instance.
-
-1. Review the dependencies with NGINX App Protect WAF and NGINX Plus.
-
-   {{< include "nim/tech-specs/security-data-plane-dependencies.md" >}}
+   - [Install NGINX App Protect WAF]({{< ref "/nap-waf/v5/admin-guide/install.md" >}}) on one or more data plane instances. Each data plane instance must have connectivity to the NGINX Instance Manager host.
+   - [Configure NGINX App Protect WAF]({{< ref "/nap-waf/v5/configuration-guide/configuration.md#policy-configuration-overview" >}}) according to your needs on each of the data plane instance.
 
 1. Determine your use case: **Security Monitoring only** or **Security Monitoring and Configuration Management**.
 1. [Upload your license]({{< ref "/nim/admin-guide/add-license.md" >}}).


### PR DESCRIPTION
### Proposed changes

This PR:

- Removes the Security Monitoring <--> NAP WAF compatibility table in the NIM _Set up App Protect WAF instances for Security Monitoring_ doc. Sec Mon is not part of NIM.
- Updated the NAP WAF links in step 1 to point to the latest version (v5) of those docs.

### After

<img width="1184" height="562" alt="image" src="https://github.com/user-attachments/assets/0b7af992-109f-470e-b7b5-d9e7a22bd50f" />

### Before

<img width="1226" height="1698" alt="image" src="https://github.com/user-attachments/assets/eb516221-4fcc-48af-ba33-a958739f2937" />
