### PR TITLE
fix: DoS add learning detail

### DIFF
--- a/content/nap-dos/monitoring/live-activity-monitoring.md
+++ b/content/nap-dos/monitoring/live-activity-monitoring.md
@@ -133,7 +133,7 @@ In multi-instance environments with an arbitrator, these statistics will be comb
 | Mitigations/s  | - | Number of mitigated requests per second  |
 | Requests  | - | Total number of incoming requests  |
 | Mitigations  | - | Total number of mitigated requests  |
-| Learning  | [ready\|ba only\|not ready] | Whether F5 DoS for NGINX collected enough data to protect the Protected Object  |
+| Learning  | [ready\|ba only\|not ready] | Whether F5 DoS for NGINX collected enough data to protect the Protected Object. Note: `ba only` means that request thresholds were learned, but full request sampling is not complete. In this status, F5 DoS for NGINX will only detect bad actors (by IP or IP+TLS fingerprint) and will not utilize mitigation signatures.  |
 | Protocol  | [http1\|http2\|grpc] | As defined by the `protocol` argument of the `app_protect_dos_monitor` directive  |
 | Mitigation Mode  | [standard\|conservative\|none]  | As defined by the `mitigation_mode` object in the JSON policy file from the `app_protect_dos_policy_file` directive  |
 | Signatures  | [on\|off] | As defined by the `signatures` object in the JSON policy file from the `app_protect_dos_policy_file` directive. Values - on/off  |


### PR DESCRIPTION
### Proposed changes

The F5 DoS for NGINX learning mode does not describe the `ba only` state. This PR provides a little detail about this status.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
