### PR TITLE
fix: LinkChecker error triggering due to broken njs url

### DIFF
--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/active-directory-federation-services.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/active-directory-federation-services.md
@@ -25,7 +25,7 @@ The instructions assume you have the following:
 
 - A running deployment of AD FS, either on‑premises or in Azure.
 - An NGINX Plus subscription and <span style="white-space: nowrap;">NGINX Plus R15</span> or later. For installation instructions, see the [NGINX Plus Admin Guide](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
-- The [NGINX JavaScript module](https://www.nginx.com/blog/introduction-nginscript/) (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
+- The [NGINX JavaScript module](https://nginx.org/en/docs/njs/index.html) (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
 
    For Debian and Ubuntu:
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/auth0.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/auth0.md
@@ -24,7 +24,7 @@ To complete the steps in this guide, you need the following:
 
 - An Auth0 tenant with administrator privileges.
 - [NGINX Plus](https://www.f5.com/products/nginx/nginx-plus) with a valid subscription.
-- The [NGINX JavaScript module](https://www.nginx.com/products/nginx/modules/nginx-javascript/) (`njs`) -- the `njs` module handles the interaction between NGINX Plus and Auth0.
+- The [NGINX JavaScript module](https://nginx.org/en/docs/njs/index.html) (`njs`) -- the `njs` module handles the interaction between NGINX Plus and Auth0.
 
 ## Install NGINX Plus and the njs Module {#install-nginx-plus-njs}
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/cognito.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/cognito.md
@@ -26,7 +26,7 @@ The instructions assume you have the following:
 
 - An [AWS account](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).
 - An NGINX Plus subscription and <span style="white-space: nowrap;">NGINX Plus R15</span> or later. For installation instructions, see the [NGINX Plus Admin Guide](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
-- The [NGINX JavaScript module](https://www.nginx.com/blog/introduction-nginscript/) (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
+- The [NGINX JavaScript module](https://nginx.org/en/docs/njs/index.html) (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
 
    For Debian and Ubuntu:
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/keycloak.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/keycloak.md
@@ -26,7 +26,7 @@ The instructions assume you have the following:
 
 - A running Keycloak server. See the Keycloak documentation for [Getting Started](https://www.keycloak.org/guides#getting-started) and [Server](https://www.keycloak.org/guides#server) configuration instructions.
 - An NGINX Plus subscription and <span style="white-space: nowrap;">NGINX Plus R15</span> or later. For installation instructions, see the [NGINX Plus Admin Guide](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
-- The [NGINX JavaScript module](https://www.nginx.com/blog/introduction-nginscript/) (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
+- The [NGINX JavaScript module](https://nginx.org/en/docs/njs/index.html) (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
 
    For Debian and Ubuntu:
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/okta.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/okta.md
@@ -24,7 +24,7 @@ To complete the steps in this guide, you need the following:
 
 - An Okta administrator account.
 - [NGINX Plus](https://www.f5.com/products/nginx/nginx-plus) with a valid subscription.
-- The [NGINX JavaScript module](https://www.nginx.com/products/nginx/modules/nginx-javascript/) (`njs`) -- the `njs` module handles the interaction between NGINX Plus and Okta.
+- The [NGINX JavaScript module](https://nginx.org/en/docs/njs/index.html) (`njs`) -- the `njs` module handles the interaction between NGINX Plus and Okta.
 - Install `jq` on the host machine where you installed NGINX Plus.
 
 ## Install NGINX Plus and the njs Module

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/onelogin.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/onelogin.md
@@ -24,7 +24,7 @@ To complete the steps in this guide, you need the following:
 
 - A OneLogin tenant with administrator privileges.
 - [NGINX Plus](https://www.f5.com/products/nginx/nginx-plus) with a valid subscription.
-- The [NGINX JavaScript module](https://www.nginx.com/products/nginx/modules/nginx-javascript/) (`njs`) -- the `njs` module handles the interaction between NGINX Plus and OneLogin identity provider (IdP).
+- The [NGINX JavaScript module](https://nginx.org/en/docs/njs/index.html) (`njs`) -- the `njs` module handles the interaction between NGINX Plus and OneLogin identity provider (IdP).
 
 ## Install NGINX Plus and the njs Module {#install-nginx-plus-njs}
 

--- a/content/nginx/deployment-guides/single-sign-on/oidc-njs/ping-identity.md
+++ b/content/nginx/deployment-guides/single-sign-on/oidc-njs/ping-identity.md
@@ -27,7 +27,7 @@ The instructions assume you have the following:
 
 - A running deployment of PingFederate or PingOne for Enterprise, and a Ping Identity account. For installation and configuration instructions, see the documentation for [PingFederate](https://docs.pingidentity.com/bundle/pingfederate-93/page/tau1564002955783.html) or [PingOne for Enterprise](https://docs.pingidentity.com/bundle/pingone/page/fjn1564020491958-1.html).
 - An NGINX Plus subscription and <span style="white-space: nowrap;">NGINX Plus R15</span> or later. For installation instructions, see the [NGINX Plus Admin Guide](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/).
-- The NGINX JavaScript module (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
+- The [NGINX JavaScript module](https://nginx.org/en/docs/njs/index.html) (njs), required for handling the interaction between NGINX Plus and the IdP. After installing NGINX Plus, install the module with the command for your operating system.
 
    For Debian and Ubuntu:
 


### PR DESCRIPTION
Fixes the URL that points to njs


### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
