### PR TITLE
fix: nic link missing shortcode syntax

### DIFF
--- a/content/nic/configuration/global-configuration/command-line-arguments.md
+++ b/content/nic/configuration/global-configuration/command-line-arguments.md
@@ -666,7 +666,7 @@ The default value is `false`.
 
 When enabled, the controller automatically adjusts `proxy_buffers`, `proxy_buffer_size`, and `proxy_busy_buffers_size` to ensure they work together properly and NGINX can start successfully.
 
-More explanation about this feature can be found in the guide [here]({{< ref "/nic/installation/configuration/proxy-buffers-configuration.md" }}>).
+More explanation about this feature can be found in the guide [here]({{< ref "/nic/installation/configuration/proxy-buffers-configuration.md" >}}).
 
 <a name="cmdoption-enable-directive-autoadjust"></a>
 


### PR DESCRIPTION
### Proposed changes

Fix a broken link

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
