### PR TITLE
feat: Add internal stats page for shortcode usage

### DIFF
--- a/content/stats.md
+++ b/content/stats.md
@@ -1,0 +1,17 @@
+---
+title: Shortcode report
+description: Shortcode report
+nd-content-type: reference
+toc: true
+---
+
+This page contains usage information for shortcodes.
+
+## Include
+{{< shortcode-usage name="include" >}}
+
+## Call Out
+{{< shortcode-usage name="call-out" >}}
+
+## Tab Group
+{{< shortcode-usage name="tabs" >}}

--- a/documentation/include-files.md
+++ b/documentation/include-files.md
@@ -31,9 +31,12 @@ To make sure includes are effective and easy to maintain, follow these guideline
 
 ## Include file index
 
-To aid in discoverability of include files, this index is maintained to offer contributors a reference for existing entries.
+To aid in discoverability of include files, see the [include section](https://docs.nginx.com/stats#include) of our [shortcode report page](https://docs.nginx.com/stats).
+This page is updated as part of every documentation build.
 
 When viewing an include file, you may also see the `files`: parameter in the frontmatter, which shows where the file is currently in use.
+
+Examples of commonly used includes:
 
 | **_File name_** | **_Description_** |
 | ----------------| ------------------ |


### PR DESCRIPTION
feat: Add internal stats page for shortcode usage

Adds a `stats` page - https://frontdoor-test-docs.nginx.com/previews/docs/1328/stats which shows usage of some shortcodes. So far it's `include`, `callout` and `tab group`, but more can be added.