### PR TITLE
chore: remove deprecated NGINX Service Mesh

### DIFF
--- a/content/nic/configuration/global-configuration/command-line-arguments.md
+++ b/content/nic/configuration/global-configuration/command-line-arguments.md
@@ -388,24 +388,6 @@ A Secret with a TLS certificate and key for TLS termination of the Service Insig
 
 Format: `<namespace>/<name>`
 
-<a name="cmdoption-spire-agent-address"></a>
-
-### -spire-agent-address `<string>`
-
-Specifies the address of a running Spire agent. **For use with NGINX Service Mesh only**.
-
-- If the argument is set, but NGINX Ingress Controller is unable to connect to the Spire Agent, NGINX Ingress Controller will fail to start.
-
-<a name="cmdoption-enable-internal-routes"></a>
-
-### -enable-internal-routes
-
-Enable support for internal routes with NGINX Service Mesh. **For use with NGINX Service Mesh only**.
-
-Requires [-spire-agent-address](#cmdoption-spire-agent-address).
-
-- If the argument is set, but `spire-agent-address` is not provided, NGINX Ingress Controller will fail to start.
-
 <a name="cmdoption-enable-latency-metrics"></a>
 
 ### -enable-latency-metrics

--- a/content/nic/install/helm/parameters.md
+++ b/content/nic/install/helm/parameters.md
@@ -218,8 +218,6 @@ The [values.schema.json](https://github.com/nginx/kubernetes-ingress/blob/main/c
 |**nginxAgent.napMonitoring.collectorBufferSize** | Buffer size for collector. Will contain log lines and parsed log lines. Requires NGINX Agent 2.x. | 50000 |
 |**nginxAgent.napMonitoring.processorBufferSize** | Buffer size for processor. Will contain log lines and parsed log lines. Requires NGINX Agent 2.x. | 50000 |
 |**nginxAgent.customConfigMap** | The name of a custom ConfigMap to use instead of the one provided by default. Requires NGINX Agent 2.x.| "" |
-| **nginxServiceMesh.enable** | Enable integration with NGINX Service Mesh. See the NGINX Service Mesh docs for more details. Requires `controller.nginxplus`. | false |
-| **nginxServiceMesh.enableEgress** | Enable NGINX Service Mesh workloads to route egress traffic through the NGINX Ingress Controller. See the NGINX Service Mesh docs for more details. Requires `nginxServiceMesh.enable`. | false |
 | **prometheus.create** | Expose NGINX or NGINX Plus metrics in the Prometheus format. | true |
 | **prometheus.port** | Configures the port to scrape the metrics. | 9113 |
 | **prometheus.scheme** | Configures the HTTP scheme to use for connections to the Prometheus endpoint. | http |


### PR DESCRIPTION
### Proposed changes

Remove NGINX Service Mesh support from F5 NGINX Ingress Controller

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
