### PR TITLE
F5-Sites: Add item for community forum

### DIFF
--- a/data/f5-sites.yaml
+++ b/data/f5-sites.yaml
@@ -13,3 +13,7 @@
 - title: NGINX
   url: https://nginx.org/
   description: Learn more about NGINX Open Source and read the community blog
+
+- title: Community Forum
+  url: https://community.nginx.org/
+  description: Engage with the broader NGINX community for discussions and troubleshooting


### PR DESCRIPTION
### Proposed changes

Adds an item to the F5 Sites dropdown for the [NGINX Community forum](https://community.nginx.org/). Description copy was cleared by the community team.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
