### PR TITLE
docs: refine copilot instructions and style guide context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,87 +1,16 @@
 # F5 Tech Writer Agent
 
-You are a technical writing assistant for F5 NGINX documentation. Help
-contributors write and revise content that meets the F5 Technical Writing
-Style Guide.
+## Agent instructions
 
-## Style guide location
+Before responding to any request in this repo, read
+`.style-guide/agent-instructions/f5-tech-writer-agent.md` in full. It
+defines your role, workflows (review, copy edit, draft from notes), the
+style guide and template locations, north stars, mandatory rules, and
+citation format. Treat it as your primary instructions for this repo.
 
-The F5 Technical Writing Style Guide is included in this repo as a Git
-submodule at:
-
-    .style-guide/
-
-When you need to apply or check a style rule, read the relevant topic file
-from that repo. Topics are organized into subdirectories by category:
-
-accessibility/         alt-text, color, link-text
-agent-instructions/    README, f5-tech-writer-agent
-error-messages/        error-message-strings, published-error-messages,
-                       writing-error-messages
-formatting/            bold, capitalization, code-blocks, doc-titles, headings,
-                       hyphens, images, italics, lists, numbers, placeholders,
-                       tables
-grammar/               articles, gerunds, if-vs-whether, may-can-might,
-                       noun-clusters, parallel-structure, tense, that-vs-which
-procedures/            admonitions, cross-references, directional-references,
-                       prerequisites, step-formatting, step-numbers-in-headings,
-                       ui-element-names
-punctuation/           colons, dates-and-times, ellipses, em-dash, oxford-comma,
-                       possessives, quotation-marks
-security/              sensitive-information
-terminology/           acronyms, click-vs-select, configure-vs-set-up,
-                       enable-disable, ensure-vs-make-sure, f5-product-names,
-                       latin-abbreviations, login-vs-log-in, ui-terms,
-                       update-vs-upgrade, word-list
-voice-and-tone/        active-voice, anthropomorphism, contractions,
-                       global-audience, hedging, inclusive-language,
-                       modern-voice, reading-level, second-person,
-                       sentence-length, we-and-our
-
-Each topic is a single .md file named after the slug (for example,
-active-voice.md). Read the file for the topic you need -- do not guess
-at rules from memory.
-
-## Document templates
-
-Document templates live at:
-
-    .style-guide/templates/
-
-One template per content type:
-
-    concept/               template-concept.md
-    getting-started/       template-getting-started.md
-    how-to/                template-how-to.md
-    installation-guide/    template-installation-guide.md
-    reference/             template-reference.md
-    release-notes/         template-release-notes.md
-    tech-specs/            template-tech-specs.md
-    tutorial/              template-tutorial.md
-
-## How to respond
-
-**Review** -- Read the file, identify style issues, cite the topic slug each
-violates, and suggest a fix. End with a reading level assessment: identify
-the main factors driving complexity (long sentences, noun clusters, passive
-voice, long words) and suggest specific improvements.
-
-**Copy edit** -- Edit the file in place. After saving, list each change and
-cite the topic slug it applies. End with a brief reading level note explaining
-how the changes improve readability and what, if anything, could still be
-simplified.
-
-**Draft from notes** -- Identify the content type that best fits the notes:
-concept, getting-started, how-to, installation-guide, reference, release-notes,
-tech-specs, or tutorial. Read the corresponding template file and follow its
-section structure in order -- do not skip or reorder sections. Ask clarifying
-questions if anything needed to fill the template is missing or ambiguous.
-Apply all style guide rules to the drafted content.
-
-Always begin the draft with a title formatted as an H1 heading. Generate
-the title from the notes if one is not provided. Every section from the
-template must appear as an explicit H2 heading in the output -- do not
-substitute a section with inline text or fold it into an introduction.
+The section below adds NGINX-specific context this repo needs beyond the
+agent instructions. Everything below builds on those instructions -- it
+does not override them.
 
 ## Hugo includes
 
@@ -93,63 +22,6 @@ When you encounter an include shortcode in a file you are editing, read the
 included file and review it for style issues as part of the same task. Apply
 the same style rules to included files. List changes to included files
 separately in your output, citing the filename.
-
-## North stars
-
-Modern Voice and reading level are the primary goals of F5 documentation.
-All other style guide topics serve them. When reviewing or editing, ask
-whether each change makes the content simpler, clearer, and more relevant
-to the reader.
-
-Prioritize these topics above all others:
-
-1. sentence-length -- short sentences improve comprehension for global
-   audiences and machine translation. Task sentences: 20 words maximum.
-   Conceptual sentences: 25 words maximum.
-2. active-voice -- passive voice obscures meaning and adds words. Default
-   to active in every sentence.
-3. reading-level -- target Flesch-Kincaid Grade Level 8-9. Flag anything
-   above 10 for revision.
-4. global-audience -- avoid idioms, cultural references, and colloquialisms.
-   Write explicitly. Prefer short common words over long formal ones.
-
-Apply word list replacements, grammar rules, UI conventions, and all other
-style topics after these four are satisfied.
-
-## Always apply these rules
-
-Before returning any revised or drafted text, read .style-guide/terminology/word-list.md
-and .style-guide/terminology/ui-terms.md. Replace every term in the Required
-replacements tables. Also read .style-guide/terminology/click-vs-select.md
--- never use "click"; always use "select". These checks are mandatory and
-apply to every copy edit and draft without exception.
-
-Apply all style guide topics consistently. For tone and voice, follow
-.style-guide/voice-and-tone/modern-voice.md:
-
-- Focus on the customer question. One question = one topic with one answer.
-- Give a concise answer. Lead with the 80% case. Cut edge cases and obvious details.
-- Make it easy to scan. Put the most important thing first.
-- Use normal, relaxed words. Write like you're talking to a colleague. Use contractions.
-- Empathize. Never imply the user did something wrong. Acknowledge when a
-  process is long or difficult.
-- Use active voice and present tense.
-- Only apply rules from the style guide.
-
-## Citation format
-
-When citing a style rule, use the topic slug -- the filename without .md
-(for example, active-voice, not "Active voice"). Only cite topics that exist
-as files in the style guide repo. Never invent a topic name. If no topic
-covers the rule you applied, say "No matching topic" instead of guessing.
-
-Valid topics:
-README, acronyms, active-voice, admonitions, alt-text, anthropomorphism, articles, bold, capitalization, click-vs-select, code-blocks, colons, color, configure-vs-set-up, contractions, cross-references, dates-and-times, directional-references, doc-titles, ellipses, em-dash, enable-disable, ensure-vs-make-sure, error-message-strings, f5-product-names, f5-tech-writer-agent, gerunds, global-audience, headings, hedging, hyphens, if-vs-whether, images, inclusive-language, italics, latin-abbreviations, link-text, lists, login-vs-log-in, may-can-might, modern-voice, noun-clusters, numbers, oxford-comma, parallel-structure, placeholders, possessives, prerequisites, published-error-messages, quotation-marks, reading-level, second-person, sensitive-information, sentence-length, step-formatting, step-numbers-in-headings, tables, tense, that-vs-which, ui-element-names, ui-terms, update-vs-upgrade, we-and-our, word-list, writing-error-messages
-
-## Technical accuracy
-
-Flag technical accuracy issues separately from style issues. Do not correct
-them yourself -- ask the contributor to verify with a subject matter expert.
 
 ---
 
@@ -264,7 +136,8 @@ Never use relative links or bare markdown links for internal content.
 ## Git workflow
 
 ### Branch naming
-```
+
+```text
 <product-code>/<descriptive-name>
 docs/<descriptive-name>          # for repo or non-product changes
 
@@ -277,7 +150,8 @@ Examples:
 Release branches: `<product>-release-<version>` (for example, `agent-release-2.2`)
 
 ### Commit messages (Conventional Commits)
-```
+
+```text
 <type>: <subject line ~50 chars>
 
 <body wrapped at 72 chars explaining what, why, how>
@@ -286,7 +160,8 @@ Release branches: `<product>-release-<version>` (for example, `agent-release-2.2
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
 Example:
-```
+
+```text
 feat: Add TLS passthrough guide for NGF
 
 This commit adds a new how-to guide for configuring TLS passthrough


### PR DESCRIPTION
## Summary

The `.style-guide` submodule now includes a single source of truth for agent behavior: `agent-instructions/f5-tech-writer-agent.md`. This PR updates `.github/copilot-instructions.md` to reference that file instead of duplicating its content.

- Removed the agent persona, workflows (review, copy edit, draft from notes), north stars, mandatory terminology rules, citation format, and technical accuracy handling from this file. That content now lives only in `f5-tech-writer-agent.md` and applies identically across every repo that includes the style guide submodule.
- Replaced it with an **Agent instructions** section directing the assistant to read `.style-guide/agent-instructions/f5-tech-writer-agent.md` before responding to any request in this repo.
- Also removed **Style guide location** and **Document templates** — these described the submodule's directory structure, which is likewise identical across repos and now belongs solely to the canonical file.
- Kept everything specific to this repo: Hugo includes handling, build and dev commands, content structure, front matter conventions, Git workflow, linting, and the product names list. None of this has an equivalent in the
  shared agent instructions, so it stays local.

**Why this matters:** before this change, updating an agent rule meant editing it by hand in every repo. Now a change to `f5-tech-writer-agent.md` propagates to every repo on the next submodule sync, with nothing left to keep in sync manually here.

**Dependency:** this only works if the submodule is up to date and includes `agent-instructions/f5-tech-writer-agent.md`. Repos still on an older submodule commit will get a broken reference until they sync.

## Testing

GitHub Copilot's `copilot-instructions.md` doesn't support file imports, so this relies on the assistant actually reading the referenced file before responding — not guaranteed on every turn. Tested with the hardest case: a cold prompt, no task framing, in a fresh session.

### Confirm instructions

1. Start a new session.
2. Ask: `What are your instructions for this repo?`

**Output:** the assistant read `f5-tech-writer-agent.md` before answering, correctly attributed its behavior to two sources (`f5-tech-writer-agent.md` and `copilot-instructions.md`), and accurately summarized the workflows,
north stars, mandatory rules, and citation format from the canonical file — without conflating them with the NGINX-specific content that remains in this file.

```
Updated todo list
I’m going to quickly read the repo’s primary agent instruction file so I can answer precisely what governs my behavior in this workspace.
Read [](file:///Users/t.martin/Projects/git/nginx/documentation/.style-guide/agent-instructions/f5-tech-writer-agent.md)
Read memory
I’ve gathered the repo-specific instruction sources and next I’ll summarize the operating rules I’m following here in a concise list.
Primary instructions come from these two files:
- f5-tech-writer-agent.md
- copilot-instructions.md
What they require me to do in this repo:
1. Act as an F5 technical writing assistant for documentation work.
2. Use the style-guide topic files directly for rules instead of guessing.
3. Follow the defined workflows for review, copy edit, and draft-from-notes.
4. Prioritize modern voice and readability, especially sentence length, active voice, reading level, and global audience guidance.
5. Always apply mandatory terminology checks, including required word-list replacements and using “select” instead of “click.”
6. Use topic-slug citation format (for example: active-voice, sentence-length) when reporting style fixes.
7. Flag technical accuracy issues separately and ask for SME verification rather than silently rewriting facts.
8. If a page uses Hugo include shortcodes, review and apply the same style standards to the included files too.
9. Follow NGINX docs conventions in this repo: Hugo content patterns, front matter standards, internal linking with Hugo ref shortcodes, product naming rules, and repo lint/build workflows.
If you want, I can also give you a “quick operational version” focused only on how I’ll handle your current file in tech-specs.md.
```

### Confirm task-triggered fetch

Also verified with a task prompt (`Copy edit content/nim/fundamentals/tech-specs.md`). The assistant read the target file and `f5-tech-writer-agent.md` before starting the edit, confirming the reference fires on task-shaped requests
as well as cold ones.

<img width="303" height="370" alt="image" src="https://github.com/user-attachments/assets/f806d476-0c72-437a-afa6-39b05b52de13" />

<img width="874" height="536" alt="image" src="https://github.com/user-attachments/assets/f7c1869c-5cdc-4c7c-bcff-45def81d84e8" />

