### PR TITLE
Replaced yumdownloader with yum --downloadonly

### DIFF
--- a/content/waf/install/disconnected-environment.md
+++ b/content/waf/install/disconnected-environment.md
@@ -185,12 +185,11 @@ See the section for your operating system below:
    ```shell
    mkdir -p /offline/packages
 
-   sudo yumdownloader --resolve --destdir=/offline/packages \
+   sudo yum install --downloadonly --downloaddir=/offline/packages \
    app-protect \
    app-protect-attack-signatures \
    app-protect-bot-signatures \
    app-protect-threat-campaigns
-
    ```
 
 #### RHEL / Rocky Linux 9
@@ -224,7 +223,7 @@ See the section for your operating system below:
    ```shell
    mkdir -p /offline/packages
 
-   sudo yumdownloader --resolve --destdir=/offline/packages \
+   sudo yum install --downloadonly --downloaddir=/offline/packages \
    app-protect \
    app-protect-attack-signatures \
    app-protect-bot-signatures \


### PR DESCRIPTION
### Proposed changes

`yumdownloader` doesn't seem to be installed by default, while yum clearly is. So yum `--downloadonly` is preferred

### Checklist

Before sharing this pull request, I completed the following checklist:

- [X] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [X] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [X] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [X] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
