### PR TITLE
feat: nginx plus rest api redoc preview

### DIFF
--- a/content/nginx/admin-guide/basic-functionality/runtime-control.md
+++ b/content/nginx/admin-guide/basic-functionality/runtime-control.md
@@ -75,7 +75,7 @@ sudo nginx -l unix:/tmp/nginx.sock
 
 See [NGINX Control REST API reference]({{< ref "nginx/admin-guide/basic-functionality/control-api-reference.md" >}}) for details on available endpoints, request parameters, and response schemas.
 
-[{{<icon "download">}}Download Control API OpenAPI YAML specification](/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml) to explore the API using standard OpenAPI-compatible tools such as Redocly or Swagger UI.
+[{{<icon "download">}}Download Control API OpenAPI YAML specification](/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml) or copy this link to explore the API using standard OpenAPI-compatible tools such as Redoc or Swagger UI.
 
 
 

--- a/content/nginx/admin-guide/basic-functionality/runtime-control.md
+++ b/content/nginx/admin-guide/basic-functionality/runtime-control.md
@@ -55,7 +55,7 @@ The Control API provides the following endpoints:
 - `/1/control/config` — return the in-memory NGINX configuration and trigger reloads with `PATCH`;
 - `/1/nginx` — return NGINX version and build information.
 
-See [{{NGINX Control API reference]({{< ref "nginx/admin-guide/basic-functionality/control-api-reference.md" >}}) for details.
+See [NGINX Control REST API reference]({{< ref "nginx/admin-guide/basic-functionality/control-api-reference.md" >}}) for details.
 
 ### Enable NGINX Control API
 

--- a/content/nginx/admin-guide/basic-functionality/runtime-control.md
+++ b/content/nginx/admin-guide/basic-functionality/runtime-control.md
@@ -73,7 +73,7 @@ sudo nginx -l unix:/tmp/nginx.sock
 
 ### Control API reference documentation
 
-See [NGINX Control API reference]({{< ref "nginx/admin-guide/basic-functionality/control-api-reference.md" >}}) for details on available endpoints, request parameters, and response schemas.
+See [NGINX Control REST API reference]({{< ref "nginx/admin-guide/basic-functionality/control-api-reference.md" >}}) for details on available endpoints, request parameters, and response schemas.
 
 [{{<icon "download">}}Download Control API OpenAPI YAML specification](/nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml) to explore the API using standard OpenAPI-compatible tools such as Redocly or Swagger UI.
 

--- a/content/nginx/admin-guide/monitoring/live-activity-monitoring.md
+++ b/content/nginx/admin-guide/monitoring/live-activity-monitoring.md
@@ -424,7 +424,7 @@ The JSON data returned:
 }
 ```
 
-For a complete list of available endpoints and supported methods see [reference documentation](https://nginx.org/en/docs/http/ngx_http_api_module.html).
+For a complete list of available endpoints and supported methods see [reference documentation](https://nginx.org/en/docs/http/ngx_http_api_module.html). This documentation is also available in [Redoc format]({{< ref "nginx/admin-guide/monitoring/nginx-plus-api-reference.md" >}}).
 
 <span id="json_delete"></span>
 ### Resetting the statistics

--- a/content/nginx/admin-guide/monitoring/live-activity-monitoring.md
+++ b/content/nginx/admin-guide/monitoring/live-activity-monitoring.md
@@ -495,27 +495,25 @@ To set the `down` parameter for the first server in the group (with ID `0`):
 curl -X PATCH -d '{ "down": true }' -s 'http://192.168.1.23/api/9/http/upstreams/appservers/servers/0'
 ```
 
-<span id="swagger"></span>
-## OpenAPI Specification
+## OpenAPI Specification {#swagger}
 
-NGINX Plus allows you to explore the REST API documentation and send API commands with a graphical user interface. This can be done with the NGINX Plus OpenAPI specification in YAML format and the Swagger UI.
+The NGINX Plus OpenAPI Specification is available in several formats:
 
-The main purpose of Swagger UI and the YAML OpenAPI spec is to document and visualize NGINX API commands. For security reasons it is not recommended using it in a production environment.
+- as [reference documentation](https://nginx.org/en/docs/http/ngx_http_api_module.html)
+- in [Redoc format]({{< ref "nginx/admin-guide/monitoring/nginx-plus-api-reference.md" >}})
+- as a [YAML file](#yaml-version)
+
+The YAML version can be used with external tools, such as Swagger UI, to explore the REST API and send API commands through a graphical interface. You can [enable the Swagger UI](#swagger_enable) in your environment or copy the link to the [appropriate YAML file](#yaml-version), and import it into another OpenAPI v2-compatible tool.
+
+{{< call-out "warning" >}}Swagger UI and the YAML OpenAPI spec are intended for documentation and visualization of NGINX API commands only. For security reasons it is not recommended using it in a production environment.{{< /call-out >}}
 
 Prior to NGINX Plus [Release 25]({{< ref "nginx/releases.md#r25" >}}), the Swagger UI was shipped together with NGINX Plus packages. Since NGINX Plus [Release 26]({{< ref "nginx/releases.md#r26" >}}), the OpenAPI YAML specification and the Swagger UI is published separately, below.
 
-Alternatively, copy the link to the appropriate YAML file, and import into your preferred OpenAPI v2 tool.
 
 
-<span id="swagger_enable"></span>
-### Enabling the Swagger UI
+### OpenAPI versions {#yaml-version}
 
-
-To enable the Swagger UI:
-
-1. Install and configure the Swagger UI. The installation package and instructions can be found on the [Swagger UI page](https://swagger.io/tools/swagger-ui/download/).
-
-2. Choose the version of the OpenAPI YAML file that matches your version of NGINX Plus, download the file, and put it to the folder containing the Swagger UI files:
+This table matches each OpenAPI YAML file version to the corresponding [NGINX Plus release]({{< ref "nginx/releases.md" >}}).
 
 {{<bootstrap-table "table table-bordered table-striped table-responsive table-sm">}}
 
@@ -535,6 +533,16 @@ To enable the Swagger UI:
 
 {{</bootstrap-table>}}
 
+
+<span id="swagger_enable"></span>
+### Enabling the Swagger UI
+
+To enable the Swagger UI:
+
+1. Install and configure the Swagger UI. The installation package and instructions can be found on the [Swagger UI page](https://swagger.io/tools/swagger-ui/download/).
+
+2. Choose the [version of the OpenAPI YAML file](#yaml-version) that matches your version of NGINX Plus, download the file, and put it to the folder containing the Swagger UI files:
+
 3. Configure NGINX Plus to work with the Swagger UI. Create a [`location`](https://nginx.org/en/docs/http/ngx_http_core_module.html#location), for example, */swagger-ui*:
 
     ```nginx
@@ -543,7 +551,7 @@ To enable the Swagger UI:
     }
     ```
 
-2. Specify the path to the Swagger UI files and the YAML spec with the [`root`](https://nginx.org/en/docs/http/ngx_http_core_module.html#root) directive, for example, to `usr/share/nginx/html`:
+4. Specify the path to the Swagger UI files and the YAML spec with the [`root`](https://nginx.org/en/docs/http/ngx_http_core_module.html#root) directive, for example, to `usr/share/nginx/html`:
 
     ```nginx
     location /swagger-ui {
@@ -555,7 +563,7 @@ To enable the Swagger UI:
    For NGINX Plus Release 25 and earlier, the Swagger UI is located in the root directory specified by the [`root`](https://nginx.org/en/docs/http/ngx_http_core_module.html#root) directive, for example, */usr/share/nginx/html*.
 
 
-3. Restrict access to this location only from a local network with [`allow`](https://nginx.org/en/docs/http/ngx_http_access_module.html#allow) and [`deny`](https://nginx.org/en/docs/http/ngx_http_access_module.html#deny) directives:
+5. Restrict access to this location only from a local network with [`allow`](https://nginx.org/en/docs/http/ngx_http_access_module.html#allow) and [`deny`](https://nginx.org/en/docs/http/ngx_http_access_module.html#deny) directives:
 
     ```nginx
     location /swagger-ui {
@@ -565,7 +573,7 @@ To enable the Swagger UI:
     }
     ```
 
-4. It is also recommended enabling Content Security Policy headers that define that all resources are loaded from the same origin as Swagger UI with the [`add_header`](https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header) directive:
+6. It is also recommended enabling Content Security Policy headers that define that all resources are loaded from the same origin as Swagger UI with the [`add_header`](https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header) directive:
 
     ```nginx
     location /swagger-ui {

--- a/content/nginx/admin-guide/monitoring/nginx-plus-api-reference.md
+++ b/content/nginx/admin-guide/monitoring/nginx-plus-api-reference.md
@@ -7,9 +7,9 @@ doctypes:
 type: redoc
 tags:
   - api
-title: NGINX Control REST API reference
+title: NGINX Plus REST API reference
 toc: false
 weight: null
-f5-api-reference: "./nginx/admin-guide/yaml/nginx-control-api/1/nginx_control_api.yaml"
+f5-api-reference: "./nginx/admin-guide/yaml/v9/nginx_api.yaml"
 f5-product: NONECO
 ---


### PR DESCRIPTION
This PR adds Redoc preview for NGINX Plus REST API. Additionally, this PR adds the word 'REST' to these APIs.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
