### PR TITLE
fix: NIC Helm install: add spacing to prevent overflow

### DIFF
--- a/content/nic/installation/installing-nic/installation-with-helm.md
+++ b/content/nic/installation/installing-nic/installation-with-helm.md
@@ -110,7 +110,7 @@ When installing the NGINX Ingress Controller chart, Helm will also install the r
 
 If the CRDs are not installed, NGINX Ingress Controller pods will not become _Ready_.
 
-If you do not use the custom resources that require those CRDs (With `controller.enableCustomResources`,`controller.appprotect.enable` and `controller.appprotectdos.enable` set to `false`), the installation of the CRDs can be skipped by specifying `--skip-crds` in your _helm install_ command.
+If you do not use the custom resources that require those CRDs (With `controller.enableCustomResources`, `controller.appprotect.enable` and `controller.appprotectdos.enable` set to `false`), the installation of the CRDs can be skipped by specifying `--skip-crds` in your _helm install_ command.
 
 {{< call-out "caution" "Running multiple NGINX Ingress Controller instances">}}
 


### PR DESCRIPTION
### Proposed changes

Add spacing between CRD items to prevent mobile overflow.

<img width="462" height="388" alt="image" src="https://github.com/user-attachments/assets/e72ecd8c-6166-4fd0-9914-e81188f649cf" />


### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
