### PR TITLE
Change timeline for NGINX updates on stable channel

### DIFF
--- a/content/nginxaas-azure/quickstart/upgrade-channels.md
+++ b/content/nginxaas-azure/quickstart/upgrade-channels.md
@@ -30,7 +30,7 @@ Maintaining the latest version NGINX Plus, operating system (OS), and other soft
 | Channel     | Availablity of NGINX Plus and related modules |
 |-------------|-----------------------------------------------|
 | preview     | No sooner than 14 days of a new NGINX Plus [release](https://docs.nginx.com/nginx/releases/). |
-| stable      | No sooner than 45 days of a new NGINX Plus [release](https://docs.nginx.com/nginx/releases/). |
+| stable      | No sooner than 24 days of a new NGINX Plus [release](https://docs.nginx.com/nginx/releases/). |
 {{< /table >}}
 
 A new version of NGINX Plus and its related modules is first introduced to the **preview** channel, where it is goes through our acceptance testing. Once we have baked the software in the **preview** channel for a reasonable time, it is eventually graduated to the **stable** channel. The actual promotion timelines can vary, and you can view our [Changelog]({{< ref "/nginxaas-azure/changelog/changelog.md" >}}) for latest updates.


### PR DESCRIPTION

### Proposed changes

We want to be able to deliver the latest NGINX release sooner. Currently we state the minimum delay between an. NGINX release and when NGINXaaS will deploy it to the stable channel is 45 days.  We want to shorten it to 24 days (this is a minimum and doesn't require that we release in 24 days - we could take longer depending on the significance of the changes).

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
