### PR TITLE
fix: add missing NIC-WAF version to the respective table

### DIFF
--- a/content/includes/nic/compatibility-tables/nic-nap.md
+++ b/content/includes/nic/compatibility-tables/nic-nap.md
@@ -14,7 +14,7 @@ NGINX Ingress Controller supports the following versions of [F5 WAF for NGINX](h
 | NIC Version         | NAP-WAF Version | Config Manager | Enforcer |
 | ------------------- | --------------- | -------------- | -------- |
 | {{< nic-version >}} | 36+{{< appprotect-compiler-version>}}       | {{< nic-waf-release-version >}}          | {{< nic-waf-release-version >}}   |
-| 5.3.4               | 35+5.527.0      | 5.11.2         | 5.11.2    |
+| 5.3.4               | 35+5.527.0      | 5.11.2         | 5.11.2   |
 | 5.2.1               | 35+5.527.0      | 5.9.0          | 5.9.0    |
 | 5.1.1               | 35+5.498        | 5.8.0          | 5.8.0    |
 | 5.0.0               | 34+5.342        | 5.6.0          | 5.6.0    |

--- a/content/includes/nic/compatibility-tables/nic-nap.md
+++ b/content/includes/nic/compatibility-tables/nic-nap.md
@@ -14,6 +14,7 @@ NGINX Ingress Controller supports the following versions of [F5 WAF for NGINX](h
 | NIC Version         | NAP-WAF Version | Config Manager | Enforcer |
 | ------------------- | --------------- | -------------- | -------- |
 | {{< nic-version >}} | 36+{{< appprotect-compiler-version>}}       | {{< nic-waf-release-version >}}          | {{< nic-waf-release-version >}}   |
+| 5.3.4               | 35+5.527.0      | 5.11.2          | 5.11.2    |
 | 5.2.1               | 35+5.527.0      | 5.9.0          | 5.9.0    |
 | 5.1.1               | 35+5.498        | 5.8.0          | 5.8.0    |
 | 5.0.0               | 34+5.342        | 5.6.0          | 5.6.0    |

--- a/content/includes/nic/compatibility-tables/nic-nap.md
+++ b/content/includes/nic/compatibility-tables/nic-nap.md
@@ -14,7 +14,7 @@ NGINX Ingress Controller supports the following versions of [F5 WAF for NGINX](h
 | NIC Version         | NAP-WAF Version | Config Manager | Enforcer |
 | ------------------- | --------------- | -------------- | -------- |
 | {{< nic-version >}} | 36+{{< appprotect-compiler-version>}}       | {{< nic-waf-release-version >}}          | {{< nic-waf-release-version >}}   |
-| 5.3.4               | 35+5.527.0      | 5.11.2          | 5.11.2    |
+| 5.3.4               | 35+5.527.0      | 5.11.2         | 5.11.2    |
 | 5.2.1               | 35+5.527.0      | 5.9.0          | 5.9.0    |
 | 5.1.1               | 35+5.498        | 5.8.0          | 5.8.0    |
 | 5.0.0               | 34+5.342        | 5.6.0          | 5.6.0    |


### PR DESCRIPTION
### Proposed changes

It seems when updating NIC Docs, we replaced instead of adding to this compatability table. This adds the previous version of NIC to the table.

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
