### PR TITLE
Fix: WAF debian nginx plus dockerfile needs to show plus version

### DIFF
--- a/content/waf/install/kubernetes.md
+++ b/content/waf/install/kubernetes.md
@@ -102,7 +102,7 @@ If you are not using using `custom_log_format.json` or the IP intelligence featu
 
 {{% tab name="NGINX Plus" %}}
 
-{{< include "/waf/dockerfiles/debian-oss.md" >}}
+{{< include "/waf/dockerfiles/debian-plus.md" >}}
 
 {{% /tab %}}
 


### PR DESCRIPTION
### Proposed changes

The WAF Dockerfile for Debian was showing the OSS instead of Plus Dockerfile include. Fixing this.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
