### PR TITLE
Document new Config Explorer feature

### DIFF
--- a/content/nginx-one-console/changelog.md
+++ b/content/nginx-one-console/changelog.md
@@ -9,6 +9,20 @@ f5-docs: DOCS-1394
 
 Stay up-to-date with what's new and improved in the F5 NGINX One Console.
 
+## June 12, 2026
+
+### Config Explorer
+
+You can now explore any NGINX configuration as an interactive node graph using Config Explorer. Config Explorer is available for Staged Configurations, Instances, and Config Sync Groups.
+
+Key capabilities:
+
+- **Visual node graph**: Browse your entire NGINX configuration hierarchy — including upstreams, servers, and locations — as a navigable graph.
+- **Properties panel**: Select any node to view its properties, source file reference, and inline NGINX documentation.
+- **Search**: Use the search bar to find specific directives across the entire configuration in real time.
+
+See [Explore configurations with Config Explorer]({{< ref "/nginx-one-console/nginx-configs/explore-configurations.md" >}}) for more information.
+
 ## April 7, 2026
 
 ### Observability: F5 WAF for NGINX security dashboard

--- a/content/nginx-one-console/nginx-configs/explore-configurations.md
+++ b/content/nginx-one-console/nginx-configs/explore-configurations.md
@@ -1,0 +1,98 @@
+---
+title: Explore configurations with Config Explorer
+description: "Use Config Explorer to browse and search your NGINX configurations as an interactive node graph."
+f5-product: NONECO
+f5-content-type: howto
+f5-docs: DOCS-000
+f5-keywords: "Config Explorer, NGINX One Console, staged configurations, instances, config sync groups, node graph"
+f5-summary: >
+  Use Config Explorer to visualize and navigate any NGINX configuration as an interactive node graph in NGINX One Console.
+  Config Explorer lets you browse directive contexts, inspect properties and inline documentation, and search across all directives.
+  Config Explorer is available for Staged Configurations, Instances, and Config Sync Groups.
+f5-audience: any
+toc: true
+weight: 450
+---
+
+## Overview
+
+Config Explorer is an interactive view for any NGINX configuration in NGINX One Console. Instead of reading raw configuration files, you can navigate your entire NGINX configuration hierarchy as a visual node graph. Each node in the graph represents a directive context — such as `main`, `http`, `upstream`, `server`, or `location` — and you can select any node to inspect its properties and documentation.
+
+Config Explorer is available on the detail page of the following resources:
+
+- Staged Configurations
+- Instances
+- Config Sync Groups
+
+---
+
+## Before you begin
+
+Before you begin, ensure you have:
+
+- **An NGINX One Console account**: You must have access to NGINX One Console and permission to view the resource you want to explore.
+
+---
+
+## Open Config Explorer
+
+### Open Config Explorer for a Staged Configuration
+
+1. On the left menu, select **Staged Configurations**.
+2. Select the Staged Configuration you want to explore.
+3. Select the **Explorer** tab.
+
+### Open Config Explorer for an Instance
+
+1. On the left menu, select **Instances**.
+2. Select the instance you want to explore.
+3. Select the **Explorer** tab.
+
+### Open Config Explorer for a Config Sync Group
+
+1. On the left menu, select **Config Sync Groups**.
+2. Select the Config Sync Group you want to explore.
+3. Select the **Explorer** tab.
+
+---
+
+## Browse the configuration
+
+When Config Explorer opens, it displays your NGINX configuration as an interactive node graph on the canvas.
+
+1. Use the **view filter** in the toolbar to narrow the graph to a specific directive type, such as Upstreams or HTTP. The directive count next to the filter updates to reflect the current view.
+
+2. Select any node in the graph to open its **Properties** panel on the right. The Properties panel shows:
+   - The breadcrumb path of the selected directive within the configuration hierarchy.
+   - The source file and line reference.
+   - The parsed field values for the directive, such as host, port, and flags.
+   - **Children** — an expandable list of child directives.
+   - **Docs** — inline NGINX documentation for the selected directive, including its syntax, default value, valid contexts, and a plain-English description.
+
+3. Use the scroll and zoom controls in the lower-left corner of the canvas to pan and zoom the graph.
+
+4. Review the **Directives** bar at the bottom of the canvas for a color-coded breakdown of all directive types and their counts in the current view.
+
+---
+
+## Search for directives
+
+1. Select the **Search** bar in the toolbar.
+
+2. Type any term to search across all directives in the configuration. Config Explorer searches the graph in real time and highlights matching nodes.
+
+3. Matching results appear in a dropdown list showing the full breadcrumb path of each match. The counter in the search bar, for example `7/12`, shows your current position in the result set and the total number of matches.
+
+4. Use the arrow keys or select a result from the dropdown to navigate between matches. Config Explorer moves focus to the matching node in the graph and updates the Properties panel.
+
+5. Select the clear button in the search bar or press **Escape** to close the search results.
+
+---
+
+## References
+
+For more information, see:
+
+- [View and edit a Staged Configuration]({{< ref "/nginx-one-console/nginx-configs/staged-configs/edit-staged-config.md" >}})
+- [Manage Config Sync Groups]({{< ref "/nginx-one-console/nginx-configs/config-sync-groups/manage-config-sync-groups.md" >}})
+- [View and edit an NGINX instance]({{< ref "/nginx-one-console/nginx-configs/one-instance/view-edit-nginx-configurations.md" >}})


### PR DESCRIPTION
### Proposed changes

> Plan is for Config Explorer GA on June 12

Add documentation and changelog entry for Config Explorer, a new NGINX One Console feature that lets users browse and search any NGINX configuration as an interactive node graph. Config Explorer is generally available as of June 12, 2026 for Staged Configurations, Instances, and Config Sync Groups.

A new how-to page (nginx-configs/explore-configurations.md) explains how to open Config Explorer for each supported resource type, browse the configuration node graph, and search for directives. The page follows the existing howto content type, frontmatter conventions, and procedural step structure used across the nginx-one-console section. It is weighted at 450, placing it after the staged-configs, config-sync-groups, and config-templates subsections in the sidebar.

The changelog.md entry follows the existing date-heading and ### feature-heading format used by all prior entries in that file.

The documentation page intentionally omits the upstream server editing capability, which is not generally available and is enabled on a per-tenant basis outside of the standard release.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
