### PR TITLE
fix: Add volume mounts for NIC Security Monitoring due to missing permissions

### DIFF
--- a/content/nic/tutorials/security-monitoring.md
+++ b/content/nic/tutorials/security-monitoring.md
@@ -84,7 +84,6 @@ If you use custom container images, NGINX Agent must be installed along with NGI
 
 3. Make sure that the ConfigMap is mounted to the NGINX Ingress Controller pod at `/etc/nginx-agent/nginx-agent.conf` and the dynamic agent config is mounted at `/var/lib/nginx-agent` by adding the following volumes and volumeMounts to the NGINX Ingress Controller deployment manifest:
 
-   **Volumes:**
    ```yaml
    volumes:
      - name: agent-conf
@@ -94,7 +93,6 @@ If you use custom container images, NGINX Agent must be installed along with NGI
        emptyDir: {}
    ```
 
-   **Volume Mounts:**
    ```yaml
    volumeMounts:
      - name: agent-conf

--- a/content/nic/tutorials/security-monitoring.md
+++ b/content/nic/tutorials/security-monitoring.md
@@ -82,13 +82,26 @@ If you use custom container images, NGINX Agent must be installed along with NGI
 
 {{< call-out "note" >}} The `features` list must not contain `nginx-config-async` or `nginx-ssl-config` as these features can cause conflicts with NGINX Ingress Controller.{{< /call-out >}}
 
-3. Make sure that the ConfigMap is mounted to the NGINX Ingress Controller pod at `/etc/nginx-agent/nginx-agent.conf` by adding the following to the NGINX Ingress Controller deployment manifest:
+3. Make sure that the ConfigMap is mounted to the NGINX Ingress Controller pod at `/etc/nginx-agent/nginx-agent.conf` and the dynamic agent config is mounted at `/var/lib/nginx-agent` by adding the following volumes and volumeMounts to the NGINX Ingress Controller deployment manifest:
 
+   **Volumes:**
    ```yaml
-    volumeMounts:
-    - name: agent-conf
-      mountPath: /etc/nginx-agent/nginx-agent.conf
-      subPath: nginx-agent.conf
+   volumes:
+     - name: agent-conf
+       configMap:
+         name: agent-conf
+     - name: agent-dynamic
+       emptyDir: {}
+   ```
+
+   **Volume Mounts:**
+   ```yaml
+   volumeMounts:
+     - name: agent-conf
+       mountPath: /etc/nginx-agent/nginx-agent.conf
+       subPath: nginx-agent.conf
+     - name: agent-dynamic
+       mountPath: /var/lib/nginx-agent
    ```
 
 4. Follow the [Installation with Manifests]({{< ref "/nic/installation/installing-nic/installation-with-manifests.md" >}}) instructions to deploy NGINX Ingress Controller with custom resources enabled.


### PR DESCRIPTION
NIC Security Monitoring doc was missing volume mounts for manifests, this was reported by https://github.com/nginx/kubernetes-ingress/issues/7846. Helm works just fine by already including these volumes and volumeMounts.

This fix makes sure that both helm and manifests have the exact same mounting permissions when it comes to Agent + App Protect. 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
