### PR TITLE
docs: add access log metrics setup details to Agent docs

### DIFF
--- a/content/includes/use-cases/monitoring/enable-nginx-oss-stub-status.md
+++ b/content/includes/use-cases/monitoring/enable-nginx-oss-stub-status.md
@@ -27,3 +27,17 @@ This configuration:
 - Blocks all other requests for security.
 
 For more details, see the [NGINX Stub Status module documentation](https://nginx.org/en/docs/http/ngx_http_stub_status_module.html).
+
+{{<call-out "note" "Note: NGINX Open Source Metrics" >}} For collecting metrics from NGINX Open Source, ensure that following log format is used in the NGINX configuration:
+
+```nginx
+log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for" '
+                  '"$bytes_sent" "$request_length" "$request_time" '
+                  '"$gzip_ratio" $server_protocol ';
+
+access_log  /var/log/nginx/access.log  main;
+```
+
+{{</call-out>}}

--- a/content/nginx-one-console/agent/configure-instances/configure-agent-features.md
+++ b/content/nginx-one-console/agent/configure-instances/configure-agent-features.md
@@ -88,17 +88,3 @@ Define features in the `nginx-agent.conf` file:
    `sudo systemctl restart nginx-agent`
 
 Once the steps have been completed, users will be able to view metrics data being sent but will not have the capability to push NGINX configuration changes.
-
-{{<call-out "note" "Note: NGINX Access Log Metrics" >}} For collecting metrics from NGINX access logs, ensure that following log format is used in the NGINX configuration:
-
-```nginx
-log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                  '$status $body_bytes_sent "$http_referer" '
-                  '"$http_user_agent" "$http_x_forwarded_for" '
-                  '"$bytes_sent" "$request_length" "$request_time" '
-                  '"$gzip_ratio" $server_protocol ';
-
-access_log  /var/log/nginx/access.log  main;
-```
-
-{{</call-out>}}


### PR DESCRIPTION
### Proposed changes

Update N1C docs to include setting up access logs with Agent for metric collection

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
