### PR TITLE
Added F5 branding to NGINX product documentation landing page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,9 +1,9 @@
 ---
-title: NGINX Product Documentation
+title: F5 NGINX Product Documentation
 description: Learn how to deliver, manage, and protect your applications using F5 NGINX products.
 ---
 
-## NGINX Product Documentation 
+# F5 NGINX Product Documentation 
 Learn how to deliver, manage, and protect your applications using F5 NGINX products. 
 
 {{<card-section showAsCards="true" title="NGINX One">}}
@@ -34,10 +34,10 @@ Learn how to deliver, manage, and protect your applications using F5 NGINX produ
 {{</card-section>}}
 
 {{<card-section showAsCards="true" title="NGINX App Protect">}}
-  {{<card title="NGINX App Protect WAF" titleUrl="/nginx-app-protect-waf/" brandIcon="NGINX-App-Protect-WAF-product-icon.svg" isLanding="true">}}
+  {{<card title="F5 WAF for NGINX" titleUrl="/nginx-app-protect-waf/" brandIcon="NGINX-App-Protect-WAF-product-icon.svg" isLanding="true">}}
     Lightweight, high-performance, advanced protection against Layer 7 attacks on your apps and APIs.
   {{</card >}}
-  {{<card title="NGINX App Protect DoS" titleUrl="/nginx-app-protect-dos/" brandIcon="NGINX-App-Protect-DoS-product-icon.svg" isLanding="true">}}
+  {{<card title="F5 DoS for NGINX" titleUrl="/nginx-app-protect-dos/" brandIcon="NGINX-App-Protect-DoS-product-icon.svg" isLanding="true">}}
     Defend, adapt, and mitigate against Layer 7 denial-of-service attacks on your apps and APIs.
   {{</card >}}
 {{</card-section>}}


### PR DESCRIPTION
### Proposed changes

This PR:

- Adds "F5" to the NGINX Product documentation landing page title
- Changes title to H1
- Renames:
  - NGINX App Protect WAF --> F5 WAF for NGINX
  - NGINX App Protect DoS --> F5 DoS for NGINX

<img width="2244" height="1616" alt="image" src="https://github.com/user-attachments/assets/11c2db0e-a0ac-438d-8a21-69332e283930" />


### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
