### PR TITLE
Remove restriction on combination of WAF policies

### DIFF
--- a/content/nginxaas-azure/app-protect/configure-waf.md
+++ b/content/nginxaas-azure/app-protect/configure-waf.md
@@ -125,10 +125,6 @@ After your policy has been saved, you can then reference it in your NGINX config
 
 {{< call-out "note" >}}The **name** field within the security policy must be unique among the policies referenced in your NGINX configuration.{{< /call-out >}}
 
-{{< call-out "warning" >}}Referencing both custom and precompiled policies in your NGINX configuration is not supported at this time. 
-As a workaround, make a copy of the default policy you want to use, then add it as a custom policy with a different name.
-{{< /call-out >}}
-
 The **Custom Policies** tab shows the status of your custom policies (Compilation and Application Status). Custom policies are automatically compiled when created or modified. Policies that are applied to the NGINX configuration cannot be deleted until they are first removed from the configuration. 
 
 It is highly recommended to use logging to monitor the performance of F5 WAF for NGINX and to help diagnose problems. See [Enable F5 WAF for NGINX Logs]({{< ref "/nginxaas-azure/app-protect/enable-logging.md" >}}) for directions to configure security and operational logs.

--- a/content/nginxaas-azure/changelog.md
+++ b/content/nginxaas-azure/changelog.md
@@ -23,6 +23,10 @@ Users can now test the availability of specific IP addresses from their deployme
 
 NGINXaaS now supports downloading certificate from Azure Key Vault via Private Endpoints. This will allow users to increase network security by disabling public access on their Key Vault. For more information, please visit [Integrate with Private Endpoint]({{< ref "/nginxaas-azure/quickstart/security-controls/certificates.md#integrate-with-private-endpoint" >}})
 
+- {{% icon-feature %}} **Support for both precompiled and custom WAF policies in the same NGINX config**
+
+NGINXaaS now allows both precompiled and custom policies for F5 NGINX App Protect WAF to be referenced within the same NGINX config. This removes a previous restriction.
+
 ## September 18, 2025
 
 - {{% icon-feature %}} **Notification on update to deployments using the Stable Upgrade Channel**

--- a/content/nginxaas-azure/known-issues.md
+++ b/content/nginxaas-azure/known-issues.md
@@ -17,12 +17,6 @@ Updating managed identities on an NGINXaaS deployment after creation may result 
 
 **Workaround**: To avoid this issue, when you create an NGINXaaS deployment, make sure that the managed identity with access to AKV is assigned during initial creation. If managed identities need to be updated after creation, enable public access to AKV or [configure Network Security Perimeter]({{< ref "/nginxaas-azure/quickstart/security-controls/certificates.md#configure-network-security-perimeter-nsp" >}})
 
-### {{% icon-bug %}} Custom and precompiled security policies cannot both be referenced in an NGINX configuration
-
-When using F5 WAF for NGINX, you can only reference default or custom security policies in your NGINX configuration, not both.
-
-**Workaround**: Make a copy of the default policy you want to use, then add it as a custom policy with a different name.
-
 ### {{% icon-bug %}} Terraform fails to apply due to validation errors, but creates "Failed" resources in Azure (ID-4424)
 
 Some validation errors are caught later in the creation process, and can leave behind "Failed" resources in Azure. An example initial failure might look like:


### PR DESCRIPTION

### Proposed changes

- Removes restriction on the combination of both precompiled and custom policies in an NGINX config

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
