### PR TITLE
NGF: document NginxProxy useClusterIP setting

### DIFF
--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -406,10 +406,10 @@ EOF
 ```
 
 `useClusterIP` applies only when the target Service has a ClusterIP. The following cases fall back to the default Pod IP resolution:
-
-- Headless Services (`ClusterIP: None`).
+- Headless Services (ClusterIP: None).
 - ExternalName Services.
-- Layer 4 (TCPRoute/UDPRoute) stream upstreams, which are not affected by this setting.
+
+Layer 4 (TCPRoute/UDPRoute) stream upstreams are unaffected by this setting, since it does not apply to L4 traffic.
 
 If not specified, `useClusterIP` defaults to `false`. As with other `NginxProxy` fields, it can be set on the GatewayClass to apply globally, or on a Gateway to override the GatewayClass value. See the [Merging Semantics](#merging-semantics) section for details, and the `NginxProxy spec` in the [API reference]({{< ref "/ngf/reference/api.md" >}}) for the full list of options.
 

--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -390,6 +390,8 @@ By default, NGINX Gateway Fabric resolves each backend Service to its individual
 
 Setting `useClusterIP` to `true` in the `NginxProxy` resource configures NGINX to route to the Service's ClusterIP and port instead of the individual Pod IPs. The upstream then contains a single server (the Service VIP), and NGINX no longer needs to reload when the backend Pods churn. This is also useful for service mesh compatibility and for controllers or operators that require traffic to traverse the Service VIP.
 
+You can set `useClusterIP` globally for all Services through the `NginxProxy` resource, as shown below, or for a specific Service through the `useClusterIP` field of an [`UpstreamSettingsPolicy`]({{< ref "/ngf/traffic-management/upstream-settings.md" >}}). When both are configured for the same Service, the `UpstreamSettingsPolicy` value takes precedence.
+
 {{< call-out "note" >}} Because the upstream contains only the Service VIP as a single server, you lose NGINX's load balancing across the backend Pods. Traffic is instead load balanced by the Kubernetes Service (kube-proxy), so NGINX load balancing settings such as those in an `UpstreamSettingsPolicy` no longer apply to that Service. {{< /call-out >}}
 
 The following command creates an `NginxProxy` resource that enables `useClusterIP`:

--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -384,6 +384,35 @@ EOF
 
 ---
 
+## Route upstream traffic to the Service ClusterIP
+
+By default, NGINX Gateway Fabric resolves each backend Service to its individual Pod IPs and uses those as the upstream servers. This means that every time the backend Pods change (for example, during a scale up, scale down, or rollout), NGINX must reload to pick up the new set of endpoints.
+
+Setting `useClusterIP` to `true` in the `NginxProxy` resource configures NGINX to route to the Service's ClusterIP and port instead of the individual Pod IPs. The upstream then contains a single server (the Service VIP), and NGINX no longer needs to reload when the backend Pods churn. This is also useful for service mesh compatibility and for controllers or operators that require traffic to traverse the Service VIP.
+
+The following command creates an `NginxProxy` resource that enables `useClusterIP`:
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+metadata:
+  name: ngf-proxy-config
+spec:
+  useClusterIP: true
+EOF
+```
+
+`useClusterIP` applies only when the target Service has a ClusterIP. The following cases fall back to the default Pod IP resolution:
+
+- Headless Services (`ClusterIP: None`).
+- ExternalName Services.
+- Layer 4 (TCPRoute/UDPRoute) stream upstreams, which are not affected by this setting.
+
+If not specified, `useClusterIP` defaults to `false`. As with other `NginxProxy` fields, it can be set on the GatewayClass to apply globally, or on a Gateway to override the GatewayClass value. See the [Merging Semantics](#merging-semantics) section for details, and the `NginxProxy spec` in the [API reference]({{< ref "/ngf/reference/api.md" >}}) for the full list of options.
+
+---
+
 ## Configure infrastructure-related settings
 
 You can configure deployment and service settings for all data plane instances by editing the `NginxProxy` resource at the Gateway or GatewayClass level. These settings can also be specified under the `nginx` section in the Helm values file. You can edit things such as replicas, pod scheduling options, container resource limits, extra volume mounts, service types and load balancer settings.

--- a/content/ngf/how-to/data-plane-configuration.md
+++ b/content/ngf/how-to/data-plane-configuration.md
@@ -390,6 +390,8 @@ By default, NGINX Gateway Fabric resolves each backend Service to its individual
 
 Setting `useClusterIP` to `true` in the `NginxProxy` resource configures NGINX to route to the Service's ClusterIP and port instead of the individual Pod IPs. The upstream then contains a single server (the Service VIP), and NGINX no longer needs to reload when the backend Pods churn. This is also useful for service mesh compatibility and for controllers or operators that require traffic to traverse the Service VIP.
 
+{{< call-out "note" >}} Because the upstream contains only the Service VIP as a single server, you lose NGINX's load balancing across the backend Pods. Traffic is instead load balanced by the Kubernetes Service (kube-proxy), so NGINX load balancing settings such as those in an `UpstreamSettingsPolicy` no longer apply to that Service. {{< /call-out >}}
+
 The following command creates an `NginxProxy` resource that enables `useClusterIP`:
 
 ```yaml


### PR DESCRIPTION
### Proposed changes

Problem: NGINX Gateway Fabric is adding a `useClusterIP` field to the `NginxProxy` resource (nginx/nginx-gateway-fabric#5557, resolving nginx/nginx-gateway-fabric#5554). The data plane configuration guide does not yet document it.

Solution: Add a "Route upstream traffic to the Service ClusterIP" section to `content/ngf/how-to/data-plane-configuration.md`. It explains what the setting does and why (fewer NGINX reloads on backend Pod churn, service-mesh compatibility), gives an `NginxProxy` YAML example, and documents the fallback cases (headless Services, ExternalName Services, L4/stream upstreams) and the default value.

Testing: Rendered/reviewed the Markdown locally; no functional changes.

Related: nginx/nginx-gateway-fabric#5557, nginx/nginx-gateway-fabric#5554