### PR TITLE
fix: sles16 in install guide

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-plus.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-plus.md
@@ -319,21 +319,21 @@ NGINX Plus can be installed on the following versions of Debian or Ubuntu:
 
 1. Add the **nginx-plus** repo.
 
-    **For SLES 15**:
+   For **SLES 15**:
 
-    ```shell
-    zypper addrepo -G -t yum -c \
-    "https://pkgs.nginx.com/plus/sles/15?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer" \
-    nginx-plus
-    ```
+   ```shell
+   zypper addrepo -G -t yum -c \
+   "https://pkgs.nginx.com/plus/sles/15?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer" \
+   nginx-plus
+   ```
 
-    **For SLES 16**:
+   For **SLES 16**:
 
-    ```shell
-    zypper addrepo -G -t yum -c \
-    "https://pkgs.nginx.com/plus/sles/16?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer" \
-    nginx-plus
-    ```
+   ```shell
+   zypper addrepo -G -t yum -c \
+   "https://pkgs.nginx.com/plus/sles/16?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer" \
+   nginx-plus
+   ```
 
 1. Install the **nginx-plus** package. Any older NGINX Plus package is automatically replaced.
 


### PR DESCRIPTION
This PR adds SLES repo installation command to NGINX Plus installaton guide

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
