### PR TITLE
Remove before-you-begin shortcode

### DIFF
--- a/layouts/shortcodes/before-you-begin.html
+++ b/layouts/shortcodes/before-you-begin.html
@@ -1,3 +1,0 @@
-<blockquote class="tip">
-  <div><strong>Before you begin:</strong><br/> {{ .Inner | markdownify }}</div>
-</blockquote>


### PR DESCRIPTION
### Proposed changes

Remove redundant and outdated shortcode.

Example: On https://docs-staging.nginx.com/nginx-instance-manager/admin-guide/authentication/basic-auth/set-up-basic-authentication/

Before:
<img width="833" height="169" alt="Screenshot 2025-08-28 at 9 05 42 AM" src="https://github.com/user-attachments/assets/a0da8f0a-b200-463d-a255-8b5c246b57c1" />

After:
<img width="744" height="110" alt="Screenshot 2025-08-28 at 9 05 47 AM" src="https://github.com/user-attachments/assets/10ef07e5-4a3c-4ee7-8f92-e462be201718" />

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
