### PR TITLE
fix: correct Ubuntu packages link reference

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-open-source.md
@@ -266,7 +266,7 @@ Before installing, check if your operating system and architecture are supported
 
 ### Debian packages
 
-This section covers Debian packages only. For Ubuntu-specific instructions, see [Ubuntu packages](#prebuilt_ubuntu).
+This section covers Debian packages only. For Ubuntu-specific instructions, see [Ubuntu packages](#ubuntu-packages).
 
 Before installing, check if your operating system and architecture are supported, see [Supported distributions and versions](https://nginx.org/en/linux_packages.html#distributions).
 


### PR DESCRIPTION
The anchor for the Ubuntu Packages Installation Heading is not working. This commit updates the anchor link reference from `#prebuild_ubuntu` to `#ubuntu-packages` to match Hugo's generated ID for the Ubuntu packages heading. With this change, the anchor works properly.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
