### PR TITLE
nic: add missing configmap fields

### DIFF
--- a/content/nic/configuration/global-configuration/configmap-resource.md
+++ b/content/nic/configuration/global-configuration/configmap-resource.md
@@ -184,8 +184,20 @@ For more information on timeouts, see [here](https://github.com/nginxinc/nginx-o
 | *oidc-pkce-timeout* | Sets the timeout for PKCE (Proof Key for Code Exchange) in OIDC. | `90s` |
 | *oidc-id-tokens-timeout* | Sets the timeout for ID tokens in OIDC. | `1h` |
 | *oidc-access-tokens-timeout* | Sets the timeout for access tokens in OIDC. | `1h` |
-| *oidc-refresh-tokens-timeout* | Sets the timeout for refresh tokens in OIDC. | `24h` |
-| *oidc-sids-timeout* | Sets the timeout for session IDs in OIDC. | `24h` |
+| *oidc-refresh-tokens-timeout* | Sets the timeout for refresh tokens in OIDC. | `8h` |
+| *oidc-sids-timeout* | Sets the timeout for session IDs in OIDC. | `8h` |
+
+### OIDC (OpenID Connect) ZoneSizes
+
+For more information on zonesizes, see [here](https://github.com/nginxinc/nginx-openid-connect?tab=readme-ov-file#configuring-the-key-value-store)
+
+| ConfigMap Key | Description | Default |
+| ------------- | ------------| ------- |
+| *oidc-pkce-zone-size* | Sets the zonesize for PKCE (Proof Key for Code Exchange) in OIDC. | `128K` |
+| *oidc-id-tokens-zone-size* | Sets the zonesize for ID tokens in OIDC. | `1M` |
+| *oidc-access-tokens-zone-size* | Sets the zonesize for access tokens in OIDC. | `1M` |
+| *oidc-refresh-tokens-zone-size* | Sets the zonesize for refresh tokens in OIDC. | `1M` |
+| *oidc-sids-zone-size* | Sets the zonesize for session IDs in OIDC. | `1M` |
 
 ### Snippets and custom templates
 


### PR DESCRIPTION
### Proposed changes

- Adds missing configmap fields required for OIDC zoneSize config
reference: https://github.com/nginx/kubernetes-ingress/blob/main/internal/configs/config_params.go#L294-L304

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
