### PR TITLE
fix: Remove VS/VSR Header subheading

### DIFF
--- a/content/nic/configuration/virtualserver-and-virtualserverroute-resources.md
+++ b/content/nic/configuration/virtualserver-and-virtualserverroute-resources.md
@@ -493,20 +493,6 @@ See the [`sticky`](https://nginx.org/en/docs/http/ngx_http_upstream_module.html?
 |``secure`` | Adds the ``Secure`` attribute to the cookie. | ``boolean`` | No |
 |``samesite`` | Adds the ``SameSite`` attribute to the cookie. The allowed values are: ``strict``, ``lax``, ``none`` | ``string`` | No |
 
-### Header
-
-The header defines an HTTP Header:
-
-```yaml
-name: Host
-value: example.com
-```
-
-|Field | Description | Type | Required |
-| ---| ---| ---| --- |
-|``name`` | The name of the header. | ``string`` | Yes |
-|``value`` | The value of the header. | ``string`` | No |
-
 ### Action
 
 The action defines an action to perform for a request.


### PR DESCRIPTION
### Proposed changes

Remove misleading heading in the VirtualServer/VirtualServerRoute configuration page.  Headers can not be added to the VS/VSR spec directly, only with `Action.Return`, `Action.Proxy.RequestHeaders` & `Action.Proxy.ResponseHeaders`.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
