### PR TITLE
fix: freebsd version

### DIFF
--- a/content/includes/nginx-plus/supported-distributions.md
+++ b/content/includes/nginx-plus/supported-distributions.md
@@ -5,7 +5,7 @@ f5-files:
 ---
 
 {{<bootstrap-table "table table-striped table-bordered">}}
-| Distribution                 | Supported on [R37.0]({{< ref "nginx/releases.md#r37.0" >}})                     | Supported on [R36]({{< ref "nginx/releases.md#r36" >}}) |
+| Distribution                 | Supported on [PLS.37.0]({{< ref "nginx/releases.md#r37.0" >}})                     | Supported on [R36]({{< ref "nginx/releases.md#r36" >}}) |
 |------------------------------|---------------------------------------------------------------------------------|---------------------------------------------------------|
 | AlmaLinux                    | 8.1+ (x86_64, aarch64) <br> 9.7+ (x86_64, aarch64) <br> 10 (x86_64, aarch64)    | 8.1+ (x86_64, aarch64) <br> 9 (x86_64, aarch64) <br> 10 (x86_64, aarch64)      |
 | Alpine Linux                 | 3.21 (x86_64, aarch64) <br> 3.22 (x86_64, aarch64) <br> 3.23 (x86_64, aarch64)  | 3.20 (x86_64, aarch64) <br> 3.21 (x86_64, aarch64) <br> 3.22 (x86_64, aarch64) |

--- a/content/nginx/releases.md
+++ b/content/nginx/releases.md
@@ -28,7 +28,7 @@ CRs are identified by the second numeric component, for example, PLS.37.`1`.0.0,
 
 {{< call-out "note" "Important" >}} To use the LTS release track instead of the CR track, you must update your repository configuration to point to the LTS package URL, replacing the default URL. See [Installing NGINX Plus LTS]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus-lts.md" >}}) for details. {{< /call-out >}}
 
-### NGINX Plus  PLS.37.0.1.1 LTS {#r37.0.1}
+### NGINX Plus  PLS.37.0.1.1 LTS {#pls.37.0.1}
 _May 22, 2026_<br/>
 
 NGINX Plus PLS.37.0.1.1 LTS is a security release.
@@ -68,7 +68,7 @@ NGINX Plus PLS.37.0.0.1 LTS is supported on:
 | Alpine Linux   | 3.21, 3.22, 3.23          | x86_64, aarch64 |
 | Amazon Linux   | 2 LTS, 2023               | x86_64, aarch64 |
 | Debian         | 11, 12, 13                | x86_64, aarch64 |
-| FreeBSD        | 13.5+, 14.3+              | amd64           |
+| FreeBSD        | 13.5+, 14.3+, 15.0+       | amd64           |
 | Oracle Linux   | 8.1+, 9.7+                | x86_64, aarch64 |
 | RHEL           | 8.1+, 9.7+, 10.1+         | x86_64, aarch64 |
 | Rocky Linux    | 8.1+, 9.7+, 10.1+         | x86_64, aarch64 |


### PR DESCRIPTION
Added FreeBSD 15 to relese notes, also product name was fixed in tech specs

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
