### PR TITLE
Fixed broken anchor

### DIFF
--- a/content/nic/configuration/global-configuration/configmap-resource.md
+++ b/content/nic/configuration/global-configuration/configmap-resource.md
@@ -28,7 +28,7 @@ that make sense for your setup:
       client-max-body-size: "2m"
     ```
 
-    See the section [Summary of ConfigMap Keys](#summary-of-configmap-keys) for the explanation of the available ConfigMap keys (such as `proxy-connect-timeout` in this example).
+    See the section [Summary of ConfigMap Keys](#configmap-keys) for the explanation of the available ConfigMap keys (such as `proxy-connect-timeout` in this example).
 
 1. Create a new (or update the existing) ConfigMap resource:
 


### PR DESCRIPTION
### Proposed changes

Page https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/ links to a broken anchor

### Checklist

Before sharing this pull request, I completed the following checklist:

- [X] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [X] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [X] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [X] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
