### PR TITLE
docs: Updates N1 Changelog Regarding API Field Conf_Path

### DIFF
--- a/content/nginx-one-console/changelog.md
+++ b/content/nginx-one-console/changelog.md
@@ -9,7 +9,7 @@ nd-docs: DOCS-1394
 
 Stay up-to-date with what's new and improved in the F5 NGINX One Console.
 
-## January 13, 2026
+## January 27, 2026
 
 ### API behavior change: conf_path is now optional for PUT/PATCH operations
 


### PR DESCRIPTION
### Proposed changes

This commit updates the NGINX One Console changelog to reflect the API behavior change that makes the field `conf_path` go from being `required` to now being `optional`. 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
