### PR TITLE
fix: correct nginx-agent.conf metrics feature for NIC/NIM

### DIFF
--- a/content/nic/tutorials/security-monitoring.md
+++ b/content/nic/tutorials/security-monitoring.md
@@ -66,7 +66,7 @@ If you use custom container images, NGINX Agent must be installed along with F5 
         features:
         - registration
         - nginx-counting
-        - metrics-sender
+        - metrics
         - dataplane-status
         extensions:
         - nginx-app-protect


### PR DESCRIPTION
### Proposed changes

Update the Security monitoring tutorial for NIC & NIM.  The `nginx-agent.conf` had the incorrect metrics feature listed.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
