### PR TITLE
docs: use example.com in WAF parameter-reference per RFC 2606

### DIFF
--- a/content/includes/waf/policy.html
+++ b/content/includes/waf/policy.html
@@ -5330,7 +5330,7 @@
 <tr class="odd">
 <td><code>allowRenderingInFramesOnlyFrom</code></td>
 <td>string</td>
-<td>Specifies that the browser may load the frame or iframe from a specified domain. Type the protocol and domain in URL format for example, <a href="http://www.mywebsite.com">http://www.mywebsite.com</a>. Do not enter a sub-URL, such as <a href="http://www.mywebsite.com/index">http://www.mywebsite.com/index</a>.</td>
+<td>Specifies that the browser may load the frame or iframe from a specified domain. Type the protocol and domain in URL format for example, <a href="http://www.example.com">http://www.example.com</a>. Do not enter a sub-URL, such as <a href="http://www.example.com/index">http://www.example.com/index</a>.</td>
 <td></td>
 </tr>
 <tr class="even">

--- a/data/nap-waf/schema/policy.json
+++ b/data/nap-waf/schema/policy.json
@@ -4056,7 +4056,7 @@
                               "type" : "string"
                            },
                            "allowRenderingInFramesOnlyFrom" : {
-                              "description" : "Specifies that the browser may load the frame or iframe from a specified domain. Type the protocol and domain in URL format for example, http://www.mywebsite.com. Do not enter a sub-URL, such as http://www.mywebsite.com/index.",
+                              "description" : "Specifies that the browser may load the frame or iframe from a specified domain. Type the protocol and domain in URL format for example, http://www.example.com. Do not enter a sub-URL, such as http://www.example.com/index.",
                               "type" : "string"
                            },
                            "attackSignaturesCheck" : {


### PR DESCRIPTION
Resolves #2002.

The `allowRenderingInFramesOnlyFrom` row in the WAF parameter reference uses `www.mywebsite.com` as the example domain. As the issue notes, that host is flagged as a badware risk by F5's link filters, and RFC 2606 reserves `example.com` for documentation.

This replaces the example links with `www.example.com` in both files that carry the description:

- `content/includes/waf/policy.html` — the rendered table row (`href` and link text).
- `data/nap-waf/schema/policy.json` — the matching `description` string the table is generated from.

Both are updated so the two copies stay in sync; the HTTP scheme and the `/index` sub-URL example are preserved. No other content changes.
