### PR TITLE
fix: include for NGINX on FreeBSD

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-plus.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-plus.md
@@ -294,7 +294,7 @@ NGINX Plus can be installed on the following versions of Debian or Ubuntu:
 
 1. {{< include "nginx-plus/install/check-nginx-binary-version.md" >}}
 
-1. {{< include "nginx-plus/install/configure-usage-reporting.md" >}}
+1. Make sure license reporting to F5 licensing endpoint is configured. By default, no configuration is required. However, it becomes necessary when NGINX Plus is installed in a disconnected environment, uses NGINX Instance Manager for usage reporting, or uses a custom path for the license file. Configuration can be done in the [`mgmt {}`](https://nginx.org/en/docs/ngx_mgmt_module.html) block of the NGINX Plus configuration file (`/usr/local/etc/nginx/nginx.conf`). For more information, see [About Subscription Licenses](https://docs.nginx.com/solutions/about-subscription-licenses/).
 
 1. {{< include "nginx-plus/install/install-nginx-agent-for-nim.md" >}}
 
@@ -398,7 +398,7 @@ NGINX Plus can be installed on the following versions of Debian or Ubuntu:
 
 1. {{< include "nginx-plus/install/install-nginx-agent-for-nim.md" >}}
 
-## Install Dynamically Loadable Modules {#install_modules}
+## Install dynamically loadable modules {#install_modules}
 
 NGINX Plus functionality can be extended with dynamically loadable modules. They can be added or updated independently of the core binary, enabling powerful capabilities such as advanced security, traffic shaping, telemetry, embedded scripting, geolocation, and many more.
 
@@ -515,7 +515,7 @@ After installing the module, you will need to:
 - enable it with the [`load_module`](https://nginx.org/en/docs/ngx_core_module.html#load_module) directive
 - configure it according to the module's documentation
 
-### Enabling Dynamic Modules {#enable_dynamic}
+### Enabling dynamic modules {#enable_dynamic}
 
 To enable a dynamic module:
 
@@ -694,7 +694,7 @@ For a community dynamic module to work with NGINX Plus, it must be compiled alo
 
 After installing the module, you need to enable it in the NGINX Plus configuration file. For more information, see [Enabling Dynamic Modules](#enable_dynamic).
 
-## NGINX Plus Unprivileged Installation {#unpriv_install}
+## NGINX Plus unprivileged installation {#unpriv_install}
 
 In some environments, access to the root account is restricted for security reasons. On Linux systems, this limitation prevents the use of package managers to install NGINX Plus without root privileges.
 
@@ -787,7 +787,7 @@ With this script, you can also upgrade an existing unprivileged installation of 
 ./ngxunprivinst.sh upgrade [-y] -p <path> <file1.rpm> <file2.rpm>
 ```
 
-## NGINX Plus Offline Installation {#offline_install}
+## NGINX Plus offline installation {#offline_install}
 
 This section explains how to install NGINX Plus and its [dynamic modules]({{< ref "/nginx/admin-guide/dynamic-modules/dynamic-modules.md" >}}) on a server with limited or no Internet access.
 
@@ -982,7 +982,7 @@ To upgrade your NGINX Plus installation to the newest version:
    nginx version: nginx/1.29.0 (nginx-plus-r35)
    ```
 
-## Upgrade NGINX Plus Modules {#upgrade_modules}
+## Upgrade NGINX Plus modules {#upgrade_modules}
 
 The upgrade procedure depends on how the module was supplied and installed.
 
@@ -992,7 +992,7 @@ The upgrade procedure depends on how the module was supplied and installed.
 
 - [Community](#community-dynamic-modules) dynamic modules must be recompiled against the corresponding NGINX Open Source  version. See [Installing NGINX Community Modules](#install_modules_oss).
 
-## Explore Related Topics
+## Explore related topics
 
 ### Install NGINX App Protect
 


### PR DESCRIPTION
A quick fix for Step 12 of https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/#install_freebsd
Currently, the Linux path (/etc/nginx/nginx.conf) is used instead of FreeBSD (/usr/local/etc/nginx/nginx.conf).

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
