### PR TITLE
Revert "Remove Google verification html file"

### DIFF
--- a/static/google1f145127a2762dc1.html
+++ b/static/google1f145127a2762dc1.html
@@ -1,0 +1,1 @@
+google-site-verification: google1f145127a2762dc1.html


### PR DESCRIPTION
Reverts nginx/documentation#1970 cuz Google wants the files to continue to stay even past verification.

See here:
<img width="832" height="138" alt="Screenshot 2026-05-18 at 3 29 02 PM" src="https://github.com/user-attachments/assets/900dbe38-297d-4850-92d8-e97167ad5922" />
