### PR TITLE
Chore(CODEOWNERS): Adjust WAF Content to Updated GitHub Team Tag 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,8 +26,8 @@ content/nginx/nms/agent/*   @nginx/nginx-agent
 content/nap-dos/*           @nginx/dos-docs-approvers
 
 # F5 WAF for NGINX
-content/waf/*               @nginx/waf
-content/includes/waf/*      @nginx/waf
+content/waf/*               @nginx/nap-dev
+content/includes/waf/*      @nginx/nap-dev
 
 # NGINXaaS for Azure 
 content/nginxaas-azure/*          @nginx/nginxaas-docs-approvers


### PR DESCRIPTION
### Proposed changes

Adjusts CODEOWNERs for WAF content to reference the new GitHub team. (nginx/waf -> nginx/nap-dev)

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
