### PR TITLE
Corrected naming for "howto" content type in copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -207,7 +207,7 @@ description: "One sentence summarizing the page, under 160 characters."
 weight: 100                   # Controls sort order, increments of 100
 toc: false                    # Enable for large documents (tech-specs, tutorial)
 f5-product: F5 NGINX Ingress Controller           # Use a name from the Product Names list below
-f5-content-type: howto        # howto | concept | reference | tech-specs | tutorial
+f5-content-type: how-to       # how-to | concept | reference | tech-specs | tutorial | getting-started | installation-guide | release-notes
 f5-docs: DOCS-000             # Jira ticket ID for the doc request
 f5-keywords: "keyword1, keyword2, keyword3"
 f5-summary: >


### PR DESCRIPTION
### Proposed changes

Corrected name from `howto` to `how-to`.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
