### PR TITLE
Fix links to /waf/logging/logs-overview.md

### DIFF
--- a/content/nginx-one-console/waf-integration/log-profiles/configure-log-profiles.md
+++ b/content/nginx-one-console/waf-integration/log-profiles/configure-log-profiles.md
@@ -28,7 +28,7 @@ For detailed information about security logging capabilities and available log a
 
 From NGINX One Console, select **WAF** > **Log Profiles**. In the screen that appears, select **Add Log Profile**. This action opens a screen where you can:
 
-- In **Start From**, select an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/log-overview.md#default-logging-profile-bundles" >}}) as a starting point.
+- In **Start From**, select an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/logs-overview.md#default-logging-profile-bundles" >}}) as a starting point.
 - In **General Settings**, name and describe the log profile
 - Configure the filter settings to determine which requests are logged
 - Set the content format and options for how log messages are structured

--- a/content/nginx-one-console/waf-integration/policy/configure-policy.md
+++ b/content/nginx-one-console/waf-integration/policy/configure-policy.md
@@ -22,7 +22,7 @@ If you already know F5 WAF for NGINX, you can go beyond the options available in
 
 From NGINX One Console, select **WAF > Policies**. In the screen that appears, select **Add Policy**. That action opens a screen where you can:
 
-- Optionally, select an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/log-overview.md#default-logging-profile-bundles>}} as a starting point.
+- Optionally, select an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/log-overview.md#default-logging-profile-bundles" >}} as a starting point.
 - In General Settings, name and describe the policy.
   - You can also set one of the following enforcement modes:
     - Transparent

--- a/content/nginx-one-console/waf-integration/policy/configure-policy.md
+++ b/content/nginx-one-console/waf-integration/policy/configure-policy.md
@@ -22,7 +22,7 @@ If you already know F5 WAF for NGINX, you can go beyond the options available in
 
 From NGINX One Console, select **WAF > Policies**. In the screen that appears, select **Add Policy**. That action opens a screen where you can:
 
-- Optionally, select an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/log-overview.md#default-logging-profile-bundles" >}} as a starting point.
+- Optionally, select an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/logs-overview.md#default-logging-profile-bundles" >}} as a starting point.
 - In General Settings, name and describe the policy.
   - You can also set one of the following enforcement modes:
     - Transparent

--- a/content/nim/waf-integration/policies-and-logs/log-profiles/deploy-log-profile.md
+++ b/content/nim/waf-integration/policies-and-logs/log-profiles/deploy-log-profile.md
@@ -63,7 +63,7 @@ You can also deploy a log profile directly when editing the NGINX configuration 
 1. Select the **Configuration** tab, then select **Edit Configuration**.
 
    {{< call-out class="note" >}}
-  You can also reference an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/log-overview.md#default-logging-profile-bundles" >}}) by name. You don't need to deploy it first.
+  You can also reference an F5 WAF for NGINX [default logging profile]({{< ref "/waf/logging/logs-overview.md#default-logging-profile-bundles" >}}) by name. You don't need to deploy it first.
    {{< /call-out >}}
 
 1. Select **Apply security** and select which log profile to deploy.


### PR DESCRIPTION
This MR fixes a three broken links to `/waf/logging/logs-overview.md`