### PR TITLE
Rename ngf landing card links to be more prescriptive

### DIFF
--- a/content/ngf/_index.md
+++ b/content/ngf/_index.md
@@ -59,13 +59,13 @@ For more information, see the [Gateway architecture]({{< ref "/ngf/overview/gate
   {{<card title="Changelog" titleUrl="/nginx-gateway-fabric/changelog">}}
     Review the changes from the latest releases.
   {{</card>}}
-  {{<card title="Technical specifications" titleUrl="/nginx-gateway-fabric/reference/technical-specifications/">}}
+  {{<card title="Technical specifications" titleUrl="/nginx-gateway-fabric/overview/technical-specifications">}}
     Check which versions of NGINX Gateway Fabric match the API.
   {{</card>}}
-  {{<card title="Routing traffic to applications" titleUrl="/nginx-gateway-fabric/traffic-management/basic-routing/">}}
+  {{<card title="Routing traffic to applications" titleUrl="/nginx-gateway-fabric/traffic-management/basic-routing">}}
     Create simple rules for directing network traffic with HTTPRoute resources.
   {{</card>}}
-  {{<card title="Secure traffic using Let's Encrypt" titleUrl="/nginx-gateway-fabric/traffic-security/integrate-cert-manager/">}}
+  {{<card title="Secure traffic using Let's Encrypt" titleUrl="/nginx-gateway-fabric/traffic-security/integrate-cert-manager">}}
     Implement HTTPS with Let's Encrypt to secure client-server communication.
   {{</card>}}
 {{</card-section>}}


### PR DESCRIPTION
### Proposed changes

Use better links to articles instead of fuzzy url + fix link for technical-specification.md since it moved in https://github.com/nginx/documentation/commit/5c21ef0d4b5842050663302c63a8e7881cd0b68e#diff-7098e35404fd6d7ebc5a04a986f62cd14d7d65a2ae9a86da00f64baa50f11929

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
