### PR TITLE
fixed metadata in N1C api ref guide that prevented it from loading

### DIFF
--- a/content/nginx-one-console/api/api-reference-guide.md
+++ b/content/nginx-one-console/api/api-reference-guide.md
@@ -2,11 +2,14 @@
 description: ''
 nd-docs: DOCS-1398
 nd-content-type: redoc
-nd-product: NONECO
+doctypes:
+  - reference
+type: redoc
 tags:
   - api
 title: API reference guide
 toc: false
 weight: null
 nd-api-reference: "./nginx-one-console/api/one.json"
+nd-product: NONECO
 ---


### PR DESCRIPTION
### Proposed changes

This PR:

- Restores metadata to the N1C API ref guide that prevented the guide from loading when it was missing.