### PR TITLE
Fix: NGF - update WAF policy XC base urls

### DIFF
--- a/content/ngf/reference/api.md
+++ b/content/ngf/reference/api.md
@@ -2561,7 +2561,7 @@ string
 </td>
 <td>
 <p>URL is the base URL of the F5 NGINX One Console instance,
-e.g. &ldquo;https://<tenant>.volterra.us&rdquo;.</p>
+e.g. &ldquo;https://&lt;tenant&gt;.console.ves.volterra.io&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -2628,7 +2628,7 @@ string
 </td>
 <td>
 <p>URL is the base URL of the F5 NGINX One Console instance,
-e.g. &ldquo;https://<tenant>.volterra.us&rdquo;.</p>
+e.g. &ldquo;https://&lt;tenant&gt;.console.ves.volterra.io&rdquo;.</p>
 </td>
 </tr>
 <tr>

--- a/content/ngf/waf-integration/policy-sources.md
+++ b/content/ngf/waf-integration/policy-sources.md
@@ -177,7 +177,7 @@ spec:
     name: gateway
   policySource:
     n1cSource:
-      url: https://<tenant>.volterra.us
+      url: https://<tenant>.console.ves.volterra.io
       namespace: default
       policyObjectID: pol_12345_WTHGmDEX9qnbVjQ
       policyVersionID: pv_Tm__12345oWmJgwxiKlHAg
@@ -191,7 +191,7 @@ spec:
         server: syslog-svc.default.svc.cluster.local:514
     logSource:
       n1cSource:
-        url: https://<tenant>.volterra.us
+        url: https://<tenant>.console.ves.volterra.io
         namespace: default
         profileObjectID: "lp_8s8uZxLpThWwEGF7LTn_rA"
       auth:
@@ -244,7 +244,7 @@ spec:
   type: N1C
   policySource:
     n1cSource:
-      url: https://<tenant>.volterra.us
+      url: https://<tenant>.console.ves.volterra.io
       namespace: default
       policyName: "ngfExample"
     auth:
@@ -257,7 +257,7 @@ spec:
         server: localhost:1514
     logSource:
       n1cSource:
-        url: https://<tenant>.volterra.us
+        url: https://<tenant>.console.ves.volterra.io
         namespace: default
         profileName: "secops_dashboard"
       auth:


### PR DESCRIPTION
### Proposed changes

- Update base XC URLs so that the N1C WAF Policy integration will connect and fetch policies properly
- HTML encode existing `<` and `>` literals so they appear in markdown rendering

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 NGINX Documentation style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/nginx/documentation/blob/main/documentation/style-guide.md) for guidance about placeholder content.
