### PR TITLE
docs(nim): add NIM service log monitoring to usage reporting pages

### DIFF
--- a/content/includes/licensing-and-reporting/nim-service-log-location.md
+++ b/content/includes/licensing-and-reporting/nim-service-log-location.md
@@ -1,0 +1,15 @@
+---
+nd-product: NIMNGR
+nd-files:
+- content/nim/licensing-and-reporting/report-usage-connected-deployment.md
+- content/nim/licensing-and-reporting/report-usage-disconnected-deployment.md
+---
+
+All usage reporting logs are written by the `nms-integrations` process. Where you find them depends on your deployment:
+
+{{< bootstrap-table "table table-striped table-bordered" >}}
+| Deployment | Log location |
+|------------|--------------|
+| Linux (systemd) | `journalctl -u nms-integrations` or `/var/log/nms/nms.log` |
+| Container | `docker logs <integrations-container>` or `kubectl logs <pod> -c integrations` |
+{{< /bootstrap-table >}}

--- a/content/nim/licensing-and-reporting/report-usage-connected-deployment.md
+++ b/content/nim/licensing-and-reporting/report-usage-connected-deployment.md
@@ -82,4 +82,47 @@ To submit usage reports manually:
 
 ## Error log location and monitoring {#log-monitoring}
 
+{{< include "licensing-and-reporting/nim-service-log-location.md" >}}
+
+Monitor the following log prefixes to identify issues with automatic usage reporting to F5.
+
+**`[INT-NC]`** — usage report polling and submission:
+
+```text
+[error] [INT-NC] failed to get pending count: <error>
+[error] [INT-NC] failed to process NC usage batch: <error>
+[info]  [INT-NC] successfully processed NC usage batch
+[error] [INT-NC] failed to upsert telemetry event: <error>
+[info]  [INT-NC] stopping NC usage subscriber (context done)
+```
+
+**`[AIDF-SUB]`** — usage message processing:
+
+```text
+[error] [AIDF-SUB] corrupted proto msg[<i>]: <error>; terminating message
+[error] [AIDF-SUB] msg[<i>] missing jwt_token; terminating unprocessable message
+[warn]  [AIDF-SUB] no valid reports after parsing <n> messages
+[error] [AIDF-SUB] failed to create NC client for jwt group: <error>
+[warn]  [AIDF-SUB] NC submission failed for chunk <start>-<end>: <error>
+[error] [AIDF-SUB] failed to ack msg after NC success: <error>
+[warn]  [AIDF-SUB] completed with <n> errors: <errors>
+[info]  [AIDF-SUB] successfully processed <n> valid messages
+```
+
+**`[NC-POST]` / `[NC-RETRY]`** — HTTP communication with F5:
+
+```text
+[info]  [NC-POST]  NC response status=<code> batch_size=<n>
+[warn]  [NC-RETRY] retrying after error: <error> wait=<duration>
+[error] [NC-SUBMIT] failed to convert report <i>: <error>
+```
+
+**`[AIDF-PUB]`** — usage data publishing from the data plane manager:
+
+```text
+[error] [AIDF-PUB] failed to marshal proto report: <error>
+[error] [AIDF-PUB] failed to publish proto report: <error>
+[info]  [AIDF-PUB] published proto report seq=<n> nginx_version=<ver>
+```
+
 {{< include "licensing-and-reporting/log-location-and-monitoring.md" >}}

--- a/content/nim/licensing-and-reporting/report-usage-disconnected-deployment.md
+++ b/content/nim/licensing-and-reporting/report-usage-disconnected-deployment.md
@@ -261,4 +261,22 @@ To submit the report and download the acknowledgment, follow steps 3–5 in the 
 
 ## Error log location and monitoring {#log-monitoring}
 
+{{< include "licensing-and-reporting/nim-service-log-location.md" >}}
+
+Monitor the following log prefixes to identify issues generating and exporting offline usage reports.
+
+**`[OfflineAggregator]`** — offline usage report packaging:
+
+```text
+[error] [OfflineAggregator] PullSubscribe failed consumer=<name>: <error>
+[error] [OfflineAggregator] error fetching messages: <error>
+[error] [OfflineAggregator] error processing message msg_index=<i>: <error> (skipping)
+[warn]  [OfflineAggregator] proto.Unmarshal failed: <error> (data_len=<n>)
+[warn]  [OfflineAggregator] message silently dropped (likely proto unmarshal failure) msg_index=<i>
+[error] [OfflineAggregator] failed to delete stale consumer=<name>: <error>
+[info]  [OfflineAggregator] aggregation complete: total_directories=<n> total_processed=<n> ...
+[info]  [OfflineAggregator] empty fetch attempt <n>/<max> (total_processed_so_far=<n>)
+[info]  [OfflineAggregator] <n> consecutive empty fetches, stream exhausted
+```
+
 {{< include "licensing-and-reporting/log-location-and-monitoring.md" >}}


### PR DESCRIPTION
**Summary**

Adds NIM service-level log monitoring documentation for NGINX Instance Manager 2.22+ to the usage reporting pages for connected and disconnected deployments.

In NIM 2.22+, usage reporting is handled by the `nms-integrations` process, not the NGINX Plus process. The existing log monitoring section in both pages only covered the NGINX Plus error log (`/var/log/nginx/error.log`). This PR adds the `nms-integrations` log location and the relevant log prefixes so operators can diagnose usage reporting issues end to end.

**Changes**

- nim-service-log-location.md *(new)* — shared include with the log location table for Linux (systemd) and container deployments
- report-usage-connected-deployment.md — added new include and connected-mode log prefix reference (`[INT-NC]`, `[AIDF-SUB]`, `[NC-POST]`/`[NC-RETRY]`, `[AIDF-PUB]`)
- report-usage-disconnected-deployment.md — added new include and disconnected-mode log prefix reference (`[OfflineAggregator]`)

The existing log-location-and-monitoring.md include (NGINX Plus error log) is preserved on both pages — it remains accurate for NGINX Plus process-level monitoring.

**Notes for reviewers**

- The log prefixes and example log lines are taken verbatim from the developer's notes in TECHDOCS-4607. Please confirm the prefix names and example messages match the actual 2.22 implementation before merge.
- The `nms-integrations` container name in the container log command (`kubectl logs <pod> -c integrations`) should be verified against the Helm chart's container spec.

**Closes:** [TECHDOCS-4607](https://jira.f5net.com/browse/TECHDOCS-4607)