### PR TITLE
Add workflow to prune stale branches

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,41 @@
+name: Prune stale branches
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *' # run every day at 01:30 UTC
+
+jobs:
+  stale-branches:
+    runs-on: ubuntu-latest
+    env:
+      ORG: nginx
+      REPO: documentation
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - name: Prune all stale branches
+        run: |
+            HAS_MORE="true"
+
+            while [ "$HAS_MORE" == "true" ]; do
+              RESPONSE=$(curl -L -s \
+              -X GET \
+              -H "Accept: application/json" \
+              -s "https://github.com/${{env.ORG}}/${{env.REPO}}/branches/stale")
+
+              HAS_MORE=$(echo "$RESPONSE" | jq -r '.payload.has_more')
+              BRANCHES=$(echo "$RESPONSE" | jq -r '.payload.branches[].name')
+
+              for BRANCH in $BRANCHES; do
+                echo "Deleting branch $BRANCH..."
+                DELETE_RESPONSE=$(curl -L -s \
+                  -X DELETE \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer ${{env.GITHUB_TOKEN}}" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  https://api.github.com/repos/${{env.ORG}}/${{env.REPO}}/git/refs/heads/$BRANCH)
+                echo "Delete response for branch $BRANCH: $DELETE_RESPONSE"
+              done
+            done
+


### PR DESCRIPTION
### Proposed changes

Prunes all stale branches. All branches are considered stale after 90 days.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
