### PR TITLE
Fixed wrong filename

### DIFF
--- a/content/waf/support.md
+++ b/content/waf/support.md
@@ -52,7 +52,7 @@ system_version.txt
 package_versions.txt
 /var/log/app_protect/*
 /var/log/nginx/*
-/etc/nginx.conf
+/etc/nginx/nginx.conf
 # Add any additional policy or log configuration files
 ```
 


### PR DESCRIPTION
### Proposed changes

Fixed wrong filename, from ︃`/etc/nginx.conf︃` to ︃`/etc/nginx/nginx.conf︃`

### Checklist

Before sharing this pull request, I completed the following checklist:

- [X] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [X] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [X] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
