### PR TITLE
NGF Add docs for WAF PLM

### DIFF
--- a/content/ngf/waf-integration/configuration.md
+++ b/content/ngf/waf-integration/configuration.md
@@ -36,8 +36,8 @@ Each log entry must specify a log source. For the `HTTP`, `NIM`, and `N1C` polic
 
 For the `PLM` policy type, use `logRef` instead of `logSource`:
 
-| Field          | Description                                          |
-|----------------|------------------------------------------------------|
+| Field          | Description                                                 |
+|----------------|-------------------------------------------------------------|
 | `apLogConfRef` | Reference to an `APLogConf` custom resource compiled by PLM |
 
 **Built-in log profiles:** `log_default`, `log_all`, `log_blocked`, `log_illegal`, `log_grpc_all`, `log_grpc_blocked`, `log_grpc_illegal`

--- a/content/ngf/waf-integration/configuration.md
+++ b/content/ngf/waf-integration/configuration.md
@@ -25,14 +25,20 @@ The `securityLogs` field on a `WAFPolicy` supports multiple log destinations. Ea
 
 ### Log source types
 
-Each log entry must specify a `logSource` using one of:
+Each log entry must specify a log source. For the `HTTP`, `NIM`, and `N1C` policy types, use `logSource` with one of:
 
-| Field            | Description                          |
-|------------------|--------------------------------------|
-| `defaultProfile` | A built-in WAF log profile name      |
-| `httpSource`     | URL to a compiled log profile bundle |
-| `nimSource`      | NGINX Instance Manager log profile configuration        |
-| `n1cSource`      | NGINX One Console log profile configuration        |
+| Field            | Description                                      |
+|------------------|--------------------------------------------------|
+| `defaultProfile` | A built-in WAF log profile name                  |
+| `httpSource`     | URL to a compiled log profile bundle             |
+| `nimSource`      | NGINX Instance Manager log profile configuration |
+| `n1cSource`      | NGINX One Console log profile configuration      |
+
+For the `PLM` policy type, use `logRef` instead of `logSource`:
+
+| Field          | Description                                          |
+|----------------|------------------------------------------------------|
+| `apLogConfRef` | Reference to an `APLogConf` custom resource compiled by PLM |
 
 **Built-in log profiles:** `log_default`, `log_all`, `log_blocked`, `log_illegal`, `log_grpc_all`, `log_grpc_blocked`, `log_grpc_illegal`
 
@@ -70,6 +76,8 @@ securityLogs:
 
 Polling enables NGINX Gateway Fabric to detect and deploy updated policy bundles without modifying the `WAFPolicy` resource. This is useful when the same URL or policy name always resolves to the latest compiled bundle — for example, in a CI/CD workflow that overwrites the bundle file in place.
 
+{{< call-out "note" >}} Polling applies only to the `HTTP`, `NIM`, and `N1C` policy types. The `PLM` type is event-driven: NGINX Gateway Fabric watches the referenced `APPolicy` and `APLogConf` resources and re-fetches automatically when their compiled bundles change, so no polling configuration is needed. {{< /call-out >}}
+
 Enable polling on a `policySource` or `logSource`:
 
 ```yaml
@@ -93,6 +101,61 @@ policySource:
 **When not to enable polling:** If you pin a specific version — `policyUID` for NGINX Instance Manager, `policyVersionID` for NGINX One Console, or a version-specific URL for HTTP — the source always returns the same bundle. Every poll will detect "unchanged" and trigger no action. In that case, disable polling to avoid unnecessary network requests.
 
 **On poll failure:** If a poll attempt fails, the existing deployed bundle remains active. WAF protection is not interrupted. The error is recorded in the `WAFPolicy` status with reason `StaleBundleWarning`.
+
+---
+
+## Configure PLM storage access
+
+When you use the `PLM` policy type, NGINX Gateway Fabric fetches compiled bundles from PLM's in-cluster storage. Access to that storage is configured once, cluster-wide, at install time — it is not set per `WAFPolicy`. This configuration applies to all `WAFPolicy` resources that use `type: PLM`.
+
+{{< call-out "note" >}} This section covers only the NGINX Gateway Fabric side of PLM configuration. Installing the PLM system and authoring `APPolicy`/`APLogConf` resources are covered in the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> {{< /call-out >}}
+
+### Helm values
+
+Set the PLM storage values under `nginxGateway.plmStorage`:
+
+```yaml
+# values.yaml
+nginxGateway:
+  plmStorage:
+    url: "https://plm-storage-service.plm-system.svc.cluster.local"
+    credentialsSecretName: "plm-storage-credentials"  # contains the seaweedfs_admin_secret field
+    tls:
+      caSecretName: "plm-ca-secret"             # Secret with ca.crt for server verification
+      clientSSLSecretName: "plm-client-secret"  # Secret with tls.crt/tls.key for mutual TLS
+      insecureSkipVerify: false                 # use only for testing
+```
+
+The equivalent control plane CLI flags for manifest installs are:
+
+| Flag                               | Description                                                            | Required when PLM is used |
+|------------------------------------|------------------------------------------------------------------------|---------------------------|
+| `--plm-storage-url`                | PLM storage service URL (HTTP or HTTPS)                                | Yes                       |
+| `--plm-storage-credentials-secret` | Secret containing the S3 secret access key (`seaweedfs_admin_secret`)  | No                        |
+| `--plm-storage-ca-secret`          | Secret containing the CA certificate (`ca.crt`)                        | No                        |
+| `--plm-storage-client-ssl-secret`  | Secret containing the client certificate and key (`tls.crt`/`tls.key`) | No                        |
+| `--plm-storage-skip-verify`        | Skip TLS certificate verification (testing only)                       | No                        |
+
+Secret names may include a namespace prefix (`namespace/name`). If no namespace is given, the NGINX Gateway Fabric control plane namespace is assumed.
+
+### Credentials Secret
+
+The credentials Secret is created automatically by the PLM installation. It contains the S3 secret access key in the `seaweedfs_admin_secret` field; the access key ID is `admin` by default:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: plm-storage-credentials
+  namespace: nginx-gateway
+type: Opaque
+data:
+  seaweedfs_admin_secret: <BASE64_ENCODED_SECRET_ACCESS_KEY>
+```
+
+NGINX Gateway Fabric watches the PLM credentials and TLS Secrets and rebuilds its storage client when they change, so credentials can be rotated without restarting the pod.
+
+{{< call-out "caution" >}} For production, always use HTTPS with TLS verification by providing `caSecretName`. Enable mutual TLS with `clientSSLSecretName` for high-security environments. Never set `insecureSkipVerify: true` (or `--plm-storage-skip-verify=true`) in production. {{< /call-out >}}
 
 ---
 
@@ -191,6 +254,10 @@ policySource:
 The `expectedChecksum` must be a 64-character hexadecimal SHA-256 digest.
 
 {{< call-out "note" >}} `verifyChecksum` and `expectedChecksum` are mutually exclusive. You can use one or the other on the same policy source, but not both. {{< /call-out >}}
+
+### PLM source
+
+For the `PLM` policy type, integrity verification is automatic and requires no configuration. NGINX Gateway Fabric verifies the downloaded bundle against `status.bundle.sha256` from the referenced `APPolicy` or `APLogConf` resource. A mismatch prevents the bundle from being deployed and sets `Programmed=False` with reason `IntegrityError`.
 
 ---
 

--- a/content/ngf/waf-integration/configuration.md
+++ b/content/ngf/waf-integration/configuration.md
@@ -106,9 +106,9 @@ policySource:
 
 ## Configure PLM storage access
 
-When you use the `PLM` policy type, NGINX Gateway Fabric fetches compiled bundles from PLM's in-cluster storage. Access to that storage is configured once, cluster-wide, at install time — it is not set per `WAFPolicy`. This configuration applies to all `WAFPolicy` resources that use `type: PLM`.
+When you use the `PLM` policy type, NGINX Gateway Fabric fetches compiled bundles from PLM's in-cluster storage. Storage access is configured once, cluster-wide, at install time — not per `WAFPolicy`. This configuration applies to all `WAFPolicy` resources that use `type: PLM`.
 
-{{< call-out "note" >}} This section covers only the NGINX Gateway Fabric side of PLM configuration. Installing the PLM system and authoring `APPolicy`/`APLogConf` resources are covered in the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> {{< /call-out >}}
+{{< call-out "note" >}} This section covers the NGINX Gateway Fabric side of PLM configuration only. For installing the PLM system and authoring `APPolicy`/`APLogConf` resources, see the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> {{< /call-out >}}
 
 ### Helm values
 
@@ -136,11 +136,11 @@ The equivalent control plane CLI flags for manifest installs are:
 | `--plm-storage-client-ssl-secret`  | Secret containing the client certificate and key (`tls.crt`/`tls.key`) | No                        |
 | `--plm-storage-skip-verify`        | Skip TLS certificate verification (testing only)                       | No                        |
 
-Secret names may include a namespace prefix (`namespace/name`). If no namespace is given, the NGINX Gateway Fabric control plane namespace is assumed.
+Secret names may include a namespace prefix (`namespace/name`). If you don't include a namespace, the NGINX Gateway Fabric control plane namespace is used.
 
 ### Credentials Secret
 
-The credentials Secret is created automatically by the PLM installation. It contains the S3 secret access key in the `seaweedfs_admin_secret` field; the access key ID is `admin` by default:
+The PLM installation creates the credentials Secret automatically. It contains the S3 secret access key in the `seaweedfs_admin_secret` field; the access key ID is `admin` by default:
 
 ```yaml
 apiVersion: v1
@@ -153,15 +153,15 @@ data:
   seaweedfs_admin_secret: <BASE64_ENCODED_SECRET_ACCESS_KEY>
 ```
 
-NGINX Gateway Fabric watches the PLM credentials and TLS Secrets and rebuilds its storage client when they change, so credentials can be rotated without restarting the pod.
+NGINX Gateway Fabric watches the PLM credentials and TLS Secrets and rebuilds its storage client when they change. You can rotate credentials without restarting the pod.
 
-{{< call-out "caution" >}} For production, always use HTTPS with TLS verification by providing `caSecretName`. Enable mutual TLS with `clientSSLSecretName` for high-security environments. Never set `insecureSkipVerify: true` (or `--plm-storage-skip-verify=true`) in production. {{< /call-out >}}
+{{< call-out "caution" >}} For production, always use HTTPS with TLS verification by providing `caSecretName`. Add `clientSSLSecretName` for mutual TLS in high-security environments. Never set `insecureSkipVerify: true` (or `--plm-storage-skip-verify=true`) in production. {{< /call-out >}}
 
 ---
 
 ## Configure the WAF cookie seed
 
-When WAF is enabled, NGINX Gateway Fabric automatically sets the `app_protect_cookie_seed` NGINX directive to a stable value derived from the Gateway's UID. This ensures that WAF session cookies issued by one NGINX replica can be validated by any other replica in the same deployment. Without this, each replica generates its own random seed at startup, which causes cross-replica cookie validation failures.
+When WAF is enabled, NGINX Gateway Fabric sets the `app_protect_cookie_seed` NGINX directive to a stable value derived from the Gateway's UID. This lets any NGINX replica validate WAF session cookies issued by any other replica in the same deployment. Without this, each replica generates its own random seed at startup, causing cross-replica cookie validation failures.
 
 If you have pre-compiled the cookie seed into your WAF policy bundles using the [compiler global settings]({{< ref "/waf/configure/compiler.md" >}}), disable the automatic cookie seed in the NginxProxy CRD to avoid conflicting with the compiled-in value:
 
@@ -253,11 +253,11 @@ policySource:
 
 The `expectedChecksum` must be a 64-character hexadecimal SHA-256 digest.
 
-{{< call-out "note" >}} `verifyChecksum` and `expectedChecksum` are mutually exclusive. You can use one or the other on the same policy source, but not both. {{< /call-out >}}
+{{< call-out "note" >}} `verifyChecksum` and `expectedChecksum` are mutually exclusive. Use one or the other on the same policy source, but not both. {{< /call-out >}}
 
 ### PLM source
 
-For the `PLM` policy type, integrity verification is automatic and requires no configuration. NGINX Gateway Fabric verifies the downloaded bundle against `status.bundle.sha256` from the referenced `APPolicy` or `APLogConf` resource. A mismatch prevents the bundle from being deployed and sets `Programmed=False` with reason `IntegrityError`.
+For the `PLM` policy type, integrity verification is automatic — no configuration needed. NGINX Gateway Fabric verifies the downloaded bundle against `status.bundle.sha256` from the referenced `APPolicy` or `APLogConf` resource. A mismatch prevents the bundle from being deployed and sets `Programmed=False` with reason `IntegrityError`.
 
 ---
 

--- a/content/ngf/waf-integration/configuration.md
+++ b/content/ngf/waf-integration/configuration.md
@@ -36,9 +36,9 @@ Each log entry must specify a log source. For the `HTTP`, `NIM`, and `N1C` polic
 
 For the `PLM` policy type, use `logRef` instead of `logSource`:
 
-| Field          | Description                                                 |
-|----------------|-------------------------------------------------------------|
-| `apLogConfRef` | Reference to an `APLogConf` custom resource compiled by PLM |
+| Field          | Description                                                                                |
+|----------------|--------------------------------------------------------------------------------------------|
+| `apLogConfRef` | Reference to an `APLogConf` custom resource compiled by the Policy Lifecycle Manager (PLM) |
 
 **Built-in log profiles:** `log_default`, `log_all`, `log_blocked`, `log_illegal`, `log_grpc_all`, `log_grpc_blocked`, `log_grpc_illegal`
 
@@ -76,7 +76,7 @@ securityLogs:
 
 Polling enables NGINX Gateway Fabric to detect and deploy updated policy bundles without modifying the `WAFPolicy` resource. This is useful when the same URL or policy name always resolves to the latest compiled bundle — for example, in a CI/CD workflow that overwrites the bundle file in place.
 
-{{< call-out "note" >}} Polling applies only to the `HTTP`, `NIM`, and `N1C` policy types. The `PLM` type is event-driven: NGINX Gateway Fabric watches the referenced `APPolicy` and `APLogConf` resources and re-fetches automatically when their compiled bundles change, so no polling configuration is needed. {{< /call-out >}}
+{{< call-out "note" >}} Polling applies only to the `HTTP`, `NIM`, and `N1C` policy types. The `PLM` type is event-driven. NGINX Gateway Fabric watches the referenced `APPolicy` and `APLogConf` resources and re-fetches automatically when their compiled bundles change. No polling configuration is needed. {{< /call-out >}}
 
 Enable polling on a `policySource` or `logSource`:
 

--- a/content/ngf/waf-integration/overview.md
+++ b/content/ngf/waf-integration/overview.md
@@ -110,13 +110,46 @@ WAF policies must be compiled before they can be applied. Compilation takes a JS
 
 The following policy source types are supported, selected via the `spec.type` field on the `WAFPolicy` resource:
 
-| Type   | Description                                                                          |
-|--------|--------------------------------------------------------------------------------------|
-| `NIM`  | NGINX Instance Manager — fetched by policy name or UID via NGINX Instance Manager API|
-| `N1C`  | NGINX One Console — fetched by policy name or object ID via NGINX One Console API    |
-| `HTTP` | Direct HTTP/HTTPS URL to a compiled bundle file                                      |
+| Type   | Description                                                                                       |
+|--------|---------------------------------------------------------------------------------------------------|
+| `NIM`  | NGINX Instance Manager — fetched by policy name or UID via NGINX Instance Manager API             |
+| `N1C`  | NGINX One Console — fetched by policy name or object ID via NGINX One Console API                 |
+| `HTTP` | Direct HTTP/HTTPS URL to a compiled bundle file                                                   |
+| `PLM`  | Policy Lifecycle Management — `APPolicy`/`APLogConf` CRDs, fetched from in-cluster storage        |
+
+The `NIM`, `N1C`, and `HTTP` source types reference an externally compiled bundle through `policySource` (and `logSource` for log profiles), and detect updates by polling. The `PLM` source type is Kubernetes-native and event-driven: it references `APPolicy` and `APLogConf` custom resources through `policyRef` (and `logRef`), and requires no polling. See [PLM (Policy Lifecycle Management)](#plm-policy-lifecycle-management) below.
 
 For details on configuring each source type, see [Configure policy sources]({{< ref "/ngf/waf-integration/policy-sources.md" >}}).
+
+### PLM (Policy Lifecycle Management)
+
+Policy Lifecycle Management (PLM) is a Kubernetes-native policy source. Instead of pointing NGINX Gateway Fabric at an externally compiled bundle, you define your WAF security posture as `APPolicy` and `APLogConf` custom resources in the cluster. The PLM controller watches these resources, compiles them automatically, and stores the resulting bundles in in-cluster S3-compatible storage. NGINX Gateway Fabric then fetches the bundles from that storage and deploys them to the data plane.
+
+The following table summarizes how PLM differs from the HTTP, NGINX Instance Manager, and NGINX One Console source types:
+
+| Aspect             | HTTP / NIM / N1C                                | PLM                                                     |
+|--------------------|-------------------------------------------------|---------------------------------------------------------|
+| Policy definition  | Authored externally (file/Git, NIM, or N1C)     | Authored in-cluster as `APPolicy`/`APLogConf` CRDs      |
+| Compilation        | External (compiler CLI/CI-CD, NIM, or N1C)      | Automatic, by the PLM controller                        |
+| Bundle storage     | HTTP server, NIM, or N1C                        | In-cluster S3-compatible storage                        |
+| `WAFPolicy` fields | `policySource` / `logSource`                    | `policyRef.apPolicyRef` / `logRef.apLogConfRef`         |
+| Update detection   | Polling (checksum or conditional GET)           | Event-driven Kubernetes watch (no polling)              |
+| Authentication     | Per-`WAFPolicy` credentials Secret              | Cluster-wide PLM storage credentials, set at install    |
+| Network access     | External egress to the policy source            | Fully in-cluster                                        |
+
+At runtime, the flow is:
+
+```text
+Create APPolicy/APLogConf → PLM compiles and sets status.bundle.state: ready →
+NGINX Gateway Fabric detects the ready status via watch → fetches the bundle from
+in-cluster storage → deploys to the data plane
+```
+
+Subsequent changes to an `APPolicy` or `APLogConf` spec trigger recompilation and an automatic re-fetch — no polling and no change to the `WAFPolicy` resource are required.
+
+When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, a [ReferenceGrant](https://gateway-api.sigs.k8s.io/api-types/referencegrant/) is required in the target namespace to permit the reference.
+
+{{< call-out "note" >}} PLM requires the PLM system to be installed in the cluster, and requires PLM storage access to be configured on NGINX Gateway Fabric at install time. For authoring `APPolicy`/`APLogConf` resources and installing PLM, see the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> For NGINX Gateway Fabric configuration, see [Configure PLM storage access]({{< ref "/ngf/waf-integration/configuration.md#configure-plm-storage-access" >}}). {{< /call-out >}}
 
 ---
 

--- a/content/ngf/waf-integration/overview.md
+++ b/content/ngf/waf-integration/overview.md
@@ -108,7 +108,7 @@ WAF policies must be compiled before they can be applied. Compilation takes a JS
 
 ### Source types
 
-The following policy source types are supported, selected via the `spec.type` field on the `WAFPolicy` resource:
+Set the source type using the `spec.type` field on the `WAFPolicy` resource:
 
 | Type   | Description                                                                                       |
 |--------|---------------------------------------------------------------------------------------------------|
@@ -117,13 +117,13 @@ The following policy source types are supported, selected via the `spec.type` fi
 | `HTTP` | Direct HTTP/HTTPS URL to a compiled bundle file                                                   |
 | `PLM`  | Policy Lifecycle Management — `APPolicy`/`APLogConf` CRDs, fetched from in-cluster storage        |
 
-The `NIM`, `N1C`, and `HTTP` source types reference an externally compiled bundle through `policySource` (and `logSource` for log profiles), and detect updates by polling. The `PLM` source type is Kubernetes-native and event-driven: it references `APPolicy` and `APLogConf` custom resources through `policyRef` (and `logRef`), and requires no polling. See [PLM (Policy Lifecycle Management)](#plm-policy-lifecycle-management) below.
+The `NIM`, `N1C`, and `HTTP` source types reference an externally compiled bundle through `policySource` (and `logSource` for log profiles). They detect updates by polling. The `PLM` source type is Kubernetes-native and event-driven: it references `APPolicy` and `APLogConf` custom resources through `policyRef` (and `logRef`), and doesn't require polling. See [PLM (Policy Lifecycle Management)](#plm-policy-lifecycle-management) below.
 
 For details on configuring each source type, see [Configure policy sources]({{< ref "/ngf/waf-integration/policy-sources.md" >}}).
 
 ### PLM (Policy Lifecycle Management)
 
-Policy Lifecycle Management (PLM) is a Kubernetes-native policy source. Instead of pointing NGINX Gateway Fabric at an externally compiled bundle, you define your WAF security posture as `APPolicy` and `APLogConf` custom resources in the cluster. The PLM controller watches these resources, compiles them automatically, and stores the resulting bundles in in-cluster S3-compatible storage. NGINX Gateway Fabric then fetches the bundles from that storage and deploys them to the data plane.
+Policy Lifecycle Management (PLM) is a Kubernetes-native policy source. Instead of pointing NGINX Gateway Fabric at an externally compiled bundle, you define your WAF security posture as `APPolicy` and `APLogConf` custom resources in the cluster. The PLM controller watches these resources, compiles them automatically, and stores the resulting bundles in in-cluster S3-compatible storage. NGINX Gateway Fabric fetches the bundles from that storage and deploys them to the data plane.
 
 The following table summarizes how PLM differs from the HTTP, NGINX Instance Manager, and NGINX One Console source types:
 
@@ -145,11 +145,11 @@ NGINX Gateway Fabric detects the ready status via watch → fetches the bundle f
 in-cluster storage → deploys to the data plane
 ```
 
-Subsequent changes to an `APPolicy` or `APLogConf` spec trigger recompilation and an automatic re-fetch — no polling and no change to the `WAFPolicy` resource are required.
+Changes to an `APPolicy` or `APLogConf` spec trigger recompilation and an automatic re-fetch — no polling required, and no change to the `WAFPolicy` resource.
 
-When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, a [ReferenceGrant](https://gateway-api.sigs.k8s.io/api-types/referencegrant/) is required in the target namespace to permit the reference.
+When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, create a [ReferenceGrant](https://gateway-api.sigs.k8s.io/api-types/referencegrant/) in the target namespace to permit the reference.
 
-{{< call-out "note" >}} PLM requires the PLM system to be installed in the cluster, and requires PLM storage access to be configured on NGINX Gateway Fabric at install time. For authoring `APPolicy`/`APLogConf` resources and installing PLM, see the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> For NGINX Gateway Fabric configuration, see [Configure PLM storage access]({{< ref "/ngf/waf-integration/configuration.md#configure-plm-storage-access" >}}). {{< /call-out >}}
+{{< call-out "note" >}} PLM requires the PLM system to be installed in the cluster and PLM storage access to be set up on NGINX Gateway Fabric at install time. For authoring `APPolicy`/`APLogConf` resources and installing PLM, see the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> For NGINX Gateway Fabric configuration, see [Configure PLM storage access]({{< ref "/ngf/waf-integration/configuration.md#configure-plm-storage-access" >}}). {{< /call-out >}}
 
 ---
 

--- a/content/ngf/waf-integration/policy-sources.md
+++ b/content/ngf/waf-integration/policy-sources.md
@@ -238,6 +238,40 @@ For a comparison of PLM with the other source types, see [PLM (Policy Lifecycle 
 2. Create a `WAFPolicy` with `type: PLM` that references the `APPolicy` by name and namespace.
 3. NGINX Gateway Fabric watches the referenced resources and deploys the bundle once it is `ready`. Later changes to the `APPolicy` or `APLogConf` spec trigger recompilation and an automatic re-fetch — no change to the `WAFPolicy` is required.
 
+
+### Create namespaces
+
+```yaml
+kubectl create namespace security
+kubectl create namespace applications
+```
+
+### Cross-namespace references
+
+When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, create a `ReferenceGrant` in the target namespace to permit the reference. The following grant allows `WAFPolicy` resources in the `applications` namespace to reference `APPolicy` and `APLogConf` resources in the `security` namespace:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-wafpolicy-refs
+  namespace: security
+spec:
+  from:
+  - group: gateway.nginx.org
+    kind: WAFPolicy
+    namespace: applications
+  to:
+  - group: appprotect.f5.com
+    kind: APPolicy
+  - group: appprotect.f5.com
+    kind: APLogConf
+EOF
+```
+
+Without a matching `ReferenceGrant`, the `WAFPolicy` is rejected with `ResolvedRefs=False` and reason `RefNotPermitted`. See [Troubleshoot WAFPolicy status]({{< ref "/ngf/waf-integration/troubleshooting.md" >}}).
+
 ### Create the APPolicy and APLogConf resources
 
 The `APPolicy` resource defines the security policy. The PLM controller watches it, compiles the policy, uploads the bundle to in-cluster storage, and writes `status.bundle` (with `state: ready`, `location`, and `sha256`). The following example blocks all attack signatures:
@@ -360,32 +394,6 @@ EOF
 ```
 
 This example reuses the `attack-signatures` policy for the route-level override. In practice, create a separate `APPolicy` (and, if needed, `APLogConf`) with the stricter posture you want for this route, then reference it here. This policy overrides the gateway-level policy for the `customers` route only. Any other routes attached to the gateway continue to use the gateway-level policy.
-
-### Cross-namespace references
-
-When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, create a `ReferenceGrant` in the target namespace to permit the reference. The following grant allows `WAFPolicy` resources in the `applications` namespace to reference `APPolicy` and `APLogConf` resources in the `security` namespace:
-
-```yaml
-kubectl apply -f - <<EOF
-apiVersion: gateway.networking.k8s.io/v1
-kind: ReferenceGrant
-metadata:
-  name: allow-wafpolicy-refs
-  namespace: security
-spec:
-  from:
-  - group: gateway.nginx.org
-    kind: WAFPolicy
-    namespace: applications
-  to:
-  - group: appprotect.f5.com
-    kind: APPolicy
-  - group: appprotect.f5.com
-    kind: APLogConf
-EOF
-```
-
-Without a matching `ReferenceGrant`, the `WAFPolicy` is rejected with `ResolvedRefs=False` and reason `RefNotPermitted`. See [Troubleshoot WAFPolicy status]({{< ref "/ngf/waf-integration/troubleshooting.md" >}}).
 
 ---
 

--- a/content/ngf/waf-integration/policy-sources.md
+++ b/content/ngf/waf-integration/policy-sources.md
@@ -4,10 +4,10 @@ weight: 300
 toc: true
 f5-content-type: how-to
 f5-product: FABRIC
-f5-description: Configure WAFPolicy to fetch compiled bundles from F5 NGINX Instance Manager, F5 NGINX One Console, or an HTTP server.
+f5-description: Configure WAFPolicy to fetch compiled bundles from F5 NGINX Instance Manager, F5 NGINX One Console, an HTTP server, or Policy Lifecycle Management (PLM).
 ---
 
-NGINX Gateway Fabric supports three policy source types for fetching compiled WAF bundles: F5 NGINX Instance Manager, F5 NGINX One Console, and direct HTTP/HTTPS URLs. For a quick start walkthrough using the HTTP source, see [Get started with F5 WAF for NGINX]({{< ref "/ngf/waf-integration/get-started.md" >}}).
+NGINX Gateway Fabric supports four policy source types for fetching compiled WAF bundles: F5 NGINX Instance Manager, F5 NGINX One Console, direct HTTP/HTTPS URLs, and Policy Lifecycle Management (PLM). For a quick start walkthrough using the HTTP source, see [Get started with F5 WAF for NGINX]({{< ref "/ngf/waf-integration/get-started.md" >}}).
 
 Before configuring a policy source, ensure that WAF is [enabled on the NginxProxy]({{< ref "/ngf/waf-integration/overview.md#enable-waf-on-the-nginxproxy" >}}) — either per Gateway or globally via Helm values.
 
@@ -213,6 +213,179 @@ Use this option when you compile WAF policies using the F5 WAF compiler CLI or a
 For a complete walkthrough including policy compilation and a bundle server deployment, see [Get started with F5 WAF for NGINX]({{< ref "/ngf/waf-integration/get-started.md" >}}).
 
 For production environments, you would typically host compiled bundles on an HTTPS server with authentication. See [Configure WAF settings]({{< ref "/ngf/waf-integration/configuration.md" >}}) for details on adding credentials, custom CA certificates, and checksum verification to your `policySource`.
+
+---
+
+## Policy Lifecycle Management (PLM)
+
+Use this option when you manage WAF policies as Kubernetes resources with Policy Lifecycle Management (PLM). With PLM, you define your security posture as `APPolicy` and `APLogConf` custom resources; the PLM controller compiles them automatically and stores the resulting bundles in in-cluster storage. NGINX Gateway Fabric fetches those bundles and deploys them to the data plane.
+
+Unlike the other source types, PLM is Kubernetes-native and event-driven:
+
+- Policies and log profiles are referenced with `policyRef.apPolicyRef` and `logRef.apLogConfRef` instead of `policySource` and `logSource`.
+- Updates are detected through a Kubernetes watch, so [polling]({{< ref "/ngf/waf-integration/configuration.md#configure-automatic-policy-updates-polling" >}}) does not apply.
+- No per-`WAFPolicy` credentials Secret is needed. Access to PLM storage is configured once, cluster-wide, at install time.
+
+For a comparison of PLM with the other source types, see [PLM (Policy Lifecycle Management)]({{< ref "/ngf/waf-integration/overview.md#plm-policy-lifecycle-management" >}}).
+
+**Before you begin:**
+
+- The PLM system must be installed in the cluster, and PLM storage access must be configured on NGINX Gateway Fabric. See [Configure PLM storage access]({{< ref "/ngf/waf-integration/configuration.md#configure-plm-storage-access" >}}).
+
+**Workflow:**
+
+1. Create your `APPolicy` (and optionally `APLogConf`) resources. The PLM controller compiles them and sets `status.bundle.state` to `ready` when the bundle is available.
+2. Create a `WAFPolicy` with `type: PLM` that references the `APPolicy` by name and namespace.
+3. NGINX Gateway Fabric watches the referenced resources and deploys the bundle once it is `ready`. Later changes to the `APPolicy` or `APLogConf` spec trigger recompilation and an automatic re-fetch — no change to the `WAFPolicy` is required.
+
+### Create the APPolicy and APLogConf resources
+
+The `APPolicy` resource defines the security policy. The PLM controller watches it, compiles the policy, uploads the bundle to in-cluster storage, and writes `status.bundle` (with `state: ready`, `location`, and `sha256`). The following example blocks all attack signatures:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: appprotect.f5.com/v1
+kind: APPolicy
+metadata:
+  name: attack-signatures
+  namespace: security
+spec:
+  policy:
+    name: attack-signatures-blocking
+    template:
+      name: POLICY_TEMPLATE_NGINX_BASE
+    applicationLanguage: utf-8
+    enforcementMode: blocking
+    signature-sets:
+    - name: All Signatures
+      block: true
+      alarm: true
+    cookies:
+    - name: "*"
+      attackSignaturesCheck: true
+      enforcementType: enforce
+      maskValueInLogs: false
+EOF
+```
+
+The `APLogConf` resource defines a security logging profile, which PLM compiles and stores in the same way. The following example logs illegal requests:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: appprotect.f5.com/v1
+kind: APLogConf
+metadata:
+  name: log-illegal
+  namespace: security
+spec:
+  filter:
+    request_type: illegal
+  content:
+    format: default
+    max_request_size: any
+    max_message_size: 15k
+EOF
+```
+
+Wait until both resources report `status.bundle.state: ready` before referencing them from a `WAFPolicy`.
+
+{{< call-out "note" >}} These examples are a starting point. For the full `APPolicy` and `APLogConf` specifications and additional configuration options, see the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> {{< /call-out >}}
+
+### Create a gateway-level WAFPolicy
+
+The following `WAFPolicy` targets the Gateway and protects all attached routes. It references the `APPolicy` for the security policy and the `APLogConf` for security logging:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: gateway-base-protection
+  namespace: applications
+spec:
+  type: PLM
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  policyRef:
+    apPolicyRef:
+      name: attack-signatures
+      namespace: security
+  securityLogs:
+  - destination:
+      type: syslog
+      syslog:
+        server: syslog-svc.default.svc.cluster.local:514
+    logRef:
+      apLogConfRef:
+        name: log-illegal
+        namespace: security
+EOF
+```
+
+Replace `attack-signatures` and `log-illegal` with the names of your `APPolicy` and `APLogConf` resources.
+
+{{< call-out "note" >}} When the `APPolicy` or `APLogConf` is in a different namespace from the `WAFPolicy`, you must create a `ReferenceGrant` in the target namespace. See [Cross-namespace references](#cross-namespace-references). {{< /call-out >}}
+
+### Apply a route-level override (optional)
+
+To apply a different policy to a specific route, create a route-level `WAFPolicy`:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: gateway.nginx.org/v1alpha1
+kind: WAFPolicy
+metadata:
+  name: route-protection
+  namespace: applications
+spec:
+  type: PLM
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: customers
+  policyRef:
+    apPolicyRef:
+      name: attack-signatures
+      namespace: security
+  securityLogs:
+  - destination:
+      type: stderr
+    logRef:
+      apLogConfRef:
+        name: log-illegal
+        namespace: security
+EOF
+```
+
+This example reuses the `attack-signatures` policy for the route-level override. In practice, create a separate `APPolicy` (and, if needed, `APLogConf`) with the stricter posture you want for this route, then reference it here. This policy overrides the gateway-level policy for the `customers` route only. Any other routes attached to the gateway continue to use the gateway-level policy.
+
+### Cross-namespace references
+
+When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, create a `ReferenceGrant` in the target namespace to permit the reference. The following grant allows `WAFPolicy` resources in the `applications` namespace to reference `APPolicy` and `APLogConf` resources in the `security` namespace:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-wafpolicy-refs
+  namespace: security
+spec:
+  from:
+  - group: gateway.nginx.org
+    kind: WAFPolicy
+    namespace: applications
+  to:
+  - group: appprotect.f5.com
+    kind: APPolicy
+  - group: appprotect.f5.com
+    kind: APLogConf
+EOF
+```
+
+Without a matching `ReferenceGrant`, the `WAFPolicy` is rejected with `ResolvedRefs=False` and reason `RefNotPermitted`. See [Troubleshoot WAFPolicy status]({{< ref "/ngf/waf-integration/troubleshooting.md" >}}).
 
 ---
 

--- a/content/ngf/waf-integration/policy-sources.md
+++ b/content/ngf/waf-integration/policy-sources.md
@@ -15,7 +15,7 @@ Before configuring a policy source, ensure that WAF is [enabled on the NginxProx
 
 ---
 
-## NGINX Instance Manager (NGINX Instance Manager)
+## NGINX Instance Manager
 
 Use this option when you manage WAF policies through NGINX Instance Manager. For details on creating and compiling policies in NGINX Instance Manager, see [How WAF policy management works]({{< ref "/nim/waf-integration/overview.md" >}}) and [Create a security policy bundle]({{< ref "/nim/waf-integration/policies-and-logs/bundles/create-bundle.md" >}}).
 
@@ -222,21 +222,21 @@ Use this option when you manage WAF policies as Kubernetes resources with Policy
 
 Unlike the other source types, PLM is Kubernetes-native and event-driven:
 
-- Policies and log profiles are referenced with `policyRef.apPolicyRef` and `logRef.apLogConfRef` instead of `policySource` and `logSource`.
-- Updates are detected through a Kubernetes watch, so [polling]({{< ref "/ngf/waf-integration/configuration.md#configure-automatic-policy-updates-polling" >}}) does not apply.
-- No per-`WAFPolicy` credentials Secret is needed. Access to PLM storage is configured once, cluster-wide, at install time.
+- Reference policies and log profiles with `policyRef.apPolicyRef` and `logRef.apLogConfRef` instead of `policySource` and `logSource`.
+- Updates are detected through a Kubernetes watch, so [polling]({{< ref "/ngf/waf-integration/configuration.md#configure-automatic-policy-updates-polling" >}}) doesn't apply.
+- No per-`WAFPolicy` credentials Secret is needed. PLM storage access is set up once, cluster-wide, at install time.
 
 For a comparison of PLM with the other source types, see [PLM (Policy Lifecycle Management)]({{< ref "/ngf/waf-integration/overview.md#plm-policy-lifecycle-management" >}}).
 
 **Before you begin:**
 
-- The PLM system must be installed in the cluster, and PLM storage access must be configured on NGINX Gateway Fabric. See [Configure PLM storage access]({{< ref "/ngf/waf-integration/configuration.md#configure-plm-storage-access" >}}).
+- The PLM system must be installed in the cluster, and PLM storage access must be set up on NGINX Gateway Fabric. See [Configure PLM storage access]({{< ref "/ngf/waf-integration/configuration.md#configure-plm-storage-access" >}}).
 
 **Workflow:**
 
 1. Create your `APPolicy` (and optionally `APLogConf`) resources. The PLM controller compiles them and sets `status.bundle.state` to `ready` when the bundle is available.
 2. Create a `WAFPolicy` with `type: PLM` that references the `APPolicy` by name and namespace.
-3. NGINX Gateway Fabric watches the referenced resources and deploys the bundle once it is `ready`. Later changes to the `APPolicy` or `APLogConf` spec trigger recompilation and an automatic re-fetch — no change to the `WAFPolicy` is required.
+3. NGINX Gateway Fabric watches the referenced resources and deploys the bundle when it's `ready`. Later changes to the `APPolicy` or `APLogConf` spec trigger recompilation and an automatic re-fetch — no change to the `WAFPolicy` is required.
 
 
 ### Create namespaces
@@ -270,7 +270,7 @@ spec:
 EOF
 ```
 
-Without a matching `ReferenceGrant`, the `WAFPolicy` is rejected with `ResolvedRefs=False` and reason `RefNotPermitted`. See [Troubleshoot WAFPolicy status]({{< ref "/ngf/waf-integration/troubleshooting.md" >}}).
+Without a matching `ReferenceGrant`, the `WAFPolicy` is rejected with `ResolvedRefs=False` and reason `RefNotPermitted`. See [Troubleshoot WAFPolicy status]({{< ref "/ngf/waf-integration/troubleshooting.md" >}}) for details.
 
 ### Create the APPolicy and APLogConf resources
 
@@ -323,7 +323,7 @@ EOF
 
 Wait until both resources report `status.bundle.state: ready` before referencing them from a `WAFPolicy`.
 
-{{< call-out "note" >}} These examples are a starting point. For the full `APPolicy` and `APLogConf` specifications and additional configuration options, see the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> {{< /call-out >}}
+{{< call-out "note" >}} These examples are a starting point. For the full `APPolicy` and `APLogConf` specifications, see the [F5 WAF PLM documentation]({{< ref "/waf/" >}}). <!-- TODO: confirm PLM docs link --> {{< /call-out >}}
 
 ### Create a gateway-level WAFPolicy
 
@@ -393,7 +393,7 @@ spec:
 EOF
 ```
 
-This example reuses the `attack-signatures` policy for the route-level override. In practice, create a separate `APPolicy` (and, if needed, `APLogConf`) with the stricter posture you want for this route, then reference it here. This policy overrides the gateway-level policy for the `customers` route only. Any other routes attached to the gateway continue to use the gateway-level policy.
+This example reuses the `attack-signatures` policy for the route-level override. In practice, create a separate `APPolicy` (and, if needed, `APLogConf`) with the stricter posture you want for this route, then reference it here. This policy overrides the gateway-level policy for the `customers` route only. Other routes attached to the gateway continue to use the gateway-level policy.
 
 ---
 

--- a/content/ngf/waf-integration/troubleshooting.md
+++ b/content/ngf/waf-integration/troubleshooting.md
@@ -25,10 +25,11 @@ Use `kubectl describe wafpolicy <CONDITION_NAME>` to inspect status conditions. 
 
 ### ResolvedRefs
 
-| Status  | Reason         | Meaning                                                       |
-|---------|----------------|---------------------------------------------------------------|
-| `True`  | `ResolvedRefs` | All referenced Secrets resolved successfully                  |
-| `False` | `InvalidRef`   | A referenced Secret was not found or is missing expected keys |
+| Status  | Reason            | Meaning                                                                                     |
+|---------|-------------------|---------------------------------------------------------------------------------------------|
+| `True`  | `ResolvedRefs`    | All referenced Secrets, `APPolicy`, and `APLogConf` resources resolved successfully         |
+| `False` | `InvalidRef`      | A referenced Secret was not found or is missing keys; or (PLM) a referenced `APPolicy`/`APLogConf` does not exist or its `status.bundle.state` is not `ready` |
+| `False` | `RefNotPermitted` | (PLM) A cross-namespace `APPolicy` or `APLogConf` reference is not allowed by a `ReferenceGrant` |
 
 ### Programmed
 
@@ -37,7 +38,7 @@ Use `kubectl describe wafpolicy <CONDITION_NAME>` to inspect status conditions. 
 | `True`  | `Programmed`         | Bundle fetched and deployed to the data plane                                    |
 | `True`  | `BundleUpdated`      | A poll cycle detected a changed bundle and deployed it                           |
 | `True`  | `StaleBundleWarning` | A poll cycle failed; previously deployed bundle remains active                   |
-| `False` | `FetchError`         | Bundle could not be fetched (network error, HTTP error, auth failure, timeout)   |
+| `False` | `FetchError`         | Bundle could not be fetched (network error, HTTP error, S3 error for PLM, auth failure, timeout) |
 | `False` | `IntegrityError`     | Bundle checksum verification failed                                              |
 | `False` | `Pending`            | Bundle has never been fetched; configuration withheld or WAF omitted (fail-open) |
 
@@ -52,6 +53,32 @@ The credentials Secret is either missing, contains the wrong keys, or the creden
 ### `FetchError` with HTTP 404 on NGINX Instance Manager or NGINX One Console
 
 The referenced policy was not found or has not been compiled yet. For NGINX Instance Manager, verify that compilation succeeded in the NGINX Instance Manager console before creating the `WAFPolicy`. For NGINX One Console, NGINX Gateway Fabric triggers compilation if no bundle exists, and a 404 after initial setup may indicate the policy was deleted in NGINX One Console.
+
+### `InvalidRef` on a PLM policy: `APPolicy` not ready
+
+For `type: PLM`, NGINX Gateway Fabric only fetches a bundle once the referenced `APPolicy` (or `APLogConf`) reports `status.bundle.state: ready`. While PLM is still compiling, the `ResolvedRefs` condition is `False` with reason `InvalidRef`:
+
+```text
+- Type:    ResolvedRefs
+  Status:  False
+  Reason:  InvalidRef
+  Message: APLogConf namespace/name bundle is not ready (state: processing)
+```
+
+Verify the `APPolicy` exists and that PLM has finished compiling it: `kubectl get appolicy -n <namespace>`. If the state is `invalid`, check the PLM compilation errors in the resource's `status`.
+
+### `RefNotPermitted` on a PLM policy: missing `ReferenceGrant`
+
+When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, a `ReferenceGrant` must exist in the target namespace:
+
+```text
+- Type:    ResolvedRefs
+  Status:  False
+  Reason:  RefNotPermitted
+  Message: cross-namespace reference to APLogConf namespace/name not permitted by ReferenceGrant
+```
+
+Create a `ReferenceGrant` in the target namespace that allows `WAFPolicy` resources from the source namespace to reference the `APPolicy`/`APLogConf` Kinds. See [Cross-namespace references]({{< ref "/ngf/waf-integration/policy-sources.md#cross-namespace-references" >}}).
 
 ### `Pending`
 

--- a/content/ngf/waf-integration/troubleshooting.md
+++ b/content/ngf/waf-integration/troubleshooting.md
@@ -33,14 +33,14 @@ Use `kubectl describe wafpolicy <CONDITION_NAME>` to inspect status conditions. 
 
 ### Programmed
 
-| Status  | Reason               | Meaning                                                                          |
-|---------|----------------------|----------------------------------------------------------------------------------|
-| `True`  | `Programmed`         | Bundle fetched and deployed to the data plane                                    |
-| `True`  | `BundleUpdated`      | A poll cycle detected a changed bundle and deployed it                           |
-| `True`  | `StaleBundleWarning` | A poll cycle failed; previously deployed bundle remains active                   |
+| Status  | Reason               | Meaning                                                                                          |
+|---------|----------------------|--------------------------------------------------------------------------------------------------|
+| `True`  | `Programmed`         | Bundle fetched and deployed to the data plane                                                    |
+| `True`  | `BundleUpdated`      | A poll cycle detected a changed bundle and deployed it                                           |
+| `True`  | `StaleBundleWarning` | A poll cycle failed; previously deployed bundle remains active                                   |
 | `False` | `FetchError`         | Bundle could not be fetched (network error, HTTP error, S3 error for PLM, auth failure, timeout) |
-| `False` | `IntegrityError`     | Bundle checksum verification failed                                              |
-| `False` | `Pending`            | Bundle has never been fetched; configuration withheld or WAF omitted (fail-open) |
+| `False` | `IntegrityError`     | Bundle checksum verification failed                                                              |
+| `False` | `Pending`            | Bundle has never been fetched; configuration withheld or WAF omitted (fail-open)                 |
 
 ---
 

--- a/content/ngf/waf-integration/troubleshooting.md
+++ b/content/ngf/waf-integration/troubleshooting.md
@@ -48,15 +48,15 @@ Use `kubectl describe wafpolicy <CONDITION_NAME>` to inspect status conditions. 
 
 ### `FetchError` with HTTP 403
 
-The credentials Secret is either missing, contains the wrong keys, or the credentials are invalid. Verify the Secret exists in the same namespace as the `WAFPolicy` and that the keys match the authentication method (`username`/`password` for Basic Auth, `token` for Bearer/APIToken).
+The credentials Secret is missing, contains the wrong keys, or the credentials are invalid. Verify the Secret exists in the same namespace as the `WAFPolicy`. Confirm the keys match the authentication method (`username`/`password` for Basic Auth, `token` for Bearer/APIToken).
 
 ### `FetchError` with HTTP 404 on NGINX Instance Manager or NGINX One Console
 
-The referenced policy was not found or has not been compiled yet. For NGINX Instance Manager, verify that compilation succeeded in the NGINX Instance Manager console before creating the `WAFPolicy`. For NGINX One Console, NGINX Gateway Fabric triggers compilation if no bundle exists, and a 404 after initial setup may indicate the policy was deleted in NGINX One Console.
+The referenced policy wasn't found or hasn't been compiled yet. For NGINX Instance Manager, verify that compilation succeeded in the NGINX Instance Manager console before creating the `WAFPolicy`. For NGINX One Console, NGINX Gateway Fabric triggers compilation if no bundle exists. A 404 after initial setup may mean the policy was deleted in NGINX One Console.
 
 ### `InvalidRef` on a PLM policy: `APPolicy` not ready
 
-For `type: PLM`, NGINX Gateway Fabric only fetches a bundle once the referenced `APPolicy` (or `APLogConf`) reports `status.bundle.state: ready`. While PLM is still compiling, the `ResolvedRefs` condition is `False` with reason `InvalidRef`:
+For `type: PLM`, NGINX Gateway Fabric only fetches a bundle after the referenced `APPolicy` (or `APLogConf`) reports `status.bundle.state: ready`. While PLM is still compiling, the `ResolvedRefs` condition is `False` with reason `InvalidRef`:
 
 ```text
 - Type:    ResolvedRefs
@@ -69,7 +69,7 @@ Verify the `APPolicy` exists and that PLM has finished compiling it: `kubectl ge
 
 ### `RefNotPermitted` on a PLM policy: missing `ReferenceGrant`
 
-When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, a `ReferenceGrant` must exist in the target namespace:
+When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namespace, a `ReferenceGrant` must exist in the target namespace to allow the reference:
 
 ```text
 - Type:    ResolvedRefs
@@ -78,11 +78,11 @@ When a `WAFPolicy` references an `APPolicy` or `APLogConf` in a different namesp
   Message: cross-namespace reference to APLogConf namespace/name not permitted by ReferenceGrant
 ```
 
-Create a `ReferenceGrant` in the target namespace that allows `WAFPolicy` resources from the source namespace to reference the `APPolicy`/`APLogConf` Kinds. See [Cross-namespace references]({{< ref "/ngf/waf-integration/policy-sources.md#cross-namespace-references" >}}).
+Create a `ReferenceGrant` in the target namespace that allows `WAFPolicy` resources from the source namespace to reference the `APPolicy`/`APLogConf` kinds. See [Cross-namespace references]({{< ref "/ngf/waf-integration/policy-sources.md#cross-namespace-references" >}}).
 
 ### `Pending`
 
-The bundle has never been successfully fetched. If `bundleFailOpen` is `false` (the default), the NGINX configuration push is withheld for this Gateway. If `bundleFailOpen` is `true`, traffic flows without WAF protection.
+The bundle has never been successfully fetched. If `bundleFailOpen` is `false` (the default), NGINX Gateway Fabric withholds the configuration push for this Gateway. If `bundleFailOpen` is `true`, traffic flows without WAF protection.
 
 Check the `Programmed` condition message for the last fetch error. Common causes include network connectivity issues, incorrect URLs, or authentication failures. Verify the policy source URL and credentials Secret.
 


### PR DESCRIPTION
### Proposed changes

WAF using PLM requires documentation. Basic knowledge on AP resources should be present in the NGF docs, however the F5 WAF PLM docs should be referenced for all other details.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
