### PR TITLE
Remove 2 instances of term not to be used

### DIFF
--- a/content/nginx/admin-guide/content-cache/content-caching.md
+++ b/content/nginx/admin-guide/content-cache/content-caching.md
@@ -188,7 +188,7 @@ map $request_method $purge_method {
 }
 ```
 
-In this example, NGINX checks if the `PURGE` method is used in a request, and, if so, analyzes the client IP address. If the IP address is whitelisted, then the `$purge_method` is set to `$purge_allowed`: `1` permits purging, and `0` denies it.
+In this example, NGINX checks if the `PURGE` method is used in a request, and, if so, analyzes the client IP address. If the IP address is allowed to, then the `$purge_method` is set to `$purge_allowed`: `1` permits purging, and `0` denies it.
 
 <span id="purge_remove"></span>
 ### Completely Remove Files from the Cache

--- a/content/nginx/deployment-guides/single-sign-on/auth0.md
+++ b/content/nginx/deployment-guides/single-sign-on/auth0.md
@@ -149,7 +149,7 @@ With Auth0 configured, you can enable OIDC on NGINX Plus. NGINX Plus serves as t
     
     - The **logout_uri** is URI that a user visits to start an RP‑initiated logout flow.
 
-    - The **post_logout_uri** is absolute HTTPS URL where Auth0 should redirect the user after a successful logout. This value **must also be whitelisted** in **Allowed Logout URLs** on the Auth0 side.
+    - The **post_logout_uri** is absolute HTTPS URL where Auth0 should redirect the user after a successful logout. This value **must also be specified** in **Allowed Logout URLs** on the Auth0 side.
 
     - If the **logout_token_hint** directive set to `on`, NGINX Plus sends the user’s ID token as a *hint* to Auth0.
       This directive is **optional**, however, if it is omitted the Auth0 may display an extra confirmation page asking the user to approve the logout request.


### PR DESCRIPTION
### Proposed changes

Since these 2 instances of terms can easily be replaced, this PR does so.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
