### PR TITLE
fix: nap compiler install in airgapped environment

### DIFF
--- a/content/nim/waf-integration/configuration/install-waf-compiler/install-disconnected.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install-disconnected.md
@@ -187,7 +187,8 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
    sudo mv nginx-repo.crt /etc/ssl/nginx/
    sudo mv nginx-repo.key /etc/ssl/nginx/
    sudo wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nms.repo
-   sudo yum-config-manager --disable rhel-9-appstream-rhui-rpms
+   sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+   sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
    sudo yum update -y
    sudo mkdir -p nms-nap-compiler
 


### PR DESCRIPTION
This PR fixes the airgapped installation procedure on RHEL 9 of NAP WAF compiler here: 
https://docs.nginx.com/nginx-instance-manager/waf-integration/configuration/install-waf-compiler/install-disconnected/


### Checklist

Before sharing this pull request, I completed the following checklist:

- [ ] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [ ] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [ ] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [ ] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [ ] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
