### PR TITLE
fix: genericize port number for proxy

### DIFF
--- a/content/nginx-one/connect-instances/connect-using-forward-proxy.md
+++ b/content/nginx-one/connect-instances/connect-using-forward-proxy.md
@@ -21,14 +21,14 @@ Ensure you have the following:
 
 1. Open a secure connection to your instance using SSH and log in.
 1. Open the NGINX Agent configuration file (/etc/nginx-agent/nginx-agent.conf) with a text editor. To edit this file you need superuser privileges.
-1. Add or modify the `proxy` section to include the proxy URL and timeout settings:
+1. Add or modify the `proxy` section to include the proxy URL, port number, and timeout settings:
 
    ```conf
    server:
       host: agent.connect.nginx.com
       port: 443
       proxy:
-         url: "http://proxy.example.com:3128"
+         url: "http://proxy.example.com:<port number>"
    ```
 
 1. Restart NGINX Agent to apply the changes:
@@ -50,7 +50,7 @@ To configure NGINX Agent in a containerized environment:
       --env=NGINX_AGENT_COMMAND_SERVER_HOST=agent.connect.nginx.com \
       --env=NGINX_AGENT_COMMAND_AUTH_TOKEN="<your-data-plane-key-here>" \
       --env=NGINX_AGENT_COMMAND_TLS_SKIP_VERIFY=false \
-      --env=NGINX_AGENT_COMMAND_SERVER_PROXY_URL=http://myproxy.example.com:3128 \
+      --env=NGINX_AGENT_COMMAND_SERVER_PROXY_URL=http://myproxy.example.com:<port number> \
       --restart=always \
       --runtime=runc \
       -d private-registry.nginx.com/nginx-plus/agentv3:latest
@@ -66,7 +66,7 @@ If your forward proxy requires authentication, you can specify the username and 
 
    ```conf
    proxy:
-      url: "http://proxy.example.com:3128"
+      url: "http://proxy.example.com:<port number>"
       auth_method: "basic"
       username: "user"
       password: "pass"
@@ -92,7 +92,7 @@ To set proxy authentication in a containerized environment:
       --env=NGINX_AGENT_COMMAND_SERVER_HOST=agent.connect.nginx.com \
       --env=NGINX_AGENT_COMMAND_AUTH_TOKEN="<your-data-plane-key-here>" \
       --env=NGINX_AGENT_COMMAND_TLS_SKIP_VERIFY=false \
-      --env NGINX_AGENT_COMMAND_SERVER_PROXY_URL=http://proxy.example.com:3128
+      --env NGINX_AGENT_COMMAND_SERVER_PROXY_URL=http://proxy.example.com:<port number>
       --env NGINX_AGENT_COMMAND_SERVER_PROXY_AUTH_METHOD=basic
       --env NGINX_AGENT_COMMAND_SERVER_PROXY_USERNAME="user"
       --env NGINX_AGENT_COMMAND_SERVER_PROXY_PASSWORD="pass"
@@ -108,16 +108,16 @@ To test the connectivity between NGINX Agent, your proxy, and NGINX One Console,
 1. Open a secure connection to your instance using SSH and log in.
 1. Run the following `curl` command to test the connection:
    ```sh
-   curl -x http://proxy.example.com:3128 -U your_user:your_password https://agent.connect.nginx.com/api/v1/agents
+   curl -x http://proxy.example.com:<port number> -U your_user:your_password https://agent.connect.nginx.com/api/v1/agents
    ```
 
-   - Replace `proxy.example.com:3128` with your proxy address and port.
+   - Replace `proxy.example.com:<port number>` with your proxy address and port number.
    - Replace `your_user` and `your_password` with the credentials you set up for proxy in the previous steps.
 
 To test the configuration from a containerized environment, run the following command from within the container:
 
    ```sh
-   curl -x http://host.docker.internal:3128 -U your_user:your_password https://agent.connect.nginx.com/api/v1/agents
+   curl -x http://host.docker.internal:<port number> -U your_user:your_password https://agent.connect.nginx.com/api/v1/agents
    ```
 
    - Replace `your_user` and `your_password` with the credentials you set up for proxy in the previous steps.


### PR DESCRIPTION
### Proposed changes

As web proxy servers do not have a "standard" port, it's helpful to make the number more generic. The current doc specifies 3128, which implies a specific proxy server. 

This PR replaces that number with `<port number>`

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
