### PR TITLE
NIM update security policy

### DIFF
--- a/content/nim/waf-integration/policies-and-logs/policies/add-signature-sets.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/add-signature-sets.md
@@ -7,9 +7,9 @@ nd-content-type: how-to
 nd-product: NIMNGR
 ---
 
-This topic describes how to configure signature sets and signature exceptions in F5 WAF for NGINX policies. When you add or edit a policy, NGINX Instance Manager provides options to customize attack signatures to better protect your applications.
+You can configure attack signature sets and exceptions in your F5 WAF for NGINX policies. When you add or edit a policy, you can customize attack signatures to better protect your applications.
 
-## Understanding signature sets and exceptions
+## Signature sets and exceptions
 
 Attack signatures are rules or patterns that identify known attack sequences or classes of attacks on a web application. F5 WAF for NGINX includes predefined attack signatures grouped into signature sets.
 
@@ -21,7 +21,7 @@ For example, you might have sets for SQL Injection Signatures, Cross-Site Script
 
 ### Signature exceptions
 
-A **signature exception** allows you to explicitly enable or disable individual attack signatures within a set. This gives you fine-grained control over your policy. For example:
+Use a **signature exception** to enable or disable individual attack signatures within a set. This gives you fine-grained control over your policy. For example:
 
 - If a signature in a set causes false positives (blocking legitimate traffic), you can create an exception to disable that signature while keeping the rest of the set active.
 - If you want to enable blocking for a single attack signature rather than an entire set, you can create an exception to enable just that signature.
@@ -122,6 +122,6 @@ From the **Web Protection** section, select **Attack Signature Exceptions**. Thi
 
 4. Select **Add policy**. The policy JSON updates with your changes, and the new policy appears in the list under the name you provided.
 
-From the **NGINX Instance Manager** web interface, you can review and modify saved policies at any time. Go to **WAF** > **Policies** to view or edit an existing policy.
+In the NGINX Instance Manager web interface, you can review and change saved policies at any time. Go to **WAF** > **Policies** to view or edit an existing policy.
 
 For a complete list of available signature sets and detailed information about attack signatures, see the [Attack Signatures]({{< ref "/waf/policies/attack-signatures.md" >}}) documentation.

--- a/content/nim/waf-integration/policies-and-logs/policies/cookies-parameters-urls.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/cookies-parameters-urls.md
@@ -9,7 +9,7 @@ nd-product: NIMNGR
 
 ## Add cookies
 
-Cookie protections can be configured and managed directly in the policy editor by selecting **Cookies** in the web interface.
+Configure and manage cookie protections in the policy editor by selecting **Cookies** in the web interface.
 
 ### Cookie properties and types
 
@@ -21,7 +21,7 @@ Each cookie configuration includes:
   - **Allow**: The cookie can be changed by the client and is not protected from modification.
   - **Enforce**: The cookie cannot be changed by the client.
 - `Attack Signatures`: Indicates whether attack signatures and threat campaigns are enabled, disabled, or not applicable.
-- `Mask value in logs`: When enabled, the cookie's value is masked in the request log for improved security and privacy.
+- `Mask value in logs`: When turned on, the cookie's value is masked in the request log for security and privacy.
 
 For a complete list of configurable cookie properties and options, see the [Cookie Configuration Parameters]({{< ref "/waf/policies/parameter-reference.md" >}}) documentation under the `cookies` section.
 
@@ -37,17 +37,17 @@ Select **Edit configuration** to configure cookie violations. The following viol
 For each violation type, you can:
 
 - Set the enforcement action.
-- Toggle `Alarm`, `Alarm and Block`, or `Disabled` settings.
+- Set the action to **Alarm**, **Alarm and Block**, or **Disabled**.
 
 See [Supported Violations]({{< ref "/waf/policies/violations.md#supported-violations" >}}) for additional details.
 
 ### Add a cookie to your policy
 
-1. Choose a **Cookie Type**:
+1. Select a **Cookie Type**:
    - Select either `Explicit` for exact cookie matching or `Wildcard` for pattern-based matching.
 2. Configure basic properties:
    - Enter the `Cookie Name`.
-   - Choose whether to mask the cookie value in logs.
+   - Specify whether to mask the cookie value in logs.
 3. Set an **Enforcement Type**:
    - Choose either `Allow` or `Enforce`.
 4. (Optional) Configure attack signatures:
@@ -57,7 +57,7 @@ See [Supported Violations]({{< ref "/waf/policies/violations.md#supported-violat
 
 ## Add parameters
 
-Parameter protections can be configured and managed directly in the policy editor by selecting **Parameters** in the web interface.
+Configure and manage parameter protections in the policy editor by selecting **Parameters** in the web interface.
 
 ### Parameter properties and types
 
@@ -68,7 +68,7 @@ Each parameter configuration includes:
 - `Location`: Where the parameter is expected (URL query string, POST data, etc.).
 - `Value Type`: The expected type of the parameter value (for example, alphanumeric, integer, or email).
 - `Attack Signatures`: Whether attack signature checking is enabled for this parameter.
-- `Mask value in logs`: When enabled, the parameter's value is masked in the request log for enhanced security and privacy. This sets the `sensitiveParameter` property of the parameter item.
+- `Mask value in logs`: When turned on, the parameter's value is masked in the request log for security and privacy. This sets the `sensitiveParameter` property of the parameter item.
 
 For a complete list of configurable parameter properties and options, see the [Parameter Configuration Parameters]({{< ref "/waf/policies/parameter-reference.md" >}}) documentation under the `parameters` section.
 
@@ -94,13 +94,13 @@ Select **Edit configuration** to configure parameter violations. The following v
 For each violation type, you can:
 
 - Set the enforcement action.
-- Toggle `Alarm`, `Alarm and Block`, or `Disabled` settings.
+- Set the action to **Alarm**, **Alarm and Block**, or **Disabled**.
 
 See [Supported Violations]({{< ref "/waf/policies/violations.md#supported-violations" >}}) for additional details.
 
 ### Add a parameter to your policy
 
-1. Choose a **Parameter Type**:
+1. Select a **Parameter Type**:
    - Select either `Explicit` for exact parameter matching or `Wildcard` for pattern-based matching.
 2. Configure basic properties:
    - Enter the `Parameter Name`.
@@ -122,7 +122,7 @@ See [Supported Violations]({{< ref "/waf/policies/violations.md#supported-violat
 
 ## Add URLs
 
-URL protections can be configured and managed directly in the policy editor by selecting **URLs** in the web interface.
+Configure and manage URL protections in the policy editor by selecting **URLs** in the web interface.
 
 ### URL properties and types
 
@@ -137,7 +137,7 @@ Each URL configuration includes:
 - `Attack Signatures`: Indicates whether attack signatures and threat campaigns are enabled, disabled, or not applicable.
 
 {{< call-out "important" >}}
-Attack signatures are automatically shown as “Not applicable” when the Enforcement Type is set to `Disallow`, since the URL is explicitly blocked and signature checking is unnecessary.
+Attack signatures are automatically shown as "Not applicable" when the Enforcement Type is set to `Disallow`, because the URL is explicitly blocked and signature checking is unnecessary.
 {{< /call-out >}}
 
 For a complete list of configurable URL properties and options, see the [URL Configuration Parameters]({{< ref "/waf/policies/parameter-reference.md" >}}) documentation under the `urls` section.
@@ -154,13 +154,13 @@ Select **Edit configuration** to configure URL violations. The following violati
 For each violation type, you can:
 
 - Set the enforcement action.
-- Toggle `Alarm`, `Alarm and Block`, or `Disabled` settings.
+- Set the action to **Alarm**, **Alarm and Block**, or **Disabled**.
 
 See [Supported Violations]({{< ref "/waf/policies/violations.md#supported-violations" >}}) for additional details.
 
 ### Add a URL to your policy
 
-1. Choose a **URL Type**:
+1. Select a **URL Type**:
    - Select either `Explicit` for exact URL matching or `Wildcard` for pattern-based matching.
 2. Configure basic properties:
    - Enter the `URL` path (for example, `/index.html`, `/api/data`).

--- a/content/nim/waf-integration/policies-and-logs/policies/create-policy.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/create-policy.md
@@ -28,7 +28,7 @@ To create a security policy using the NGINX Instance Manager web interface:
 
    In the configuration file, this is set using the `enforcementMode` property.
 
-5. To change character encoding, select **Show Advanced Fields**, then choose an application language. The default encoding is Unicode (`utf-8`).
+5. To change character encoding, select **Show Advanced Fields**, then select an application language. The default encoding is Unicode (`utf-8`).
 
 ### Configure a policy
 

--- a/content/nim/waf-integration/policies-and-logs/policies/delete-policy.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/delete-policy.md
@@ -17,7 +17,7 @@ You can delete a security policy using either the NGINX Instance Manager web int
 
 To delete a policy in the web interface:
 
-1. In your browser, go to the FQDN for your NGINX Instance Manager host and log in.
+1. Log in to NGINX Instance Manager.
 1. From the Launchpad, select **Instance Manager**.
 1. In the left menu, select **WAF > Policies**.
 1. On the **Security Policies** page, locate the policy you want to delete.

--- a/content/nim/waf-integration/policies-and-logs/policies/review-policy.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/review-policy.md
@@ -7,7 +7,7 @@ nd-content-type: how-to
 nd-product: NIMNGR
 ---
 
-Before deploying a policy to an NGINX instance or instance group, you can review it in NGINX Instance Manager. The system stores all F5 WAF for NGINX policies and their version history, so you can review details or roll back to an earlier version if needed.
+Before deploying a policy to an NGINX instance or instance group, you can review it in NGINX Instance Manager. The system stores all F5 WAF for NGINX policies and their version history. You can review any version or roll back to an earlier version if needed.
 
 ## Review policies
 

--- a/content/nim/waf-integration/policies-and-logs/policies/update-policy.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/update-policy.md
@@ -30,7 +30,7 @@ To update a policy in the web interface:
 
 {{%tab name="API"%}}
 
-To update a policy using the REST API, use `POST` with `isNewRevision=true`. Both methods create a new revision. `PUT` is deprecated — use `POST` instead.
+To update a policy using the REST API, use `POST` with `isNewRevision=true`. Both the `POST` and `PUT` methods create a new policy revision. However, `PUT` is deprecated — use `POST` instead.
 
 {{< table >}}
 | Method | Endpoint |
@@ -39,7 +39,7 @@ To update a policy using the REST API, use `POST` with `isNewRevision=true`. Bot
 | PUT (deprecated) | `/api/platform/v1/security/policies/{policy_uid}` |
 {{</ table >}}
 
-**Example using POST:**
+**Example using POST (creates a new policy revision):**
 
 ```shell
 curl -X POST https://<NIM_FQDN>/api/platform/v1/security/policies?isNewRevision=true \
@@ -48,7 +48,7 @@ curl -X POST https://<NIM_FQDN>/api/platform/v1/security/policies?isNewRevision=
   -d @update-xss-policy.json
 ```
 
-**Example using PUT (deprecated):**
+**Example using PUT (creates a new policy revision, deprecated):**
 
 {{< call-out "caution" "Deprecated" >}}The `PUT` method is deprecated. Use `POST` with `isNewRevision=true` instead.{{< /call-out >}}
 

--- a/content/nim/waf-integration/policies-and-logs/policies/update-policy.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/update-policy.md
@@ -24,23 +24,22 @@ To update a policy in the web interface:
 1. The policy editor opens. Change the policy as described in [Create a security policy]({{< ref "/nim/waf-integration/policies-and-logs/policies/create-policy.md" >}}).
 1. After making your changes, select **Save**.
 
+{{< call-out "note" "Note" >}}Editing a policy creates a new revision, whether or not you've deployed it.{{< /call-out >}}
+
 {{%/tab%}}
 
 {{%tab name="API"%}}
 
-To update a policy using the REST API, send either a `POST` or `PUT` request to the Security Policies endpoint.
-
-- Use `POST` with the `isNewRevision=true` parameter to create a new revision of an existing policy.
-- Use `PUT` with the policy UID to overwrite the existing version.
+To update a policy using the REST API, use `POST` with `isNewRevision=true`. Both methods create a new revision. `PUT` is deprecated — use `POST` instead.
 
 {{< table >}}
 | Method | Endpoint |
 |--------|-----------|
 | POST | `/api/platform/v1/security/policies?isNewRevision=true` |
-| PUT | `/api/platform/v1/security/policies/{policy_uid}` |
+| PUT (deprecated) | `/api/platform/v1/security/policies/{policy_uid}` |
 {{</ table >}}
 
-**Example using POST (create new revision):**
+**Example using POST:**
 
 ```shell
 curl -X POST https://<NIM_FQDN>/api/platform/v1/security/policies?isNewRevision=true \
@@ -49,9 +48,11 @@ curl -X POST https://<NIM_FQDN>/api/platform/v1/security/policies?isNewRevision=
   -d @update-xss-policy.json
 ```
 
-**Example using PUT (overwrite existing):**
+**Example using PUT (deprecated):**
 
-1. Retrieve the policy’s unique identifier (UID):
+{{< call-out "caution" "Deprecated" >}}The `PUT` method is deprecated. Use `POST` with `isNewRevision=true` instead.{{< /call-out >}}
+
+1. Get the policy UID:
 
    ```shell
    curl -X GET https://<NIM_FQDN>/api/platform/v1/security/policies \

--- a/content/nim/waf-integration/policies-and-logs/policies/update-policy.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/update-policy.md
@@ -17,11 +17,11 @@ You can update an existing F5 WAF for NGINX security policy using either the NGI
 
 To update a policy in the web interface:
 
-1. In your browser, go to the FQDN for your NGINX Instance Manager host and log in.
+1. Log in to NGINX Instance Manager.
 1. From the Launchpad, select **Instance Manager**.
 1. In the left menu, select **WAF > Policies**.
 1. On the **Security Policies** page, select **Edit** from the **Actions** column for the policy you want to update.
-1. The editor opens, allowing you to modify the policy as described in [Create a security policy]({{< ref "/nim/waf-integration/policies-and-logs/policies/create-policy.md" >}}).
+1. The policy editor opens. Change the policy as described in [Create a security policy]({{< ref "/nim/waf-integration/policies-and-logs/policies/create-policy.md" >}}).
 1. After making your changes, select **Save**.
 
 {{%/tab%}}
@@ -61,7 +61,7 @@ curl -X POST https://<NIM_FQDN>/api/platform/v1/security/policies?isNewRevision=
 1. Include the UID in your `PUT` request:
 
    ```shell
-   curl -X PUT https://<NIM_FQDN>/api/platform/v1/security/policies/<policy-uid> \
+   curl -X PUT https://<NIM_FQDN>/api/platform/v1/security/policies/{policy-uid} \
      -H "Authorization: Bearer <access token>" \
      -H "Content-Type: application/json" \
      -d @update-xss-policy.json

--- a/content/nim/waf-integration/policies-and-logs/policies/waf-policy-matching-types.md
+++ b/content/nim/waf-integration/policies-and-logs/policies/waf-policy-matching-types.md
@@ -7,7 +7,7 @@ nd-content-type: how-to
 nd-product: NIMNGR
 ---
 
-In F5 WAF for NGINX, you can define how the WAF identifies and protects URLs, cookies, and parameters using **explicit** or **wildcard** matching. The matching type determines how closely the WAF compares incoming requests to the entities defined in your security policy.
+In F5 WAF for NGINX, you can use **explicit** or **wildcard** matching to define how the WAF identifies and protects URLs, cookies, and parameters. The matching type determines how closely the WAF compares incoming requests to entities in your security policy.
 
 ## Explicit matching
 


### PR DESCRIPTION
### Proposed changes

This PR:

- Updates `content/nim/waf-integration/policies-and-logs/policies/update-policy.md`
  - Clarifies that edits to policies create new revisions
  - Marks the `PUT` method as deprecated

<img width="682" height="1104" alt="image" src="https://github.com/user-attachments/assets/4efeb368-da5b-476c-a8e5-fff30565e955" />
