### PR TITLE
fix nic cli arg for autoadjust

### DIFF
--- a/content/nic/configuration/global-configuration/command-line-arguments.md
+++ b/content/nic/configuration/global-configuration/command-line-arguments.md
@@ -658,7 +658,7 @@ The default value is `false`.
 
 ---
 
-### -with-directive-autoadjust
+### -enable-directive-autoadjust
 
 Automatically adjusts NGINX buffer directives to prevent configuration errors.
 
@@ -668,7 +668,7 @@ When enabled, the controller automatically adjusts `proxy_buffers`, `proxy_buffe
 
 More explanation about this feature can be found in the guide [here](<ref "/nic/installation/configuration/proxy-buffers-configuration.md">).
 
-<a name="cmdoption-with-directive-autoadjust"></a>
+<a name="cmdoption-enable-directive-autoadjust"></a>
 
 ---
 

--- a/content/nic/configuration/proxy-buffers-configuration.md
+++ b/content/nic/configuration/proxy-buffers-configuration.md
@@ -5,12 +5,12 @@ weight: 850
 nd-docs: DOCS-590
 ---
 
-This document explains how the `--with-directive-autoadjust` option prevents NGINX configuration errors by automatically adjusting HTTP proxy buffer directives.
+This document explains how the `--enable-directive-autoadjust` option prevents NGINX configuration errors by automatically adjusting HTTP proxy buffer directives.
 
 ---
 ## What it does
 
-The `--with-directive-autoadjust` feature automatically fixes common proxy buffer configuration mistakes that would otherwise cause NGINX to fail with errors like:
+The `--enable-directive-autoadjust` feature automatically fixes common proxy buffer configuration mistakes that would otherwise cause NGINX to fail with errors like:
 
 ```text
 [emerg] "proxy_busy_buffers_size" must be less than the size of all "proxy_buffers" minus one buffer
@@ -34,7 +34,7 @@ The `--with-directive-autoadjust` feature automatically fixes common proxy buffe
 Add the flag to the controller container:
 ```yaml
     args:
-      - --with-directive-autoadjust=true
+      - --enable-directive-autoadjust=true
 ```
 {{% /tab %}}
 {{% tab name="Helm" %}}
@@ -62,7 +62,7 @@ data:
 
 {{% tab name="Before (Error)" %}}
 
-Before enabling `--with-directive-autoadjust`, NGINX fails to start with configuration validation errors.
+Before enabling `--enable-directive-autoadjust`, NGINX fails to start with configuration validation errors.
 
 ```shell
 stderr: "2025/08/26 14:29:49 [emerg] 196#196: "proxy_busy_buffers_size" must be less than the size of all "proxy_buffers" minus one buffer in /etc/nginx/nginx.conf:121"
@@ -72,7 +72,7 @@ stderr: "2025/08/26 14:29:49 [emerg] 196#196: "proxy_busy_buffers_size" must be 
 
 {{% tab name="After (Fixed)" %}}
 
-With `--with-directive-autoadjust`, the configuration is automatically adjusted:
+With `--enable-directive-autoadjust`, the configuration is automatically adjusted:
 
 ```nginx
 		proxy_buffers 8 1m;
@@ -111,7 +111,7 @@ stderr: "2025/08/26 14:34:46 [emerg] 47#47: "proxy_busy_buffers_size" must be eq
 
 {{% tab name="After (Fixed)" %}}
 
-With `--with-directive-autoadjust`, sensible defaults are applied:
+With `--enable-directive-autoadjust`, sensible defaults are applied:
 
 ```shell
 		proxy_buffers 1024 1m;


### PR DESCRIPTION
### Proposed changes

- update NIC docs with correct cli arg

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
