### PR TITLE
NGF: Update grafana helm chart

### DIFF
--- a/content/ngf/monitoring/prometheus.md
+++ b/content/ngf/monitoring/prometheus.md
@@ -42,9 +42,9 @@ Visit [http://127.0.0.1:9090](http://127.0.0.1:9090) to view the dashboard.
 ### Grafana
 
 ```shell
-helm repo add grafana https://grafana.github.io/helm-charts
+helm repo add grafana-community https://grafana-community.github.io/helm-charts
 helm repo update
-helm install grafana grafana/grafana -n monitoring --create-namespace
+helm install grafana grafana-community/grafana -n monitoring --create-namespace
 ```
 
 Once running, you can access the Grafana dashboard by using port-forwarding in the background:


### PR DESCRIPTION
As of a couple of months ago, the old helm chart for grafana has been deprecated in favor of the `grafana-community` one. More details can be found here https://github.com/grafana/helm-charts/issues/4087. This PR updates our Prometheus and Grafana guide to point to the correct helm chart. 
