### PR TITLE
fix: wording in installation

### DIFF
--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-lts.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-plus-lts.md
@@ -26,9 +26,9 @@ NGINX Plus CRs are published several times within an annual LTS cycle. Each CR c
 
 By default, NGINX Plus repositories are configured to receive [Continuous Releases]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus.md" >}}). To use LTS, update your repository configuration to point to the LTS package URL, replacing the default URL. You can choose one of the options during installation:
 
-- **Pin to current LTS only**: receive only security updates for this LTS, no CRs, no automatic update to next LTS; supported up to three years. Follow the steps for your operating system in this guide.
-- **Pin to LTS track**: automatically upgrade to the newest LTS when it is released annually, no CRs. Follow the steps for your operating system in this guide.
-- **Default**: receive Continuous Releases within the current LTS release, automatically upgrade to each new LTS when it is released annually and then receive its CRs. See [Installing NGINX Plus]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus.md" >}}).
+- **Pin to current LTS only**: receive only security updates for this LTS, no CRs, no upgrade to next LTS; supported up to three years. Follow the steps for your operating system in this guide.
+- **Pin to LTS track**: upgrade to the newest LTS when it is released annually, no CRs. Follow the steps for your operating system in this guide.
+- **Default**: receive Continuous Releases within the current LTS release, upgrade to each new LTS when it is released annually and then receive its CRs. See [Installing NGINX Plus]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus.md" >}}).
 
 ## Prerequisites {#prereq}
 

--- a/content/nginx/admin-guide/installing-nginx/installing-nginx-plus.md
+++ b/content/nginx/admin-guide/installing-nginx/installing-nginx-plus.md
@@ -46,9 +46,9 @@ By default, NGINX Plus repositories are configured to receive Continuous Release
 
 Available repository configuration options:
 
-- **Default**: receive Continuous Releases within the current LTS release, automatically upgrade to each new LTS when it is released annually and then receive its CRs. Follow the steps for your operating system in this guide.
-- **Pin to current LTS only**: receive only security updates for this LTS, no CRs, no automatic update to next LTS; supported up to three years. See [Installing NGINX Plus LTS]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus-lts.md" >}}).
-- **Pin to LTS track**: automatically upgrade to the newest LTS when it is released annually, no CRs. See [Installing NGINX Plus LTS]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus-lts.md" >}}).
+- **Default**: receive Continuous Releases within the current LTS release, upgrade to each new LTS when it is released annually and then receive its CRs. Follow the steps for your operating system in this guide.
+- **Pin to current LTS only**: receive only security updates for this LTS, no CRs, no upgrade to next LTS; supported up to three years. See [Installing NGINX Plus LTS]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus-lts.md" >}}).
+- **Pin to LTS track**: upgrade to the newest LTS when it is released annually, no CRs. See [Installing NGINX Plus LTS]({{< ref "/nginx/admin-guide/installing-nginx/installing-nginx-plus-lts.md" >}}).
 
 ## Prerequisites {#prereq}
 


### PR DESCRIPTION
This PR removes the word "automatic" from "automatic upgrade" as it's not really automatic - you still do it manually, and it also confuses customers. 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
