### PR TITLE
docs(amplify): add end-of-life banner for NGINX Amplify

### DIFF
--- a/_banners/eol-amplify.md
+++ b/_banners/eol-amplify.md
@@ -1,0 +1,14 @@
+{{< banner "warning" "Support for NGINX Amplify Ends January 31, 2026" >}}
+
+NGINX Amplify support ends on January 31, 2026. To continue monitoring your NGINX instances, migrate to the NGINX One Console, part of the NGINX One product offering.
+
+**Transition steps:**
+
+1. [Contact the F5 NGINX Sales team](https://www.f5.com/products/get-f5/f5-nginx-products-and-packaging) to get an NGINX One subscription, if you don’t already have one.
+2. [Uninstall the NGINX Amplify agent]({{< ref "/amplify/nginx-amplify-agent/install/uninstalling-amplify-agent.md" >}}).
+3. [Follow the NGINX One Console getting started guide]({{< ref "/nginx-one/getting-started.md" >}}).
+
+[Professional Services](https://www.f5.com/services) are available to support your transition. Additional fees may apply.
+
+More details: [Read the community announcement](https://blog.nginx.org/blog/nginx-amplify-endoflife).
+{{</ banner >}}

--- a/content/amplify/_index.md
+++ b/content/amplify/_index.md
@@ -4,5 +4,9 @@ description: Lightweight SaaS monitoring and static analysis for NGINX Open Sour
 url: /nginx-amplify/
 cascade:
   logo: "NGINX-Amplify-product-icon-RGB.svg"
+  nd-banner:
+    enabled: true
+    type: deprecation
+    md: _banners/eol-amplify.md
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a deprecation banner to all NGINX Amplify documentation pages, notifying users of the upcoming End-of-Life (EOL) for **NGINX Amplify on January 31, 2026**.

## What’s Included

- A warning banner appears at the top of every NGINX Amplify page.
- The banner:
  - Announces the official EOL date.
  - Instructs users to migrate to **NGINX One Console**, part of the NGINX One product offering.
  - Lists clear transition steps with links to documentation and sales contact.
  - Notes that [Professional Services](https://www.f5.com/services) are available to assist, and that additional fees may apply.
  - Includes a placeholder for the upcoming community announcement link.

## Visual

<img width="559" height="272" alt="image" src="https://github.com/user-attachments/assets/5c6df535-dfd0-4ad2-ab64-5fa571055b4e" />

