### PR TITLE
fix: NIM Installation script | rhel9 installation failure due to missing yum-config-manager

### DIFF
--- a/static/scripts/install-nim-bundle.sh
+++ b/static/scripts/install-nim-bundle.sh
@@ -353,7 +353,7 @@ installBundleForRPMDistro(){
     fi
     printf "[nginx-plus]\nname=nginx-plus repo\nbaseurl=https://pkgs.nginx.com/plus/$os_type/\$releasever/\$basearch/\nsslclientcert=/etc/ssl/nginx/nginx-repo.crt\nsslclientkey=/etc/ssl/nginx/nginx-repo.key\ngpgcheck=0\nenabled=1" >> /etc/yum.repos.d/nginx-plus.repo
 
-    yum install -y yum-utils curl epel-release ca-certificates
+    yum install -y yum-utils curl epel-release ca-certificates dnf-plugins-core
     yum-config-manager --enable  nginx-stable
     yum-config-manager --enable  nginx-plus
 

--- a/static/scripts/install-nim-bundle.sh
+++ b/static/scripts/install-nim-bundle.sh
@@ -364,7 +364,7 @@ installBundleForRPMDistro(){
          echo "Installing nginx plus..."
          yum install -y nginx-plus
          check_last_command_status "yum install -y nginx-plus" $?
-         createNginxMgmtFile
+         create_nginx_mgmt_file
     else
          echo "Installing nginx..."
          yum install -y nginx --repo nginx-stable


### PR DESCRIPTION
Issue => rhel9 installation issues addressed ( missing `yum-config-manager` )