### PR TITLE
fix: update openshift doc with default scc

### DIFF
--- a/content/nim/deploy/kubernetes/deploy-using-helm.md
+++ b/content/nim/deploy/kubernetes/deploy-using-helm.md
@@ -179,7 +179,7 @@ The values required to pull images from the NGINX private registry are now autom
 Use the file with the `-f values.yaml` flag when installing the chart.
 
 {{< call-out "note" "OpenShift support" >}}
-OpenShift support was added in NGINX Instance Manager 2.19. To enable it, add the setting `openshift.enabled: true` to your `values.yaml` file. Starting with NGINX Instance Manager v2.22, NGINX Instance Manager supports the default SCC on OpenShift.
+OpenShift support is available in NGINX Instance Manager 2.19 and later. To enable it, add `openshift.enabled: true` to your `values.yaml` file. In NGINX Instance Manager 2.22 and later, NGINX Instance Manager supports the default Security Context Constraints (SCC) on OpenShift.
 For more details, see [Appendix: OpenShift security constraints](#appendix-openshift-security-constraints).
 {{< /call-out >}}
 

--- a/content/nim/deploy/kubernetes/deploy-using-helm.md
+++ b/content/nim/deploy/kubernetes/deploy-using-helm.md
@@ -562,7 +562,7 @@ openshift:
   enabled: true
 ```
 
-NGINX Instance Manager (NIM) is deployed on OpenShift. Starting with NIM v2.22.0, the chart no longer creates or requires a custom [Security Context Constraints (SCC)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/authentication_and_authorization/managing-pod-security-policies) with fixed UIDs (**1000** for `nms`, and **101** for `nginx` and `clickhouse`). Instead, NGNIX Instance Manager runs using the **default SCC** applied by OpenShift to the NGINX Instance Manager service account.
+With this setting enabled, NGINX Instance Manager deploys on OpenShift. In NGINX Instance Manager 2.22.0 and later, the chart no longer creates or requires a custom [Security Context Constraints (SCC)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/authentication_and_authorization/managing-pod-security-policies))). Instead, NGINX Instance Manager runs with the default SCC that OpenShift applies to the NGINX Instance Manager service account. The chart no longer uses fixed UIDs (**1000** for `nms`, and **101** for `nginx` and `clickhouse`).
 
 This deployment has been tested with OpenShift v4.15.0 Server.
 

--- a/content/nim/deploy/kubernetes/deploy-using-helm.md
+++ b/content/nim/deploy/kubernetes/deploy-using-helm.md
@@ -179,7 +179,7 @@ The values required to pull images from the NGINX private registry are now autom
 Use the file with the `-f values.yaml` flag when installing the chart.
 
 {{< call-out "note" "OpenShift support" >}}
-OpenShift support was added in NGINX Instance Manager 2.19. To enable it, add the setting `openshift.enabled: true` to your `values.yaml` file.
+OpenShift support was added in NGINX Instance Manager 2.19. To enable it, add the setting `openshift.enabled: true` to your `values.yaml` file. Starting with NGINX Instance Manager v2.22, NGINX Instance Manager supports the default SCC on OpenShift.
 For more details, see [Appendix: OpenShift security constraints](#appendix-openshift-security-constraints).
 {{< /call-out >}}
 
@@ -552,29 +552,16 @@ For instructions on creating a support package to share with NGINX Customer Supp
 
 ## Appendix: OpenShift security constraints {#appendix-openshift-security-constraints}
 
-OpenShift restricts containers from running as root by default. To support NGINX Instance Manager, the Helm chart creates a custom Security Context Constraint (SCC) when you set:
+OpenShift restricts containers from running as root by default. When you enable OpenShift support in the NGINX Instance Manager Helm chart:
 
 ```yaml
 openshift:
   enabled: true
 ```
 
-This ensures pods can run with the user IDs required by NGINX Instance Manager services.
+NGINX Instance Manager (NIM) is deployed on OpenShift. Starting with NIM v2.22.0, the chart no longer creates or requires a custom [Security Context Constraints (SCC)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/authentication_and_authorization/managing-pod-security-policies) with fixed UIDs (**1000** for `nms`, and **101** for `nginx` and `clickhouse`). Instead, NGNIX Instance Manager runs using the **default SCC** applied by OpenShift to the NGINX Instance Manager service account.
 
-
-When `openshift.enabled: true` is set in the `values.yaml` file, the NGINX Instance Manager deployment automatically creates a custom [Security Context Constraints (SCC)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.13/html/authentication_and_authorization/managing-pod-security-policies) object and links it to the Service Account used by all pods.
-
-By default, OpenShift enforces strict security policies that require containers to run as **non-root** users. The deployment needs specific user IDs (UIDs) for certain services—**1000** for `nms`, and **101** for `nginx` and `clickhouse`. Since the default SCCs don’t allow these UIDs, the deployment creates a custom SCC. This SCC sets the `runAsUser` field to allow the necessary UIDs while still complying with OpenShift’s security standards.
-
-This deployment has been tested with OpenShift v4.13.0 Server.
-
-If you see permission errors during deployment, your account might not have access to manage SCCs. Ask a cluster administrator for access.
-
-To verify that the SCC was created after installing the Helm chart, run:
-
-```shell
-oc get scc nms-restricted-v2-scc --output=yaml
-```
+This deployment has been tested with OpenShift v4.15.0 Server.
 
 ---
 

--- a/content/nim/deploy/kubernetes/deploy-using-helm.md
+++ b/content/nim/deploy/kubernetes/deploy-using-helm.md
@@ -552,7 +552,10 @@ For instructions on creating a support package to share with NGINX Customer Supp
 
 ## Appendix: OpenShift security constraints {#appendix-openshift-security-constraints}
 
-OpenShift restricts containers from running as root by default. When you enable OpenShift support in the NGINX Instance Manager Helm chart:
+OpenShift restricts containers from running as root by default.
+
+To enable OpenShift support in the NGINX Instance Manager Helm chart, set the following value:
+
 
 ```yaml
 openshift:

--- a/content/nim/deploy/kubernetes/deploy-using-helm.md
+++ b/content/nim/deploy/kubernetes/deploy-using-helm.md
@@ -562,9 +562,9 @@ openshift:
   enabled: true
 ```
 
-With this setting enabled, NGINX Instance Manager deploys on OpenShift. In NGINX Instance Manager 2.22.0 and later, the chart no longer creates or requires a custom [Security Context Constraints (SCC)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/authentication_and_authorization/managing-pod-security-policies))). Instead, NGINX Instance Manager runs with the default SCC that OpenShift applies to the NGINX Instance Manager service account. The chart no longer uses fixed UIDs (**1000** for `nms`, and **101** for `nginx` and `clickhouse`).
+With this setting enabled, NGINX Instance Manager deploys on OpenShift. In NGINX Instance Manager 2.22.0 and later, the chart no longer creates or requires a custom [Security Context Constraints (SCC)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/authentication_and_authorization/managing-pod-security-policies))). Instead, NGINX Instance Manager runs with the default SCC that OpenShift applies to the NGINX Instance Manager service account. The chart no longer uses fixed UIDs (**1000** for `nms`, and **101** for `nginx` and `clickhouse`).
 
-This deployment has been tested with OpenShift v4.15.0 Server.
+This deployment has been tested with OpenShift v4.19.0 Server.
 
 ---
 


### PR DESCRIPTION
### Proposed changes
This pull request updates the OpenShift support documentation for deploying NGINX Instance Manager using Helm. The main change is that, starting with version 2.22, NGINX Instance Manager now uses the default Security Context Constraints (SCC) on OpenShift, and no longer creates or requires a custom SCC. The documentation is updated to reflect this new behavior and to clarify the supported OpenShift version.

**OpenShift support and security constraints:**

* Updated the OpenShift support note to mention that, starting with NGINX Instance Manager v2.22, the default SCC is supported on OpenShift (`content/nim/deploy/kubernetes/deploy-using-helm.md`).
* Revised the Appendix on OpenShift security constraints to clarify that, as of NIM v2.22.0, the Helm chart no longer creates or requires a custom SCC with fixed UIDs, and instead uses the default SCC applied by OpenShift. Also updated the tested OpenShift version to v4.15.0 and removed instructions for verifying custom SCC creation (`content/nim/deploy/kubernetes/deploy-using-helm.md`).

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
