### PR TITLE
fix: remove wrong field in NIC 5.3.4 release notes

### DIFF
--- a/content/nic/changelog/_index.md
+++ b/content/nic/changelog/_index.md
@@ -24,25 +24,24 @@ For older releases, check the changelogs for previous years: [2025]({{< ref "/ni
 
 {{< /details >}}
 
-
 ## 5.3.4
 
 17 Feb 2026
 
-### {{% icon bug %}} Fixes
-- [9175](https://github.com/nginx/kubernetes-ingress/pull/9175) Replace kind load command in ci tests
-
 ### {{% icon arrow-up %}} Dependencies
+
 - [9177](https://github.com/nginx/kubernetes-ingress/pull/9177) Update go to v1.26
 -  [9131](https://github.com/nginx/kubernetes-ingress/pull/9131),[9163](https://github.com/nginx/kubernetes-ingress/pull/9163),[9162](https://github.com/nginx/kubernetes-ingress/pull/9162),[9164](https://github.com/nginx/kubernetes-ingress/pull/9164),[9114](https://github.com/nginx/kubernetes-ingress/pull/9114),[9099](https://github.com/nginx/kubernetes-ingress/pull/9099),[9104](https://github.com/nginx/kubernetes-ingress/pull/9104) & [9101](https://github.com/nginx/kubernetes-ingress/pull/9101) Bump Go dependencies
 -  [9161](https://github.com/nginx/kubernetes-ingress/pull/9161),[9130](https://github.com/nginx/kubernetes-ingress/pull/9130),[9136](https://github.com/nginx/kubernetes-ingress/pull/9136),[9133](https://github.com/nginx/kubernetes-ingress/pull/9133),[9143](https://github.com/nginx/kubernetes-ingress/pull/9143), [9113](https://github.com/nginx/kubernetes-ingress/pull/9113),[9100](https://github.com/nginx/kubernetes-ingress/pull/9100), [9098](https://github.com/nginx/kubernetes-ingress/pull/9098), [9129](https://github.com/nginx/kubernetes-ingress/pull/9129), [9152](https://github.com/nginx/kubernetes-ingress/pull/9152), [9180](https://github.com/nginx/kubernetes-ingress/pull/9180),[9097](https://github.com/nginx/kubernetes-ingress/pull/9097), [9128](https://github.com/nginx/kubernetes-ingress/pull/9128) & [9151](https://github.com/nginx/kubernetes-ingress/pull/9151) Bump Docker dependencies
 
 ### {{% icon download %}} Upgrade
+
 - For NGINX, use the 5.3.4 images from our [DockerHub](https://hub.docker.com/r/nginx/nginx-ingress/tags?page=1&ordering=last_updated&name=5.3.4), [GitHub Container](https://github.com/nginx/kubernetes-ingress/pkgs/container/kubernetes-ingress), [Amazon ECR Public Gallery](https://gallery.ecr.aws/nginx/nginx-ingress) or [Quay.io](https://quay.io/repository/nginx/nginx-ingress).
 - For NGINX Plus, use the 5.3.4 images from the F5 Container registry or build your own image using the 5.3.4 source code.
 - For Helm, use version 2.4.4 of the chart.
 
 ### {{% icon life-buoy %}} Supported Platforms
+
 We will provide technical support for NGINX Ingress Controller on any Kubernetes platform that is currently supported by its provider and that passes the Kubernetes conformance tests. This release was fully tested on the following Kubernetes versions: 1.27-1.35.
 
 ## 5.3.3


### PR DESCRIPTION
### Proposed changes

Quick fix to remove a wrong field from the latest NIC release's patch notes. This was a rebase issue when merging. 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
