### PR TITLE
fix: default Agent conf outputs OTel to stdout

### DIFF
--- a/content/nginx-one-console/k8s/add-nic.md
+++ b/content/nginx-one-console/k8s/add-nic.md
@@ -113,6 +113,10 @@ data:
         tokenpath: "/etc/nginx-agent/secrets/dataplane.key"
       tls:
         skip_verify: false
+
+collector:
+    log:
+        path: "stdout"
 ```      
 
 Make sure to set the namespace in the nginx-agent.config to the same namespace as NGINX Ingress Controller.


### PR DESCRIPTION
### Proposed changes

Adds the `collector` config to the agent conf in `add-nic.md`.

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
