### PR TITLE
Add missing closing ticks to codeblock

### DIFF
--- a/content/nginx-one-console/nginx-configs/config-templates/import-templates.md
+++ b/content/nginx-one-console/nginx-configs/config-templates/import-templates.md
@@ -170,6 +170,7 @@ ls -la /tmp/verify-archive/
 ``` text
 reverse-proxy.tmpl
 schema.yaml
+```
 
 ### Complete example workflow
 


### PR DESCRIPTION
### Proposed changes

- Add missing ticks to close off codeblock. 
- Thread - https://f5.slack.com/archives/C09LSH7D1PD/p1770245054923589

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
