### PR TITLE
Added NGINXaaS for Azure doc on how to change from basic to standard plan

### DIFF
--- a/content/nginxaas-azure/billing/change-plan/_index.md
+++ b/content/nginxaas-azure/billing/change-plan/_index.md
@@ -1,0 +1,5 @@
+---
+title: Change pricing plan
+weight: 300
+url: /nginxaas/azure/billing/change-plan/
+---

--- a/content/nginxaas-azure/billing/change-plan/basic-to-standard.md
+++ b/content/nginxaas-azure/billing/change-plan/basic-to-standard.md
@@ -1,0 +1,40 @@
+---
+title: Change from basic plan to standard plan
+weight: 200
+toc: false
+url: /nginxaas/azure/change-plan/basic-to-standard/
+type:
+- how-to
+---
+
+The basic plan is designed for early-stage trials and testing and is not intended for production use. If you are ready to create a standard plan deployment and wish to preserve the configuration of an existing basic plan deployment, you can [create a new deployment]({{< ref "/nginxaas-azure/getting-started/create-deployment.md">}}), selecting the latest standard pricing plan, and manually reapply your NGINX configuration and certificates. You can also follow the instructions below to recreate your deployment using an Azure Resource Manager (ARM) template.
+
+## Prerequisites
+
+- [Azure CLI Installation](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+- You must be logged in to your Azure account through the CLI. See [Azure CLI Authentication](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli)
+
+## Recreate deployment using ARM template
+
+To export an ARM template for an existing deployment:
+
+1. Go to your existing NGINXaaS deployment.
+1. Select **Export template** under **Automation** in the left menu.
+1. Wait for the template to generate.
+1. Select **Download**.
+1. Decompress the template archive.
+1. Open the `template.json` file and verify that the data in the template is correct. 
+1. In the `resources` section, change `sku.name` to `standardv2_Monthly`. This recreates the deployment as a standard plan deployment.
+1. Delete the original basic plan deployment.
+1. On the command line, run:
+
+```shell
+az deployment group create \
+    --subscription=<deployment subscription ID> \
+    --resource-group=<resource group name> \
+    --template-file=</path/to/template.json>
+```
+
+## Further reading
+
+For further details on recreating a deployment, see our [guide]({{< ref "/nginxaas-azure/quickstart/recreate.md">}}).

--- a/content/nginxaas-azure/billing/change-plan/migrate-from-standard.md
+++ b/content/nginxaas-azure/billing/change-plan/migrate-from-standard.md
@@ -1,8 +1,8 @@
 ---
 title: Migrate from Standard to Standard V2
-weight: 1000
+weight: 100
 toc: true
-url: /nginxaas/azure/getting-started/migrate-from-standard/
+url: /nginxaas/azure/billing/change-plan/migrate-from-standard/
 type:
 - how-to
 ---

--- a/content/nginxaas-azure/changelog/changelog.md
+++ b/content/nginxaas-azure/changelog/changelog.md
@@ -68,9 +68,7 @@ NGINXaaS now allows both precompiled and custom policies for F5 NGINX App Protec
            protected-files: protected-1.conf,protected-2.conf
       ```
 
-
   - To enhance security, the service principal used for Azure login prior to running the NGINXaaS for Azure Deployment Action now only requires the Contributor role at the scope of the NGINXaaS for Azure deployment. It no longer needs the Contributor role at the resource group level containing the deployment.
-
 
 ## May 22, 2025
 
@@ -79,7 +77,6 @@ NGINXaaS now allows both precompiled and custom policies for F5 NGINX App Protec
   Users can now configure their NGINXaaS deployments with just a single IPv6 frontend IP or in dual-stack (IPv4 + IPv6) mode.
 
   If you plan to use an IPv6 IP address whether standalone or in dual-stack mode, ensure that the subnet used by NGINXaaS has both IPv4 and IPv6 address spaces included. For more information on creating a vnets and subnets with IPv6 address spaces, refer to [Add IPv6 to virtual Network](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/add-dual-stack-ipv6-vm-portal?tabs=azureportal#add-ipv6-to-virtual-network)
-
 
 - {{% icon-feature %}} **NGINXaaS is now running NGINX Plus Release 33 (R33) in the Stable Upgrade Channel**
 
@@ -112,7 +109,6 @@ F5 WAF for NGINX is now generally available and is no longer a preview feature a
 
 ## March 31, 2025
 
-
 - {{% icon-feature %}} **NGINXaaS for Azure is now generally available in more regions**
 
   NGINXaaS for Azure is now available in the following additional regions:
@@ -132,7 +128,7 @@ See the [Supported Regions]({{< ref "/nginxaas-azure/overview/overview.md#suppor
 
 - {{% icon-info %}} **Retirement of Standard Plan**
 
-   The `Standard` plan for NGINXaaS for Azure has been retired, and you can no longer use it to create new deployments. If you have a deployment running on the `Standard` plan, consider [migrating]({{< ref "/nginxaas-azure/getting-started/migrate-from-standard.md">}}) it to the [`Standard V2 plan`]({{< ref "/nginxaas-azure/billing/overview.md#standard-v2-plan" >}}) to access new features such as F5 WAF for NGINX and additional listen ports. Plan migration does not incur downtime.
+   The `Standard` plan for NGINXaaS for Azure has been retired and can no longer be used to create new deployments. If you have an existing deployment on the `Standard` plan, consider [migrating]({{< ref "/nginxaas-azure/billing/change-plan/migrate-from-standard.md">}}) to the [`Standard V2 plan`]({{< ref "/nginxaas-azure/billing/overview.md#standard-v2-plan" >}}) to access new features such as F5 WAF for NGINX and additional listen ports. Migrating your plan does not cause downtime.
 
 ## February 10, 2025
 
@@ -144,4 +140,4 @@ See the [Supported Regions]({{< ref "/nginxaas-azure/overview/overview.md#suppor
 
 - {{< icon-feature >}} **In-place SKU Migration from Standard to Standard V2**
 
-   You can now migrate NGINXaaS for Azure from the Standard plan to the Standard V2 plan without redeploying. We recommend upgrading to the Standard V2 plan to access features like F5 WAF for NGINX and more listen ports. The Standard plan will be retired soon. For migration details, see [migrate from standard]({{< ref "/nginxaas-azure/getting-started/migrate-from-standard.md">}}).
+   You can now migrate NGINXaaS for Azure from the `Standard` plan to the `Standard V2` plan without redeploying. We recommend upgrading to the `Standard V2` plan to access features such as F5 WAF for NGINX and additional listen ports. The `Standard` plan will be retired soon. For migration steps, see [Migrate from Standard]({{< ref "/nginxaas-azure/billing/change-plan/migrate-from-standard.md">}}).


### PR DESCRIPTION

This will help users who have outgrown their basic plan deployment and wish to recreate their deployment on the standard plan.

I also grouped all the migration and plan change docs together. The existing migration doc was always out of place within the "Getting Started" section of our docs. We plan to use the "Change pricing plan" section to include more details about changing from basic to standard plans. There may be further docs here about migrating from standard v2 to v3.