### PR TITLE
docs: add FCP renewal caution to JWT licensing pages (TECHDOCS-4569)

### DIFF
--- a/content/includes/licensing-and-reporting/fcp-renewal-caution.md
+++ b/content/includes/licensing-and-reporting/fcp-renewal-caution.md
@@ -1,0 +1,14 @@
+---
+docs:
+nd-files:
+- content/solutions/about-subscription-licenses/getting-started.md
+- content/solutions/about-subscription-licenses/nginx-plus-licensing-workflows.md
+---
+
+{{< call-out "caution" "FCP subscription renewals require a manual JWT update" >}}
+If your subscription uses the Flex Consumption Program (FCP), automatic JWT renewal isn't supported. When F5 renews an FCP subscription, it creates a new subscription ID. NGINX Plus doesn't recognize this as a renewal, so the JWT license won't update automatically. If you don't update the license before it expires, NGINX Plus will stop processing traffic.
+
+Check your subscription type in [MyF5](https://my.f5.com) and plan to [update the JWT license manually]({{< ref "/solutions/about-subscription-licenses/getting-started.md#manually-update-license" >}}) at each renewal.
+
+For details and steps, see [K000160880: JWT license auto-renewal may fail in NGINX Plus](https://my.f5.com/manage/s/article/K000160880).
+{{< /call-out >}}

--- a/content/solutions/about-subscription-licenses/_index.md
+++ b/content/solutions/about-subscription-licenses/_index.md
@@ -11,9 +11,9 @@ url: /solutions/about-subscription-licenses/
 
 Starting with NGINX Plus R33, subscription licenses use JSON Web Tokens (JWTs) and require usage reporting.  
 
-To get up and running, you’ll need to add a valid license to each instance and make sure usage data can be reported.  
+To get started, add a valid license to each instance and set up usage reporting.
 
-The resources below walk you through upgrading, setting up your environment, and understanding how licensing and reporting work in NGINX Plus.
+The resources below cover upgrading, setting up your environment, and understanding how NGINX Plus licensing and reporting work.
 
 ## Featured content
 

--- a/content/solutions/about-subscription-licenses/_index.md
+++ b/content/solutions/about-subscription-licenses/_index.md
@@ -13,7 +13,7 @@ Starting with NGINX Plus R33, subscription licenses use JSON Web Tokens (JWTs) a
 
 To get started, add a valid license to each instance and set up usage reporting.
 
-The resources below cover upgrading, setting up your environment, and understanding how NGINX Plus licensing and reporting work.
+The resources below cover upgrading, setting up your environment, and understanding NGINX product licensing and reporting.
 
 ## Featured content
 

--- a/content/solutions/about-subscription-licenses/getting-started.md
+++ b/content/solutions/about-subscription-licenses/getting-started.md
@@ -8,7 +8,7 @@ nd-resource: https://lucid.app/lucidchart/0abcb9d3-b36e-40af-b56a-e74771b384d5/e
 nd-docs: DOCS-1780
 ---
 
-Starting with NGINX Plus R33, NGINX Plus instances require a valid JSON Web Token (JWT) license.  
+NGINX Plus R33 and later require a valid JSON Web Token (JWT) license.  
 
 The license:
 
@@ -32,10 +32,7 @@ For flowcharts that show how these requirements work in practice, see [NGINX Plu
 
 ### Starting NGINX Plus
 
-Starting NGINX Plus requires:
-
-- A valid license.
-- A license that has not been expired for more than 90 days.
+Starting NGINX Plus requires a valid, unexpired license. If the license has expired, NGINX Plus can still start during the 90-day grace period.
 
 ### Processing traffic
 
@@ -57,8 +54,6 @@ After you download the JWT license, deploy it to your NGINX Plus instances in on
   - In [NGINX Instance Manager]({{< ref "/nim/nginx-instances/manage-instance-groups.md" >}}), use an **instance group**, which works the same way as a Config Sync Group.  
 - **Copy the license manually:** Place the license file on each NGINX Plus instance yourself.  
 
-Both methods ensure your NGINX Plus instances have access to the required license file.  
-
 Choose the option that fits your environment:  
 
 {{< details summary="Deploy with a group sync feature (recommended)" >}}
@@ -68,7 +63,7 @@ Choose the option that fits your environment:
 {{< include "/licensing-and-reporting/deploy-jwt-with-csgs.md" >}}
 
 {{< call-out "note" "" >}}
-In NGINX Instance Manager, *instance groups* provide the same sync functionality as Config Sync Groups in the NGINX One Console.  
+In NGINX Instance Manager, **instance groups** provide the same sync functionality as Config Sync Groups in the NGINX One Console.  
 See [Manage instance groups]({{< ref "/nim/nginx-instances/manage-instance-groups.md" >}}) for setup instructions.
 {{< /call-out >}}
 
@@ -106,7 +101,7 @@ In connected environments, NGINX Plus sends usage reports directly to the F5 lic
 
 Allow the necessary outbound traffic so reports can reach F5.
 
-1. Allow NGINX Plus instances to connect to the F5 licensing endpoint (`product.connect.nginx.com`) over HTTPS (TCP `443`). Make sure the following IP addresses are allowed:
+1. Allow NGINX Plus instances to connect to the F5 licensing endpoint (`product.connect.nginx.com`) over HTTPS (TCP `443`). Allow the following IP addresses:
 
    - `3.135.72.139`  
    - `3.133.232.50`  
@@ -152,8 +147,7 @@ mgmt {
 ```
 
 {{< call-out "important" "Important" >}}
-After 180 days, if usage reporting still hasn’t been established,
-NGINX Plus will stop processing traffic.
+After 180 days without usage reporting, NGINX Plus stops processing traffic.
 {{< /call-out >}}
 
 ## Update the license {#update-license}
@@ -162,6 +156,8 @@ How you update the JWT license depends on your NGINX Plus release and environmen
 
 - In R35 and later, the license is updated automatically when the subscription renews (if reporting is configured).  
 - In earlier releases or disconnected environments, you need to update the license manually.  
+
+{{< include "licensing-and-reporting/fcp-renewal-caution.md" >}}
 
 {{< details summary="Update the license automatically (R35 and later)" >}}
 
@@ -186,7 +182,6 @@ Automatic updates only work if:
 
 If these conditions aren’t met, you must [update the JWT license manually](#manually-update-license).  
 {{< /call-out >}}
-
 {{< /details >}}
 
 {{< details summary="Update the license manually (all releases)" >}}
@@ -198,8 +193,8 @@ If automatic updates are not available (for example, in disconnected environment
 1. [Download the new JWT license](#download-jwt) from MyF5.  
 1. [Deploy the JWT license](#deploy-jwt) to your NGINX Plus instances.
 
-{{< call-out "note" "Note for Internet-connected environments" >}}
-If you manually updated your JWT license after subscription renewal, you may see this [error log message](#log-monitoring): `[notice] renewed license does not match the original one; using original license`. No action is needed and you can safely ignore this message. For details, see [K000159013](https://my.f5.com/manage/s/article/K000159013).
+{{< call-out "note" "Note for internet-connected environments" >}}
+If you manually updated your JWT license after subscription renewal, you may see this [error log message](#log-monitoring): `[notice] renewed license does not match the original one; using original license`. You don't need to take action. You can safely ignore this message. For details, see [K000159013](https://my.f5.com/manage/s/article/K000159013).
 {{< /call-out >}}
 
 {{< /details >}}

--- a/content/solutions/about-subscription-licenses/nginx-plus-licensing-workflows.md
+++ b/content/solutions/about-subscription-licenses/nginx-plus-licensing-workflows.md
@@ -12,27 +12,27 @@ This reference shows how NGINX Plus validates license status and sends usage rep
 
 ## Startup check
 
-_Click on the image to enlarge._
+_Select the image to enlarge._
 
 [{{< img src="solutions/about-subscription-licenses/images/NGINX-Plus-startup-check.svg" width="747" >}}](../images/NGINX-Plus-startup-check.svg)
 
 ## License expiration check
 
-_Click on the image to enlarge._
+_Select the image to enlarge._
 
 [{{< img src="solutions/about-subscription-licenses/images/NGINX-Plus-license-expiration-check.svg" width="747" >}}](../images/NGINX-Plus-license-expiration-check.svg)
 
-## Licensing reporting check
+## License reporting check
 
-_Click on the image to enlarge._
+_Select the image to enlarge._
 
 Default: every 1 hour.
 
 [{{< img src="solutions/about-subscription-licenses/images/NGINX-Plus-licensing-reporting-check.svg" width="747" >}}](../images/NGINX-Plus-licensing-reporting-check.svg)
 
-## Licensing reporting check (offline)
+## License reporting check (offline)
 
-_Click on the image to enlarge._
+_Select the image to enlarge._
 
 Default: every 1 hour.
 
@@ -40,8 +40,10 @@ Default: every 1 hour.
 
 ## License renewal using JWT token
 
-_Click on the image to enlarge._
+_Select the image to enlarge._
 
 [{{< img src="solutions/about-subscription-licenses/images/NGINX-Plus-license-renewal-with-JWT.svg" width="747" >}}](../images/NGINX-Plus-license-renewal-with-JWT.svg)
 
 Default: every 1 hour.
+
+{{< include "licensing-and-reporting/fcp-renewal-caution.md" >}}


### PR DESCRIPTION
### Proposed changes

This PR:

- Adds a note to the JWT solutions docs re: FCP subscription renewals require a manual JWT update.
- Closes https://jira.f5net.com/browse/TECHDOCS-4569

<img width="759" height="540" alt="image" src="https://github.com/user-attachments/assets/c320073c-86f3-487a-9bd9-c11265b45e24" />
