### PR TITLE
feat: add OIDC timeout config options to NIC ConfigMap

### DIFF
--- a/content/nic/configuration/global-configuration/configmap-resource.md
+++ b/content/nic/configuration/global-configuration/configmap-resource.md
@@ -178,6 +178,17 @@ If you encounter the error `error [emerg] 13#13: "zone_sync" directive is duplic
 |*zone-sync-resolver-ipv6* | Configures whether the optional [resolver](https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver) directive for zone-sync will look up IPv6 addresses. NGINX Plus & `zone-sync` Required | `true` |
 |*zone-sync-resolver-valid* | Configures an [NGINX time](https://nginx.org/en/docs/syntax.html) that the optional [resolver](https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver) directive for zone-sync will override the TTL value of responses from nameservers with. NGINX Plus & `zone-sync` Required | `5s` |
 
+### OIDC (OpenID Connect) Timeouts
+
+For more information on timeouts, see [here](https://github.com/nginxinc/nginx-openid-connect?tab=readme-ov-file#configuring-the-key-value-store)
+
+|ConfigMap Key | Description | Default |
+| ---| ---| ---|
+| *oidc-pkce-timeout* | Sets the timeout for PKCE (Proof Key for Code Exchange) in OIDC. | `90s` |
+| *oidc-id-tokens-timeout* | Sets the timeout for ID tokens in OIDC. | `1h` |
+| *oidc-access-tokens-timeout* | Sets the timeout for access tokens in OIDC. | `1h` |
+| *oidc-refresh-tokens-timeout* | Sets the timeout for refresh tokens in OIDC. | `24h` |
+| *oidc-sids-timeout* | Sets the timeout for session IDs in OIDC. | `24h` |
 
 ### Snippets and custom templates
 


### PR DESCRIPTION
### Proposed changes
Add OIDC Timeout config options to NIC ConfigMap

code pr:
https://github.com/nginx/kubernetes-ingress/pull/8495

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
