### PR TITLE
[codex] Fix duplicate NGINX Plus wording in Docker docs

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-docker.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-docker.md
@@ -26,7 +26,7 @@ f5-product: NGPLUS
 <span id="nginx_plus_official_images"></span>
 ## Use official NGINX Plus Docker images
 
-Since NGINX Plus NGINX Plus [Release 31]({{< ref "nginx/releases.md#r31" >}}) you can get an NGINX Plus image from the official NGINX Plus Docker registry and upload it to your private registry.
+Since NGINX Plus [Release 31]({{< ref "nginx/releases.md#r31" >}}), you can get an NGINX Plus image from the official NGINX Plus Docker registry and upload it to your private registry.
 
 The NGINX Plus Docker registry is available at `https://private-registry.nginx.com/v2/`.
 


### PR DESCRIPTION
## Summary
- removes the duplicated "NGINX Plus" phrase from the official NGINX Plus Docker image section
- keeps the existing Release 31 Hugo reference and adds the comma requested in the issue

## Why
The sentence currently reads "Since NGINX Plus NGINX Plus...", which makes the Docker install guidance harder to read.

Closes #2009

## Validation
- git diff --check
- git grep confirmed the duplicate phrase is absent

## Not run
- make lint-markdown: attempted, but the local Docker CLI did not respond while the Makefile checked Docker availability
