### PR TITLE
fix: NGF callout formatting issue

### DIFF
--- a/content/ngf/install/upgrade-version.md
+++ b/content/ngf/install/upgrade-version.md
@@ -68,7 +68,8 @@ Warning: kubectl apply should be used on resource created by either kubectl crea
 
 {{% tab name="Helm" %}}
 
-{{< call-out "important" >}} If you are using NGINX Plus and have a different Secret name than the default `nplus-license` name, specify the Secret name by setting `--set nginx.usage.secretName=<secret-name>` when running `helm install` or `helm upgrade`. {{< /call-out >}}
+
+{{< call-out "important" "Important" >}}If you are using NGINX Plus and have a different Secret name than the default `nplus-license` name, specify the Secret name by setting `--set nginx.usage.secretName=<secret-name>` when running `helm install` or `helm upgrade`.{{< /call-out >}}
 
 To upgrade the release with Helm, you can use the OCI registry, or download the chart and upgrade from the source.
 


### PR DESCRIPTION
### Proposed changes

Workaround for a callout issue inside a tab.

before:

<img width="1092" height="407" alt="image" src="https://github.com/user-attachments/assets/0086c64f-303a-4f0b-b2c0-e8c2628e3430" />


after:

<img width="1092" height="407" alt="image" src="https://github.com/user-attachments/assets/612f9263-975e-453e-b212-e2e51c135b53" />


### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
