### PR TITLE
WAF: add sudo to upgrade

### DIFF
--- a/content/waf/install/upgrade.md
+++ b/content/waf/install/upgrade.md
@@ -25,7 +25,7 @@ sudo dnf -y update app-protect
 While an `apt` based system would use the following instead:
 
 ```shell
-sudo apt-get update && apt-get install -y app-protect
+sudo apt-get update && sudo apt-get install -y app-protect
 ```
 
 ## Docker deployments


### PR DESCRIPTION
### Proposed changes

The WAF upgrade docs were missing a sudo on the install command for debian/ubuntu, causing it to fail. 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
