### PR TITLE
feat: control api reference redoc preview

### DIFF
--- a/content/nginx/admin-guide/basic-functionality/control-api-reference.md
+++ b/content/nginx/admin-guide/basic-functionality/control-api-reference.md
@@ -1,0 +1,15 @@
+---
+description: ''
+f5-docs: DOCS-0000
+f5-content-type: redoc
+doctypes:
+  - reference
+type: redoc
+tags:
+  - api
+title: Control API reference
+toc: false
+weight: null
+f5-api-reference: "/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml"
+f5-product: NONECO
+---

--- a/content/nginx/admin-guide/basic-functionality/control-api-reference.md
+++ b/content/nginx/admin-guide/basic-functionality/control-api-reference.md
@@ -10,6 +10,6 @@ tags:
 title: Control API reference
 toc: false
 weight: null
-f5-api-reference: "/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml"
+f5-api-reference: "./nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml"
 f5-product: NONECO
 ---

--- a/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
+++ b/content/nginx/admin-guide/basic-functionality/managing-configuration-files.md
@@ -4,7 +4,7 @@ description: Understand the basic elements in an NGINX or F5 NGINX Plus configur
 f5-docs: DOCS-378
 title: Create NGINX Plus and NGINX Configuration Files
 toc: true
-weight: 200
+weight: 100
 f5-content-type: how-to
 f5-product: NGPLUS
 ---

--- a/content/nginx/admin-guide/basic-functionality/runtime-control.md
+++ b/content/nginx/admin-guide/basic-functionality/runtime-control.md
@@ -4,14 +4,14 @@ description: Understand the NGINX processes that handle traffic, and how to cont
 f5-docs: DOCS-379
 title: Control NGINX Processes at Runtime
 toc: true
-weight: 100
+weight: 200
 f5-content-type: how-to
 f5-product: NGPLUS
 ---
 
 This section describes the processes that NGINX starts at run time and how to control them.
 
-## Master and Worker Processes
+## Master and worker processes {#processes}
 
 NGINX has one master process and one or more worker processes. If [caching]({{< ref "nginx/admin-guide/content-cache/content-caching.md" >}}) is enabled, the cache loader and cache manager processes also run at startup.
 
@@ -19,7 +19,7 @@ The main purpose of the master process is to read and evaluate configuration fil
 
 The worker processes do the actual processing of requests. NGINX relies on <span style="white-space: nowrap;">OS-dependent</span> mechanisms to efficiently distribute requests among worker processes. The number of worker processes is defined by the [worker_processes](https://nginx.org/en/docs/ngx_core_module.html#worker_processes) directive in the **nginx.conf** configuration file and can either be set to a fixed number or configured to adjust automatically to the number of available CPU cores.
 
-## Control NGINX
+## Control NGINX with signals {#signals}
 
 To reload your configuration, you can stop or restart NGINX, or send signals to the master process. A signal can be sent by running the `nginx` command (invoking the NGINX executable) with the `-s` argument.
 
@@ -39,11 +39,11 @@ The `kill` utility can also be used to send a signal directly to the master proc
 For more information about advanced signals (for performing live binary upgrades, for example), see [Control nginx](https://nginx.org/en/docs/control.html) at **nginx.org**.
 
 
-## NGINX Control API {#control-api}
+## Control NGINX with Control API {#control-api}
 
-In addition to signal-based controls, NGINX Plus can be controlled with the Control REST API, available since [NGINX Plus PLS R37.0.0 LTS]({{< ref "nginx/releases.md#r37.0" >}}).
+In addition to [signal-based controls](#signals), NGINX Plus can be controlled with the Control REST API, available since [NGINX Plus PLS R37.0.0 LTS]({{< ref "nginx/releases.md#r37.0" >}}).
 
-The Control API is implemented in the NGINX master process and provides a REST interface for runtime control and inspection. It allows you to:
+The Control API is implemented in the [NGINX master process](#processes) and provides a REST interface for runtime control and inspection. It allows you to:
 
 - view worker process information (process name, PID, and exit state);
 - get a memory dump of loaded NGINX configuration files;
@@ -55,11 +55,11 @@ The Control API provides the following endpoints:
 - `/1/control/config` — return the in-memory NGINX configuration and trigger reloads with `PATCH`;
 - `/1/nginx` — return NGINX version and build information.
 
-See [{{<icon "download">}}OpenAPI specification](/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml) for the Control API for details.
+See [{{NGINX Control API reference]({{< ref "nginx/admin-guide/basic-functionality/control-api-reference.md" >}}) for details.
 
 ### Enable NGINX Control API
 
-By default, the Control API is disabled. To enable it, start NGINX Plus with the `-l` option, specifying a UNIX-domain socket or TCP port:
+By default, the Control API is disabled. To enable it, start NGINX Plus with the [`-l` argument](https://nginx.org/en/docs/switches.html#l), specifying a UNIX-domain socket or TCP port:
 
 ```shell
 sudo nginx -l unix:/tmp/nginx.sock
@@ -71,13 +71,11 @@ sudo nginx -l unix:/tmp/nginx.sock
 - Configure the Control API to listen on a UNIX-domain socket. This is currently the most effective way to control access, because authorization can be managed through file permissions, and the created socket file is accessible only to the user running NGINX.
 - Keep NGINX Plus and the operating system up to date.
 
-### Control API specification
+### Control API reference documentation
 
-The Control API is described by an OpenAPI specification in YAML format:
+See [NGINX Control API reference]({{< ref "nginx/admin-guide/basic-functionality/control-api-reference.md" >}}) for details on available endpoints, request parameters, and response schemas.
 
-[{{<icon "download">}}Download Control API OpenAPI YAML specification](/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml)
-
-The specification can be explored with standard OpenAPI-compatible tools such as Redocly or Swagger UI.
+[{{<icon "download">}}Download Control API OpenAPI YAML specification](/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml) to explore the API using standard OpenAPI-compatible tools such as Redocly or Swagger UI.
 
 
 


### PR DESCRIPTION
This PR adds NGINX Control API reference preview in Redoc, also minor fixes

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
