### PR TITLE
fix: remove app_protect_enforcer_address from virt config

### DIFF
--- a/content/waf/install/virtual-environment.md
+++ b/content/waf/install/virtual-environment.md
@@ -228,7 +228,7 @@ Here are two examples of how these additions could look in configuration files:
 
 The default path for this file is `/etc/nginx/nginx.conf`.
 
-```nginx {hl_lines=[5, 33]}
+```nginx {hl_lines=[5]}
 user  nginx;
 worker_processes  auto;
 
@@ -270,7 +270,7 @@ http {
 
 The default path for this file is `/etc/nginx/conf.d/default.conf`.
 
-```nginx {hl_lines=[10]}
+```nginx {hl_lines=[9]}
 server {
     listen 80;
     server_name domain.com;


### PR DESCRIPTION
### Proposed changes

Closes #1367 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
