### PR TITLE
Use example.com in WAF policy docs

### DIFF
--- a/content/includes/waf/policy.html
+++ b/content/includes/waf/policy.html
@@ -5330,7 +5330,7 @@
 <tr class="odd">
 <td><code>allowRenderingInFramesOnlyFrom</code></td>
 <td>string</td>
-<td>Specifies that the browser may load the frame or iframe from a specified domain. Type the protocol and domain in URL format for example, <a href="http://www.mywebsite.com">http://www.mywebsite.com</a>. Do not enter a sub-URL, such as <a href="http://www.mywebsite.com/index">http://www.mywebsite.com/index</a>.</td>
+<td>Specifies that the browser may load the frame or iframe from a specified domain. Type the protocol and domain in URL format for example, <a href="http://www.example.com">http://www.example.com</a>. Do not enter a sub-URL, such as <a href="http://www.example.com/index">http://www.example.com/index</a>.</td>
 <td></td>
 </tr>
 <tr class="even">


### PR DESCRIPTION
﻿## Summary
- replace a WAF policy documentation example domain that may resolve to unsafe content
- use the reserved `example.com` domain for both the domain and sub-URL examples

Closes #2002

## Validation
- `rg -n "mywebsite\.com|www\.example\.com" content/includes/waf/policy.html`
- `git diff --check`
