### PR TITLE
fix: Update NIC NAP Helm guide to latest versions

### DIFF
--- a/content/nic/installation/installing-nic/deploy-with-nap-using-helm.md
+++ b/content/nic/installation/installing-nic/deploy-with-nap-using-helm.md
@@ -35,11 +35,9 @@ This is accomplished with the following steps:
 
 ---
 
-## Check compatibility between NGINX Ingress Controller and NGINX App Protect WAF versions
+## Check compatibility between NGINX Ingress Controller and F5 WAF for NGINX versions
 
 {{< include "nic/compatibility-tables/nic-nap.md" >}}
-
----
 
 ## Compile WAF Policy from JSON to Bundle
 


### PR DESCRIPTION
### Proposed changes

fix: Update NIC NAP Helm guide to latest versions
Add the compatability chart too so users can check the WAF version.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
