### PR TITLE
feat: IPv6 connectivity support in NGINX One APIs

### DIFF
--- a/content/includes/nginx-one/how-to/install-nginx-agent.md
+++ b/content/includes/nginx-one/how-to/install-nginx-agent.md
@@ -8,13 +8,14 @@ files:
 After entering your data plane key, you'll see a `curl` command to install NGINX Agent, similar to the one below. Copy and run this command on each NGINX instance. Once installed, NGINX Agent typically registers with NGINX One within a few seconds.
 
 {{<call-out "important" "Connecting to NGINX One" >}}
- Ensure that any firewall rules you have in place for your NGINX hosts allows network traffic to port `443` for all of the following IPs:
+ Ensure that any firewall rules you have in place for your NGINX hosts allows network traffic to port `443` for all of the following IP ranges:
 
-- `3.135.72.139`
-- `3.133.232.50`
-- `52.14.85.249`
+- `3.135.72.139/32`
+- `3.133.232.50/32`
+- `52.14.85.249/32`
+- `2600:1f16:19c8:d400::/62`
 
-NGINX Agent must be able to establish a connection to NGINX One Console's Agent endpoint (`agent.connect.nginx.com`). 
+NGINX Agent must be able to establish a connection to NGINX One Console's Agent endpoint (`agent.connect.nginx.com`).
 {{</call-out>}}
 
 To install NGINX Agent on an NGINX instance:

--- a/content/nginx-one/changelog.md
+++ b/content/nginx-one/changelog.md
@@ -30,6 +30,13 @@ h2 {
 
 Stay up-to-date with what's new and improved in the F5 NGINX One Console.
 
+## September 16, 2025
+
+### IPv6 endpoints for NGINX Agent and NGINX Plus usage reporting
+
+Your instances running in dualstack or IPv6-only environments are now able to communicate with NGINX One APIs via IPv6.
+Please check the [Getting Started Guide]({{< ref "/nginx-one/getting-started.md#install-nginx-agent" >}}) for IP ranges required to be enabled in your firewalls.
+
 ## July 15, 2025
 
 ### Set up F5 NGINX App Protect WAF security policies

--- a/content/nginx-one/getting-started.md
+++ b/content/nginx-one/getting-started.md
@@ -126,11 +126,12 @@ Depending on whether this is your first time using NGINX One Console or you've u
 After entering your data plane key, you'll see a `curl` command similar to the one below. Copy and run this command on each NGINX instance to install NGINX Agent. Once installed, NGINX Agent typically registers with NGINX One within a few seconds.
 
 {{<call-out "important" "Connecting to NGINX One" >}}
-NGINX Agent must be able to establish a connection to NGINX One Console's Agent endpoint (`agent.connect.nginx.com`). Ensure that any firewall rules you have in place for your NGINX hosts allows network traffic to port `443` for all of the following IPs:
+NGINX Agent must be able to establish a connection to NGINX One Console's Agent endpoint (`agent.connect.nginx.com`). Ensure that any firewall rules you have in place for your NGINX hosts allows network traffic to port `443` for all of the following IP ranges:
 
-- `3.135.72.139`
-- `3.133.232.50`
-- `52.14.85.249`
+- `3.135.72.139/32`
+- `3.133.232.50/32`
+- `52.14.85.249/32`
+- `2600:1f16:19c8:d400::/62`
 {{</call-out>}}
 
 To install NGINX Agent on an NGINX instance:

--- a/content/solutions/about-subscription-licenses.md
+++ b/content/solutions/about-subscription-licenses.md
@@ -100,11 +100,12 @@ To ensure NGINX Plus R33 or later can send usage reports, follow these steps bas
 
 ### For internet-connected environments
 
-1. Allow outbound HTTPS traffic on TCP port `443` to communicate with F5's licensing endpoint (`product.connect.nginx.com`). Ensure that the following IP addresses are allowed:
+1. Allow outbound HTTPS traffic on TCP port `443` to communicate with F5's licensing endpoint (`product.connect.nginx.com`). Ensure that the following IP ranges are allowed:
 
-   - `3.135.72.139`
-   - `3.133.232.50`
-   - `52.14.85.249`
+   - `3.135.72.139/32`
+   - `3.133.232.50/32`
+   - `52.14.85.249/32`
+   - `2600:1f16:19c8:d400::/62`
 
 2.  (Optional, R34 and later) If your company enforces a strict outbound traffic policy, you can use an outbound proxy for establishing an end-to-end tunnel to the F5 licensing endpoint. On each NGINX Plus instance, update the [`proxy`](https://nginx.org/en/docs/ngx_mgmt_module.html#proxy) directive in the [`mgmt`](https://nginx.org/en/docs/ngx_mgmt_module.html) block of the NGINX configuration (`/etc/nginx/nginx.conf`) to point to the company's outbound proxy server:
 

--- a/content/solutions/r33-pre-release-guidance-for-automatic-upgrades.md
+++ b/content/solutions/r33-pre-release-guidance-for-automatic-upgrades.md
@@ -73,11 +73,12 @@ To ensure NGINX Plus R33 can report telemetry data, follow these steps based on 
 #### For internet-connected environments:
 
 1. **Open port 443**:
-   Allow outbound HTTPS traffic on TCP port 443 to communicate with F5's licensing endpoint (`product.connect.nginx.com`). Ensure that the following IP addresses are allowed:
+   Allow outbound HTTPS traffic on TCP port 443 to communicate with F5's licensing endpoint (`product.connect.nginx.com`). Ensure that the following IP ranges are allowed:
 
-   - `3.135.72.139`
-   - `3.133.232.50`
-   - `52.14.85.249`
+   - `3.135.72.139/32`
+   - `3.133.232.50/32`
+   - `52.14.85.249/32`
+   - `2600:1f16:19c8:d400::/62`
 
 #### For partially connected environments:
 


### PR DESCRIPTION
### Proposed changes

Added the note about recently introduced IPv6 connectivity support for NGINX One APIs endpoints.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
