### PR TITLE
Wafmc 13048 doc offline solution ap signatures

### DIFF
--- a/content/nap-waf/v5/admin-guide/policy-lifecycle-management.md
+++ b/content/nap-waf/v5/admin-guide/policy-lifecycle-management.md
@@ -285,6 +285,21 @@ kubectl apply -f config/policy-manager/samples/appprotect_v1_apsignatures.yaml
 Downloading security updates may take several minutes. The version of security updates available at the time of compilation is always used to compile policies. If APSignatures is not created or the specified versions are not downloaded, the versions contained in the compiler docker image will be used.
 {{< /call-out >}}
 
+#### Using Security Update for users who can't use the nginx repo - Offline solution
+
+For users who prefer not to download the security update packages directly from the NGINX repository when using the APSignatures CR, there are two supported options:
+
+**1. Manual Package Placement**
+
+ - Download the required packages.
+ - Place them in the `/mnt/nap5_bundles_pv_data/security_updates_data/` directory.
+ - Ensure the files have `101:101` ownership and permissions.
+
+**2. Custom Compiler Image**
+
+ - Build a Docker image that includes the desired packages.
+ - Use this custom image in place of downloading packages at runtime.
+
 
 ### Creating Policy Resources
 

--- a/content/nap-waf/v5/admin-guide/policy-lifecycle-management.md
+++ b/content/nap-waf/v5/admin-guide/policy-lifecycle-management.md
@@ -285,6 +285,7 @@ kubectl apply -f config/policy-manager/samples/appprotect_v1_apsignatures.yaml
 Downloading security updates may take several minutes. The version of security updates available at the time of compilation is always used to compile policies. If APSignatures is not created or the specified versions are not downloaded, the versions contained in the compiler docker image will be used.
 {{< /call-out >}}
 
+
 ### Creating Policy Resources
 
 Once PLM is deployed, you can create policy resources using Kubernetes manifests. Apply the following Custom Resource examples or create your own based on these templates:


### PR DESCRIPTION
### Proposed changes

Added suggested offline solution for users who don’t want to download the security update pkgs from nginx repo.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
