### PR TITLE
NGF: Add information about error log json format

### DIFF
--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -272,7 +272,8 @@ To view the full list of supported log levels, see the `NginxProxy spec` in the 
 
 {{< call-out "note" >}}For `debug` logging to work, NGINX needs to be built with `--with-debug` or "in debug mode". NGINX Gateway Fabric can easily
 be [run with NGINX in debug mode](#run-nginx-gateway-fabric-with-nginx-in-debug-mode) upon startup through the addition
-of a few arguments. {{< /call-out >}}
+of a few arguments. 
+JSON error log format is not supported in debug mode. {{< /call-out >}}
 
 ---
 
@@ -309,6 +310,8 @@ spec:
       disable: true
 EOF
 ```
+
+NGINX Gateway Fabric supports errorLog in JSON format for NGINX Plus users. When  `errorLogFormat` is set to `json` and no custom access log format is defined, the access log also defaults to JSON format.
 
 {{< call-out "note" >}} File destinations in `logging.accessLog` are not currently supported it is always set to `/dev/stdout`. {{< /call-out >}}
 


### PR DESCRIPTION
### Proposed changes

Updates with information about JSON error log format.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
