### PR TITLE
Enable local access for NGINX Plus API

### DIFF
--- a/content/includes/config-snippets/enable-nplus-api-dashboard.md
+++ b/content/includes/config-snippets/enable-nplus-api-dashboard.md
@@ -24,7 +24,7 @@ server {
         # Enable API in write mode
         api write=on;
 
-        # To restrict access by network, uncomment and set your network:
+        # To restrict access by network, uncomment the following lines and set your network:
         # allow 192.0.2.0/24;   # replace with your network
         # allow 127.0.0.1/32;   # allow local NGINX Agent to call the NGINX Plus API to retrieve metrics
         # deny  all;


### PR DESCRIPTION
When uncommenting the config section used to restrict access to the NGINX Plus API, it will break NGINX Agent's ability to scrape the Plus API. 

If this is the case, you may receive an access log entry similar to the following:

```
2025/10/14 11:04:35 [error] 21626#21626: *76799 access forbidden by rule, client: 127.0.0.1, server: , request: "GET /api//9/nginx HTTP/1.1", host: "localhost:9000"
```

### Proposed changes

Create an additional allow rule to restore NGINX. Agent's ability to scrape the NGINX Plus API.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
