### PR TITLE
Changes w.r.t NIM patch release 2.22.2 and WAF compiler 5.13.4

### DIFF
--- a/content/includes/nim/kubernetes/nms-chart-supported-module-versions.md
+++ b/content/includes/nim/kubernetes/nms-chart-supported-module-versions.md
@@ -9,6 +9,7 @@ f5-files:
 
 | NGINX Instance Manager chart | Chart                      | Instance Manager |
 |------------------------------|----------------------------|------------------|
+| 2.2.2                        | nginx-stable/nim           | 2.22.2           |
 | 2.2.1                        | nginx-stable/nim           | 2.22.1           |
 | 2.2.0                        | nginx-stable/nim           | 2.22.0           |
 | 2.1.1                        | nginx-stable/nim           | 2.21.1           |

--- a/content/includes/nim/tech-specs/nim-app-protect-support.md
+++ b/content/includes/nim/tech-specs/nim-app-protect-support.md
@@ -12,7 +12,7 @@ NGINX Instance Manager supports the following versions of [F5 WAF for NGINX](htt
 
 | NGINX Instance Manager | F5 WAF for NGINX                                |
 | ---------------------- | ----------------------------------------------- |
-| 2.21.0-2.22.1          | Release 4.8.0–4.16.0, 5.1.0–5.13.3              |
+| 2.21.0-2.22.2          | Release 4.8.0–4.16.0, 5.1.0–5.13.4              |
 | 2.17.0–2.20.1          | Release 4.8.0–4.16.0, 5.1.0–5.8.0               |
 | 2.15.1–2.16.0          | Release 4.8.0–4.10.0                            |
 | 2.14.1–2.15.0          | Release 4.4.0–4.7.0                             |

--- a/content/includes/nim/tech-specs/supported-nginx-versions.md
+++ b/content/includes/nim/tech-specs/supported-nginx-versions.md
@@ -12,7 +12,7 @@ NGINX Instance Manager supports the following NGINX Open Source and NGINX Plus v
 
 | NGINX Instance Manager | NGINX OSS   | NGINX Plus |
 | ---------------------- | ----------- | ---------- |
-| 2.18.0 and later       | 1.18–1.31.2 | R31–R37    |
+| 2.18.0 and later       | 1.18–1.31.3 | R31–R37    |
 | 2.16.0–2.17.x          | 1.18–1.25.1 | R31–R32    |
 | 2.7.0–2.15.x           | 1.18–1.25.1 | R21–R30    |
 | 2.0.0–2.6.0            | 1.18–1.21.6 | R21–R27    |

--- a/content/includes/waf/waf-nim-compiler-support.md
+++ b/content/includes/waf/waf-nim-compiler-support.md
@@ -7,6 +7,7 @@ f5-files:
 
 | F5 WAF for NGINX version  | WAF compiler version       |
 |---------------------------|----------------------------|
+| 5.13.4                    | nms-nap-compiler-v5.635.4  |
 | 5.13.3                    | nms-nap-compiler-v5.635.3  |
 | 5.13.2                    | nms-nap-compiler-v5.635.2  |
 | 5.13.1                    | nms-nap-compiler-v5.635.1  |

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install-disconnected.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install-disconnected.md
@@ -60,11 +60,11 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
    mkdir -p compiler && cd compiler
    sudo apt-get update
 
-   sudo apt-get download nms-nap-compiler-v5.635.3
+   sudo apt-get download nms-nap-compiler-v5.635.4
    cd ../
    mkdir -p compiler/compiler.deps
    sudo apt-get install --download-only --reinstall --yes --print-uris \
-     nms-nap-compiler-v5.635.3 \
+     nms-nap-compiler-v5.635.4 \
      | grep ^\' \
      | cut -d\' -f2 \
      | xargs -n 1 wget -P ./compiler/compiler.deps
@@ -108,11 +108,11 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
    mkdir -p compiler && cd compiler
    sudo apt-get update
 
-   sudo apt-get download nms-nap-compiler-v5.635.3
+   sudo apt-get download nms-nap-compiler-v5.635.4
    cd ../
    mkdir -p compiler/compiler.deps
    sudo apt-get install --download-only --reinstall --yes --print-uris \
-     nms-nap-compiler-v5.635.3 \
+     nms-nap-compiler-v5.635.4 \
      | grep ^\' \
      | cut -d\' -f2 \
      | xargs -n 1 wget -P ./compiler/compiler.deps
@@ -157,7 +157,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
    sudo yum update -y
    sudo mkdir -p nms-nap-compiler
 
-   sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.635.3
+   sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.635.4
    tar -czvf compiler.tar.gz nms-nap-compiler/
    ```
 
@@ -192,7 +192,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
    sudo yum update -y
    sudo mkdir -p nms-nap-compiler
 
-   sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.635.3
+   sudo yumdownloader --resolve --destdir=nms-nap-compiler nms-nap-compiler-v5.635.4
    tar -czvf compiler.tar.gz nms-nap-compiler/
    ```
 

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -50,13 +50,13 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 1. Install the WAF compiler:
 
    ```shell
-   sudo apt-get install nms-nap-compiler-v5.635.3
+   sudo apt-get install nms-nap-compiler-v5.635.4
    ```
 
 1. To install multiple compiler versions on the same system, append the `--force-overwrite` option after the first installation:
 
    ```shell
-   sudo apt-get install nms-nap-compiler-v5.635.3 -o Dpkg::Options::="--force-overwrite"
+   sudo apt-get install nms-nap-compiler-v5.635.4 -o Dpkg::Options::="--force-overwrite"
    ```
 
 1. {{< include "nim/waf/restart-nms-integrations.md" >}}
@@ -80,7 +80,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 1. Install the WAF compiler:
 
    ```shell
-   sudo yum install nms-nap-compiler-v5.635.3
+   sudo yum install nms-nap-compiler-v5.635.4
    ```
 
 1. {{< include "nim/waf/restart-nms-integrations.md" >}}
@@ -104,7 +104,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 1. Install the WAF compiler:
 
    ```shell
-   sudo yum install nms-nap-compiler-v5.635.3
+   sudo yum install nms-nap-compiler-v5.635.4
    ```
 
 1. {{< include "nim/waf/restart-nms-integrations.md" >}}
@@ -128,7 +128,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 1. Install the WAF compiler:
 
    ```shell
-   sudo yum install nms-nap-compiler-v5.635.3
+   sudo yum install nms-nap-compiler-v5.635.4
    ```
 
 1. {{< include "nim/waf/restart-nms-integrations.md" >}}

--- a/content/nim/waf-integration/configuration/troubleshooting.md
+++ b/content/nim/waf-integration/configuration/troubleshooting.md
@@ -62,21 +62,21 @@ sudo /opt/nms-nap-compiler/app_protect-<version>/bin/apcompile -h
 **Example:**
 
 ```shell
-sudo /opt/nms-nap-compiler/app_protect-5.635.3/bin/apcompile -h
+sudo /opt/nms-nap-compiler/app_protect-5.635.4/bin/apcompile -h
 ```
 
 **Expected output:**
 
 ```text
 USAGE:
-    /opt/nms-nap-compiler/app_protect-5.635.3/bin/apcompile <options>
+    /opt/nms-nap-compiler/app_protect-5.635.4/bin/apcompile <options>
 
 Examples:
-    /opt/nms-nap-compiler/app_protect-5.635.3/bin/apcompile -p /path/to/policy.json -o mypolicy.tgz
-    /opt/nms-nap-compiler/app_protect-5.635.3/bin/apcompile -p policyA.json -g myglobal.json -o /path/to/policyA_bundle.tgz
-    /opt/nms-nap-compiler/app_protect-5.635.3/bin/apcompile -g myglobalsettings.json --global-state-outfile /path/to/myglobalstate.tgz
-    /opt/nms-nap-compiler/app_protect-5.635.3/bin/apcompile -b /path/to/policy_bundle.tgz --dump
-    /opt/nms-nap-compiler/app_protect-5.635.3/bin/apcompile -l logprofA.json -o /path/to/logprofA_bundle.tgz
+    /opt/nms-nap-compiler/app_protect-5.635.4/bin/apcompile -p /path/to/policy.json -o mypolicy.tgz
+    /opt/nms-nap-compiler/app_protect-5.635.4/bin/apcompile -p policyA.json -g myglobal.json -o /path/to/policyA_bundle.tgz
+    /opt/nms-nap-compiler/app_protect-5.635.4/bin/apcompile -g myglobalsettings.json --global-state-outfile /path/to/myglobalstate.tgz
+    /opt/nms-nap-compiler/app_protect-5.635.4/bin/apcompile -b /path/to/policy_bundle.tgz --dump
+    /opt/nms-nap-compiler/app_protect-5.635.4/bin/apcompile -l logprofA.json -o /path/to/logprofA_bundle.tgz
 ```
 
 ---

--- a/static/scripts/docker-compose/docker-compose-lightweight.yaml
+++ b/static/scripts/docker-compose/docker-compose-lightweight.yaml
@@ -14,7 +14,7 @@ secrets:
   #  file: ./certs/nim_ca.pem
 services:
   nim:
-    image: private-registry.nginx.com/nms/nim-standalone-compose:2.22.1
+    image: private-registry.nginx.com/nms/nim-standalone-compose:2.22.2
     hostname: nim
     ports:
       - 443:443

--- a/static/scripts/docker-compose/docker-compose.yaml
+++ b/static/scripts/docker-compose/docker-compose.yaml
@@ -14,7 +14,7 @@ secrets:
   #  file: ./certs/nim_ca.pem
 services:
   nim:
-    image: private-registry.nginx.com/nms/nim-standalone-compose:2.22.1
+    image: private-registry.nginx.com/nms/nim-standalone-compose:2.22.2
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/static/scripts/fetch-external-dependencies.sh
+++ b/static/scripts/fetch-external-dependencies.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # This script is used to fetch external packages that are not available in standard Linux distribution
 
-# Example: ./fetch-external-dependencies ubuntu20.04
-# Script will create nms-dependencies-ubuntu20.04.tar.gz in local directory which can be copied
+# Example: ./fetch-external-dependencies ubuntu22.04
+# Script will create nms-dependencies-ubuntu22.04.tar.gz in local directory which can be copied
 # into target machine and packages inside can be installed manually
 
 if ((BASH_VERSINFO[0] < 4))
@@ -35,32 +35,32 @@ fetch() {
 }
 
 declare -A CLICKHOUSE_REPO
-CLICKHOUSE_REPO['ubuntu20.04']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse/"
-CLICKHOUSE_REPO['ubuntu22.04']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse/"
-CLICKHOUSE_REPO['debian11']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse/"
-CLICKHOUSE_REPO['debian12']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse/"
-CLICKHOUSE_REPO['centos7']="https://packages.clickhouse.com/rpm/stable/"
-CLICKHOUSE_REPO['centos8']="https://packages.clickhouse.com/rpm/stable/"
-CLICKHOUSE_REPO['rhel7']="https://packages.clickhouse.com/rpm/stable/"
-CLICKHOUSE_REPO['rhel8']="https://packages.clickhouse.com/rpm/stable/"
-CLICKHOUSE_REPO['rhel9']="https://packages.clickhouse.com/rpm/stable/"
-CLICKHOUSE_REPO['oracle7']="https://packages.clickhouse.com/rpm/stable/"
-CLICKHOUSE_REPO['oracle8']="https://packages.clickhouse.com/rpm/stable/"
-CLICKHOUSE_REPO['amzn2']="https://packages.clickhouse.com/rpm/stable/"
+CLICKHOUSE_REPO['ubuntu22.04']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
+CLICKHOUSE_REPO['ubuntu24.04']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
+CLICKHOUSE_REPO['debian11']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
+CLICKHOUSE_REPO['debian12']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
+CLICKHOUSE_REPO['debian13']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
+CLICKHOUSE_REPO['rhel8']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rhel9']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rhel10']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['oracle8']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rocky8']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rocky9']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rocky10']="https://packages.clickhouse.com/rpm/stable"
 
 declare -A NGINX_REPO
-NGINX_REPO['ubuntu20.04']="https://nginx.org/packages/mainline/ubuntu/pool/nginx/n/nginx/"
 NGINX_REPO['ubuntu22.04']="https://nginx.org/packages/mainline/ubuntu/pool/nginx/n/nginx/"
+NGINX_REPO['ubuntu24.04']="https://nginx.org/packages/mainline/ubuntu/pool/nginx/n/nginx/"
 NGINX_REPO['debian11']="https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx/"
 NGINX_REPO['debian12']="https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx/"
-NGINX_REPO['centos7']="https://nginx.org/packages/mainline/centos/7/x86_64/RPMS/"
-NGINX_REPO['centos8']="https://nginx.org/packages/mainline/centos/8/x86_64/RPMS/"
-NGINX_REPO['rhel7']="https://nginx.org/packages/mainline/rhel/7/x86_64/RPMS/"
+NGINX_REPO['debian13']="https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx/"
 NGINX_REPO['rhel8']="https://nginx.org/packages/mainline/rhel/8/x86_64/RPMS/"
 NGINX_REPO['rhel9']="https://nginx.org/packages/mainline/rhel/9/x86_64/RPMS/"
-NGINX_REPO['oracle7']="https://nginx.org/packages/mainline/rhel/7/x86_64/RPMS/"
+NGINX_REPO['rhel10']="https://nginx.org/packages/mainline/rhel/10/x86_64/RPMS/"
 NGINX_REPO['oracle8']="https://nginx.org/packages/mainline/rhel/8/x86_64/RPMS/"
-NGINX_REPO['amzn2']="https://nginx.org/packages/mainline/amzn2/2/x86_64/RPMS/"
+NGINX_REPO['rocky8']="https://nginx.org/packages/mainline/rhel/8/x86_64/RPMS/"
+NGINX_REPO['rocky9']="https://nginx.org/packages/mainline/rhel/9/x86_64/RPMS/"
+NGINX_REPO['rocky10']="https://nginx.org/packages/mainline/rhel/10/x86_64/RPMS/"
 
 CLICKHOUSE_KEY="https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key"
 NGINX_KEY="https://nginx.org/keys/nginx_signing.key"
@@ -76,32 +76,32 @@ CLICKHOUSE_PACKAGES['centos']="
 clickhouse-server-${CLICKHOUSE_VERSION}.x86_64.rpm
 clickhouse-common-static-${CLICKHOUSE_VERSION}.x86_64.rpm"
 
-CLICKHOUSE_PACKAGES['ubuntu20.04']=${CLICKHOUSE_PACKAGES['ubuntu']}
 CLICKHOUSE_PACKAGES['ubuntu22.04']=${CLICKHOUSE_PACKAGES['ubuntu']}
+CLICKHOUSE_PACKAGES['ubuntu24.04']=${CLICKHOUSE_PACKAGES['ubuntu']}
 CLICKHOUSE_PACKAGES['debian11']=${CLICKHOUSE_PACKAGES['ubuntu']}
 CLICKHOUSE_PACKAGES['debian12']=${CLICKHOUSE_PACKAGES['ubuntu']}
-CLICKHOUSE_PACKAGES['centos7']=${CLICKHOUSE_PACKAGES['centos']}
-CLICKHOUSE_PACKAGES['centos8']=${CLICKHOUSE_PACKAGES['centos']}
-CLICKHOUSE_PACKAGES['rhel7']=${CLICKHOUSE_PACKAGES['centos']}
+CLICKHOUSE_PACKAGES['debian13']=${CLICKHOUSE_PACKAGES['ubuntu']}
 CLICKHOUSE_PACKAGES['rhel8']=${CLICKHOUSE_PACKAGES['centos']}
 CLICKHOUSE_PACKAGES['rhel9']=${CLICKHOUSE_PACKAGES['centos']}
-CLICKHOUSE_PACKAGES['oracle7']=${CLICKHOUSE_PACKAGES['centos']}
+CLICKHOUSE_PACKAGES['rhel10']=${CLICKHOUSE_PACKAGES['centos']}
 CLICKHOUSE_PACKAGES['oracle8']=${CLICKHOUSE_PACKAGES['centos']}
-CLICKHOUSE_PACKAGES['amzn2']=${CLICKHOUSE_PACKAGES['centos']}
+CLICKHOUSE_PACKAGES['rocky8']=${CLICKHOUSE_PACKAGES['centos']}
+CLICKHOUSE_PACKAGES['rocky9']=${CLICKHOUSE_PACKAGES['centos']}
+CLICKHOUSE_PACKAGES['rocky10']=${CLICKHOUSE_PACKAGES['centos']}
 
 declare -A NGINX_PACKAGES
-NGINX_PACKAGES['ubuntu20.04']="nginx_1.21.2-1~focal_amd64.deb"
-NGINX_PACKAGES['ubuntu22.04']="nginx_1.21.6-1~jammy_amd64.deb"
-NGINX_PACKAGES['debian11']="nginx_1.21.6-1~bullseye_amd64.deb"
-NGINX_PACKAGES['debian12']="nginx_1.21.6-1~bookworm_amd64.deb"
-NGINX_PACKAGES['centos7']="nginx-1.21.4-1.el7.ngx.x86_64.rpm"
-NGINX_PACKAGES['centos8']="nginx-1.21.4-1.el8.ngx.x86_64.rpm"
-NGINX_PACKAGES['rhel7']="nginx-1.21.4-1.el7.ngx.x86_64.rpm"
-NGINX_PACKAGES['rhel8']="nginx-1.21.4-1.el8.ngx.x86_64.rpm"
-NGINX_PACKAGES['rhel9']="nginx-1.21.6-1.el9.ngx.x86_64.rpm"
-NGINX_PACKAGES['oracle7']="nginx-1.21.4-1.el7.ngx.x86_64.rpm"
-NGINX_PACKAGES['oracle8']="nginx-1.21.4-1.el8.ngx.x86_64.rpm"
-NGINX_PACKAGES['amzn2']="nginx-1.21.6-1.amzn2.ngx.x86_64.rpm"
+NGINX_PACKAGES['ubuntu22.04']="nginx_1.31.1-1~jammy_amd64.deb"
+NGINX_PACKAGES['ubuntu24.04']="nginx_1.31.1-1~noble_amd64.deb"
+NGINX_PACKAGES['debian11']="nginx_1.31.1-1~bullseye_amd64.deb"
+NGINX_PACKAGES['debian12']="nginx_1.31.1-1~bookworm_amd64.deb"
+NGINX_PACKAGES['debian13']="nginx_1.31.1-1~trixie_amd64.deb"
+NGINX_PACKAGES['rhel8']="nginx-1.31.1-1.el8.ngx.x86_64.rpm"
+NGINX_PACKAGES['rhel9']="nginx-1.31.1-1.el9.ngx.x86_64.rpm"
+NGINX_PACKAGES['rhel10']="nginx-1.31.1-1.el10.ngx.x86_64.rpm"
+NGINX_PACKAGES['oracle8']="nginx-1.31.1-1.el8.ngx.x86_64.rpm"
+NGINX_PACKAGES['rocky8']="nginx-1.31.1-1.el8.ngx.x86_64.rpm"
+NGINX_PACKAGES['rocky9']="nginx-1.31.1-1.el9.ngx.x86_64.rpm"
+NGINX_PACKAGES['rocky10']="nginx-1.31.1-1.el10.ngx.x86_64.rpm"
 
 download_packages() {
     local target_distribution=$1

--- a/static/scripts/install-nim-bundle.sh
+++ b/static/scripts/install-nim-bundle.sh
@@ -20,6 +20,8 @@ NGINX_CERT_KEY_PATH="/etc/ssl/nginx/nginx-repo.key"
 LICENSE_JWT_PATH=""
 USE_NGINX_PLUS="false"
 UNINSTALL_NIM="false"
+INSTALL_WAF_COMPILER="false"
+CROSS_OS_PACKAGING="false"
 MODE="online"
 INSTALL_PATH=""
 SKIP_CLICKHOUSE_INSTALL="false"
@@ -29,106 +31,121 @@ TARGET_DISTRIBUTION=""
 NMS_NGINX_MGMT_BLOCK="mgmt { \n  usage_report endpoint=127.0.0.1 interval=30m; \n  ssl_verify off; \n}";
 NIM_FQDN=""
 OS_ARCH="amd64"
-UBUNTU_2004="ubuntu20.04"
 UBUNTU_2204="ubuntu22.04"
 UBUNTU_2404="ubuntu24.04"
 DEBIAN_11="debian11"
 DEBIAN_12="debian12"
-CENTOS_8="centos8"
+DEBIAN_13="debian13"
 REDHAT_8="rhel8"
 REDHAT_9="rhel9"
+REDHAT_10="rhel10"
 ORACLE_8="oracle8"
-ORACLE_9="oracle9"
+ROCKY_8="rocky8"
+ROCKY_9="rocky9"
+ROCKY_10="rocky10"
 CLICKHOUSE_VERSION="24.9.2.42"
 PKG_EXTENSION="deb"
 UBUNTU_OS=(
-    "${UBUNTU_2004}"
     "${UBUNTU_2204}"
     "${UBUNTU_2404}"
 )
 DEB_OS=(
     "${DEBIAN_11}"
     "${DEBIAN_12}"
-)
-CENT_OS=(
-    "${CENTOS_8}"
+    "${DEBIAN_13}"
 )
 RPM_OS=(
     "${REDHAT_8}"
     "${REDHAT_9}"
+    "${REDHAT_10}"
     "${ORACLE_8}"
-    "${ORACLE_9}"
+    "${ROCKY_8}"
+    "${ROCKY_9}"
+    "${ROCKY_10}"
 )
 SUPPORTED_OS=()
 SUPPORTED_OS+=("${DEB_OS[@]}")
 SUPPORTED_OS+=("${RPM_OS[@]}")
-SUPPORTED_OS+=("${CENT_OS[@]}")
 SUPPORTED_OS+=("${UBUNTU_OS[@]}")
 
 declare -A OS_DISTRO_MAP
-OS_DISTRO_MAP['ubuntu20.04']="focal"
 OS_DISTRO_MAP['ubuntu22.04']="jammy"
 OS_DISTRO_MAP['ubuntu24.04']="noble"
 OS_DISTRO_MAP['debian11']="bullseye"
 OS_DISTRO_MAP['debian12']="bookworm"
-OS_DISTRO_MAP['centos8']=".el8.ngx.x86_64"
+OS_DISTRO_MAP['debian13']="trixie"
 OS_DISTRO_MAP['rhel8']=".el8.ngx.x86_64"
 OS_DISTRO_MAP['rhel9']=".el9.ngx.x86_64"
+OS_DISTRO_MAP['rhel10']=".el10.ngx.x86_64"
 OS_DISTRO_MAP['oracle8']=".el8.ngx.x86_64"
-OS_DISTRO_MAP['oracle9']=".el9.ngx.x86_64"
+OS_DISTRO_MAP['rocky8']=".el8.ngx.x86_64"
+OS_DISTRO_MAP['rocky9']=".el9.ngx.x86_64"
+OS_DISTRO_MAP['rocky10']=".el10.ngx.x86_64"
 OS_DISTRO_MAP['amzn2']=".amzn2.ngx.x86_64"
 
 declare -A NGINX_PLUS_REPO
-NGINX_PLUS_REPO['ubuntu20.04']="https://pkgs.nginx.com/plus/ubuntu/pool/nginx-plus/n/nginx-plus"
 NGINX_PLUS_REPO['ubuntu22.04']="https://pkgs.nginx.com/plus/ubuntu/pool/nginx-plus/n/nginx-plus"
 NGINX_PLUS_REPO['ubuntu24.04']="https://pkgs.nginx.com/plus/ubuntu/pool/nginx-plus/n/nginx-plus"
 NGINX_PLUS_REPO['debian11']="https://pkgs.nginx.com/plus/debian/pool/nginx-plus/n/nginx-plus"
 NGINX_PLUS_REPO['debian12']="https://pkgs.nginx.com/plus/debian/pool/nginx-plus/n/nginx-plus"
-NGINX_PLUS_REPO['centos8']="https://pkgs.nginx.com/plus/centos/8/x86_64/RPMS"
+NGINX_PLUS_REPO['debian13']="https://pkgs.nginx.com/plus/debian/pool/nginx-plus/n/nginx-plus"
 NGINX_PLUS_REPO['rhel8']="https://pkgs.nginx.com/plus/rhel/8/x86_64/RPMS"
 NGINX_PLUS_REPO['rhel9']="https://pkgs.nginx.com/plus/rhel/9/x86_64/RPMS"
+NGINX_PLUS_REPO['rhel10']="https://pkgs.nginx.com/plus/rhel/10/x86_64/RPMS"
 NGINX_PLUS_REPO['oracle8']="https://pkgs.nginx.com/plus/rhel/8/x86_64/RPMS"
-NGINX_PLUS_REPO['oracle9']="https://pkgs.nginx.com/plus/rhel/9/x86_64/RPMS"
+NGINX_PLUS_REPO['rocky8']="https://pkgs.nginx.com/plus/rhel/8/x86_64/RPMS"
+NGINX_PLUS_REPO['rocky9']="https://pkgs.nginx.com/plus/rhel/9/x86_64/RPMS"
+NGINX_PLUS_REPO['rocky10']="https://pkgs.nginx.com/plus/rhel/10/x86_64/RPMS"
 NGINX_PLUS_REPO['amzn2']="https://pkgs.nginx.com/plus/amzn2/2/x86_64/RPMS"
 
 declare -A NIM_REPO
-NIM_REPO['ubuntu20.04']="https://pkgs.nginx.com/nms/ubuntu/pool/nginx-plus/n/nms-instance-manager"
 NIM_REPO['ubuntu22.04']="https://pkgs.nginx.com/nms/ubuntu/pool/nginx-plus/n/nms-instance-manager"
 NIM_REPO['ubuntu24.04']="https://pkgs.nginx.com/nms/ubuntu/pool/nginx-plus/n/nms-instance-manager"
 NIM_REPO['debian11']="https://pkgs.nginx.com/nms/debian/pool/nginx-plus/n/nms-instance-manager"
 NIM_REPO['debian12']="https://pkgs.nginx.com/nms/debian/pool/nginx-plus/n/nms-instance-manager"
-NIM_REPO['centos8']="https://pkgs.nginx.com/nms/centos/8/x86_64/RPMS"
+NIM_REPO['debian13']="https://pkgs.nginx.com/nms/debian/pool/nginx-plus/n/nms-instance-manager"
 NIM_REPO['rhel8']="https://pkgs.nginx.com/nms/centos/8/x86_64/RPMS"
 NIM_REPO['rhel9']="https://pkgs.nginx.com/nms/centos/9/x86_64/RPMS"
+NIM_REPO['rhel10']="https://pkgs.nginx.com/nms/centos/10/x86_64/RPMS"
 NIM_REPO['oracle8']="https://pkgs.nginx.com/nms/centos/8/x86_64/RPMS"
-NIM_REPO['oracle9']="https://pkgs.nginx.com/nms/centos/9/x86_64/RPMS"
+NIM_REPO['rocky8']="https://pkgs.nginx.com/nms/centos/8/x86_64/RPMS"
+NIM_REPO['rocky9']="https://pkgs.nginx.com/nms/centos/9/x86_64/RPMS"
+NIM_REPO['rocky10']="https://pkgs.nginx.com/nms/centos/10/x86_64/RPMS"
 NIM_REPO['amzn2']="https://pkgs.nginx.com/nms/amzn2/2/x86_64/RPMS"
 
 declare -A NGINX_REPO
-NGINX_REPO['ubuntu20.04']="https://nginx.org/packages/mainline/ubuntu/pool/nginx/n/nginx"
 NGINX_REPO['ubuntu22.04']="https://nginx.org/packages/mainline/ubuntu/pool/nginx/n/nginx"
 NGINX_REPO['ubuntu24.04']="https://nginx.org/packages/mainline/ubuntu/pool/nginx/n/nginx"
 NGINX_REPO['debian11']="https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx"
 NGINX_REPO['debian12']="https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx"
-NGINX_REPO['centos8']="https://nginx.org/packages/mainline/centos/8/x86_64/RPMS"
+NGINX_REPO['debian13']="https://nginx.org/packages/mainline/debian/pool/nginx/n/nginx"
 NGINX_REPO['rhel8']="https://nginx.org/packages/mainline/rhel/8/x86_64/RPMS"
 NGINX_REPO['rhel9']="https://nginx.org/packages/mainline/rhel/9/x86_64/RPMS"
+NGINX_REPO['rhel10']="https://nginx.org/packages/mainline/rhel/10/x86_64/RPMS"
 NGINX_REPO['oracle8']="https://nginx.org/packages/mainline/rhel/8/x86_64/RPMS"
-NGINX_REPO['oracle9']="https://nginx.org/packages/mainline/rhel/9/x86_64/RPMS"
+NGINX_REPO['rocky8']="https://nginx.org/packages/mainline/rhel/8/x86_64/RPMS"
+NGINX_REPO['rocky9']="https://nginx.org/packages/mainline/rhel/9/x86_64/RPMS"
+NGINX_REPO['rocky10']="https://nginx.org/packages/mainline/rhel/10/x86_64/RPMS"
 NGINX_REPO['amzn2']="https://nginx.org/packages/mainline/amzn2/2/x86_64/RPMS"
 
 declare -A CLICKHOUSE_REPO
-CLICKHOUSE_REPO['ubuntu20.04']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
 CLICKHOUSE_REPO['ubuntu22.04']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
 CLICKHOUSE_REPO['ubuntu24.04']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
 CLICKHOUSE_REPO['debian11']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
 CLICKHOUSE_REPO['debian12']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
-CLICKHOUSE_REPO['centos8']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['debian13']="https://packages.clickhouse.com/deb/pool/main/c/clickhouse"
 CLICKHOUSE_REPO['rhel8']="https://packages.clickhouse.com/rpm/stable"
 CLICKHOUSE_REPO['rhel9']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rhel10']="https://packages.clickhouse.com/rpm/stable"
 CLICKHOUSE_REPO['oracle8']="https://packages.clickhouse.com/rpm/stable"
-CLICKHOUSE_REPO['oracle9']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rocky8']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rocky9']="https://packages.clickhouse.com/rpm/stable"
+CLICKHOUSE_REPO['rocky10']="https://packages.clickhouse.com/rpm/stable"
 CLICKHOUSE_REPO['amzn2']="https://packages.clickhouse.com/rpm/stable"
+
+# Note: compiler packages are fetched via the nms yum/apt repo
+# (configured in /etc/yum.repos.d/nms.repo or /etc/apt/sources.list.d/nms.list)
+# using yum search / apt-cache search, so no separate URL map is needed.
 
 set -o pipefail
 
@@ -265,6 +282,14 @@ debian_install_nim(){
     apt-mark hold clickhouse-server
   fi
 
+  # Ensure rsyslog is installed — Debian 13+ does not include it by default
+  # but nms-instance-manager declares it as a hard dependency.
+  if ! dpkg -l rsyslog 2>/dev/null | grep -q "^ii"; then
+      echo "Installing rsyslog dependency (not present on this system)..."
+      DEBIAN_FRONTEND=noninteractive apt-get update -y
+      DEBIAN_FRONTEND=noninteractive apt-get install -y rsyslog
+  fi
+
   echo "Installing NGINX Instance Manager..."
   DEBIAN_FRONTEND=noninteractive apt-get install -y nms-instance-manager
   check_last_command_status "installing NGINX Instance Manager" $?
@@ -292,6 +317,25 @@ debian_install_nim(){
 
 }
 
+debian_install_compiler(){
+  echo "Installing WAF compiler (nms-nap-compiler)..."
+
+  # Create required directories with correct ownership
+  mkdir -p /etc/nms-nap-compiler
+  mkdir -p /opt/nms-nap-compiler
+  chown -R ${NIM_USER}:${NIM_GROUP} /etc/nms-nap-compiler
+  chown -R ${NIM_USER}:${NIM_GROUP} /opt/nms-nap-compiler
+
+  LATEST_COMPILER_VERSION=$(apt-cache search nms-nap-compiler | awk '{print $1}' | sort -V | tail -1)
+  if [ -z "$LATEST_COMPILER_VERSION" ]; then
+    echo "Warning: No nms-nap-compiler package found. Skipping WAF compiler installation."
+    return
+  fi
+  echo "Installing $LATEST_COMPILER_VERSION..."
+  DEBIAN_FRONTEND=noninteractive apt-get install -y "$LATEST_COMPILER_VERSION"
+  check_last_command_status "apt-get install -y $LATEST_COMPILER_VERSION" $?
+}
+
 installBundleForDebianDistro() {
   # creating nms group and nms user if it isn't already there
   declare DEBIAN_FLAVOUR="debian"
@@ -315,6 +359,9 @@ installBundleForDebianDistro() {
       debian_install_clickhouse
   fi
   debian_install_nim
+  if [[ ${INSTALL_WAF_COMPILER} == "true" ]]; then
+      debian_install_compiler
+  fi
   systemctl restart nms
   sleep 5
   systemctl restart nginx
@@ -330,6 +377,50 @@ check_restorecon(){
     else
         echo "restorecon succeeded for $path"
     fi
+}
+
+rpm_install_compiler(){
+  echo "Installing WAF compiler (nms-nap-compiler)..."
+
+  # Create required directories with correct ownership
+  mkdir -p /etc/nms-nap-compiler
+  mkdir -p /opt/nms-nap-compiler
+  chown -R ${NIM_USER}:${NIM_GROUP} /etc/nms-nap-compiler
+  chown -R ${NIM_USER}:${NIM_GROUP} /opt/nms-nap-compiler
+
+  # For EL8, add CentOS Vault PowerTools repo for dependencies
+  source /etc/os-release 2>/dev/null || true
+  if [[ "${VERSION_ID%%.*}" == "8" && "$ID" =~ ^(rhel|rocky|ol|centos)$ ]]; then
+tee /etc/yum.repos.d/centos-vault-powertools.repo << 'EOF'
+[centos-vault-powertools]
+name=CentOS Vault - PowerTools
+baseurl=https://vault.centos.org/centos/8/PowerTools/x86_64/os/
+enabled=1
+gpgcheck=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
+EOF
+  fi
+
+  # EL10: EPEL + CRB/CodeReady-Builder required for compiler deps
+  if [[ "${VERSION_ID%%.*}" == "10" && "$ID" =~ ^(rhel|rocky|ol|centos)$ ]]; then
+    rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+    if [[ "$ID" == "rocky" ]]; then
+      dnf config-manager --set-enabled crb
+    else
+      dnf config-manager --set-enabled codeready-builder-for-rhel-10-rhui-rpms
+    fi
+  fi
+
+  yum makecache -y
+  LATEST_COMPILER_VERSION=$(yum search nms-nap-compiler --repo=nms 2>/dev/null | grep "nms-nap-compiler-v" | awk '{print $1}' | sort -V | tail -1)
+  if [ -z "$LATEST_COMPILER_VERSION" ]; then
+    echo "Warning: No nms-nap-compiler package found. Skipping WAF compiler installation."
+    return
+  fi
+  echo "Installing $LATEST_COMPILER_VERSION..."
+  yum install -y "$LATEST_COMPILER_VERSION"
+  check_last_command_status "yum install -y $LATEST_COMPILER_VERSION" $?
 }
 
 installBundleForRPMDistro(){
@@ -413,6 +504,11 @@ installBundleForRPMDistro(){
         sudo sed -i 's/centos/amzn2/g' /etc/yum.repos.d/nms.repo
     fi
 
+    # Disable the 'adm' (App Delivery Manager) repo from nms.repo — it does not
+    # publish packages for all OS versions (e.g., RHEL 9, RHEL 10) and causes
+    # metadata download failures (404). Only the 'nms' repo is needed for NIM.
+    sed -i '/^\[adm\]/,/^\[/{s/^enabled[[:space:]]*=[[:space:]]*1/enabled=0/}' /etc/yum.repos.d/nms.repo 2>/dev/null || true
+
     echo "Installing NGINX Instance Manager"
     yum install -y nms-instance-manager
     check_last_command_status "installing nginx-instance-manager(nim)" $?
@@ -449,14 +545,19 @@ installBundleForRPMDistro(){
     check_restorecon /var/lib/nms/modules
     check_restorecon /var/log/nms
 
+    if [[ ${INSTALL_WAF_COMPILER} == "true" ]]; then
+        rpm_install_compiler
+    fi
+
     sleep 5
 }
 
 install_nim_online(){
+  sleep 1
   if cat /etc/*-release | grep -iq 'debian\|ubuntu'; then
     installBundleForDebianDistro
     generate_admin_password
-  elif cat /etc/*-release | grep -iq 'centos\|fedora\|rhel\|Amazon Linux'; then
+  elif cat /etc/*-release | grep -iq 'centos\|fedora\|rhel\|Amazon Linux\|rocky'; then
     installBundleForRPMDistro
     generate_admin_password
   else
@@ -560,11 +661,16 @@ This action deletes all files in the following directories: /etc/nms , /etc/ngin
     check_last_command_status "systemctl stop nginx" $?
     systemctl stop nms nms-core nms-dpm nms-ingestion nms-integrations
     check_last_command_status "systemctl stop nms nms-core nms-dpm nms-ingestion nms-integrations" $?
+    sleep 1
 
     if cat /etc/*-release | grep -iq 'debian\|ubuntu'; then
       apt-get -y remove clickhouse-common-static clickhouse-server clickhouse-client
       apt-get -y remove nms-instance-manager --purge
       check_last_command_status "apt-get remove nms-instance-manager" $?
+      # Remove WAF compiler packages
+      apt -y remove $(dpkg -l | grep "^ii" | grep nms-nap-compiler | awk '{print $2}') 2>/dev/null || true
+      rm -rf /etc/nms-nap-compiler
+      rm -rf /opt/nms-nap-compiler
       apt-get -y remove nginx --purge
       apt-get -y remove nginx-plus --purge
       rm -rf /etc/nginx
@@ -572,16 +678,20 @@ This action deletes all files in the following directories: /etc/nms , /etc/ngin
       rm -rf /var/log/nms
       echo "NGINX Instance Manager Uninstalled successfully"
       exit 0
-    elif cat /etc/*-release | grep -iq 'centos\|fedora\|rhel\|Amazon Linux'; then
+    elif cat /etc/*-release | grep -iq 'centos\|fedora\|rhel\|Amazon Linux\|rocky'; then
       yum -y remove clickhouse-common-static clickhouse-server clickhouse-client
       yum -y remove nms-instance-manager
       check_last_command_status "yum remove nms-instance-manager" $?
+      # Remove WAF compiler packages
+      yum -y remove $(rpm -qa | grep nms-nap-compiler) 2>/dev/null || true
+      rm -rf /etc/nms-nap-compiler
+      rm -rf /opt/nms-nap-compiler
       yum -y remove nginx
       yum -y remove nginx-plus
       rm -rf /etc/nginx
       rm -rf /etc/nms
       rm -rf /var/log/nms
-      yum autoremove
+      yum -y autoremove
       echo "NGINX Instance Manager Uninstalled successfully"
       exit 0
     else
@@ -610,6 +720,189 @@ getLatestPkgVersionFromRepo(){
     fi
   }
 
+package_rpm_compiler_dependencies(){
+  echo "Creating NMS NAP Compiler rpm offline package"
+  source /etc/os-release 2>/dev/null || true
+  if [[ "${VERSION_ID%%.*}" == "8" && "$ID" =~ ^(rhel|rocky|ol|centos)$ ]]; then
+tee /etc/yum.repos.d/centos-vault-powertools.repo << 'EOF'
+[centos-vault-powertools]
+name=CentOS Vault - PowerTools
+baseurl=https://vault.centos.org/centos/8/PowerTools/x86_64/os/
+enabled=1
+gpgcheck=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
+EOF
+  elif [[ "${VERSION_ID%%.*}" =~ ^(9|10)$ && "$ID" =~ ^(rhel|rocky|ol|centos)$ ]]; then
+    echo ""
+  else
+    echo "Skipping NAP compiler packaging as the OS is not supported"
+    return
+  fi
+
+  curl -o /etc/yum.repos.d/nms.repo https://cs.nginx.com/static/files/nms.repo
+
+  # Disable the 'adm' (App Delivery Manager) repo from nms.repo — it does not
+  # publish packages for all OS versions (e.g., RHEL 9, RHEL 10) and causes
+  # metadata download failures (404). Only the 'nms' repo is needed.
+  sed -i '/^\[adm\]/,/^\[/{s/^enabled[[:space:]]*=[[:space:]]*1/enabled=0/}' /etc/yum.repos.d/nms.repo 2>/dev/null || true
+
+  mkdir -p /etc/ssl/nginx/
+  cp "${NGINX_CERT_PATH}" /etc/ssl/nginx/
+  cp "${NGINX_CERT_KEY_PATH}" /etc/ssl/nginx/
+  yum makecache -y
+  if [[ "${VERSION_ID%%.*}" == "10" && "$ID" =~ ^(rhel|rocky|ol|centos)$ ]]; then
+    rpm --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+    if [[ "$ID" == "rocky" ]]; then
+      dnf config-manager --set-enabled crb
+    else
+      dnf config-manager --set-enabled codeready-builder-for-rhel-10-rhui-rpms
+    fi
+  fi
+  sudo yum update -y
+  yum install -y yum-utils
+  mkdir -p nms-nap-compiler
+  LATEST_COMPILER_VERSION=$(yum search nms-nap-compiler --repo=nms 2>/dev/null | grep "nms-nap-compiler-v" | awk '{print $1}' | sort -V | tail -1)
+  if [ -z "$LATEST_COMPILER_VERSION" ]; then
+    echo "Warning: No nms-nap-compiler package found. Skipping WAF compiler packaging."
+    rm -rf nms-nap-compiler
+    return
+  fi
+  echo "Packaging NAP compiler version - $LATEST_COMPILER_VERSION"
+  # Use an empty installroot so dnf downloads the full transitive dependency tree
+  # (including perl, re2, xalan-c, etc.) even if they are already installed on
+  # the packaging machine. Without this, yumdownloader --resolve skips installed
+  # packages, causing missing-dependency errors on clean offline target systems.
+  INSTALLROOT=$(mktemp -d)
+  dnf install -y --downloadonly \
+      --installroot="${INSTALLROOT}" \
+      --releasever="$(rpm -E %rhel)" \
+      --setopt=install_weak_deps=False \
+      --setopt=keepcache=1 \
+      --downloaddir=nms-nap-compiler \
+      "$LATEST_COMPILER_VERSION"
+  rm -rf "${INSTALLROOT}"
+  tar -czf compiler.tar.gz nms-nap-compiler/
+  mv compiler.tar.gz "${TEMP_DIR}/${TARGET_DISTRIBUTION}/"
+  rm -rf nms-nap-compiler
+}
+
+package_deb_compiler_dependencies(){
+  echo "Creating NMS NAP Compiler deb offline package"
+  # detect whether this is Ubuntu or Debian
+  local FLAVOUR
+  if grep -Eiq '^ID=ubuntu' /etc/os-release; then
+    FLAVOUR="ubuntu"
+  elif grep -Eiq '^ID=debian' /etc/os-release; then
+    FLAVOUR="debian"
+  else
+    echo "Error: unsupported Debian-based distribution" >&2
+    return
+  fi
+
+  mkdir -p /etc/ssl/nginx/
+  cp "${NGINX_CERT_PATH}" /etc/ssl/nginx/
+  cp "${NGINX_CERT_KEY_PATH}" /etc/ssl/nginx/
+
+  apt-get install -y gnupg wget
+
+  wget -qO - https://cs.nginx.com/static/keys/nginx_signing.key \
+      | gpg --dearmor \
+      | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+
+  printf "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/nms/%s %s nginx-plus\n" \
+    "${FLAVOUR}" "$(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/nms.list
+
+  wget -q -O /etc/apt/apt.conf.d/90pkgs-nginx https://cs.nginx.com/static/files/90pkgs-nginx
+  local START_DIR
+  START_DIR=$(pwd)
+  mkdir -p nms-nap-compiler && cd nms-nap-compiler || return
+  apt-get -y update
+  LATEST_COMPILER_VERSION=$(apt-cache search nms-nap-compiler | awk '{print $1}' | sort -V | tail -1)
+  if [ -z "$LATEST_COMPILER_VERSION" ]; then
+    echo "Warning: No nms-nap-compiler package found. Skipping WAF compiler packaging."
+    cd "${START_DIR}" || return
+    rm -rf nms-nap-compiler
+    return
+  fi
+  echo "Packaging NAP compiler version - $LATEST_COMPILER_VERSION"
+  apt-get download "$LATEST_COMPILER_VERSION"
+  cd "${START_DIR}" || return
+  mkdir -p nms-nap-compiler/compiler.deps
+  mkdir -p nms-nap-compiler/compiler.deps/partial
+  # Use an empty dpkg status file so apt thinks nothing is installed. This forces
+  # it to emit download URIs for the full dependency tree including Pre-Depends
+  # (e.g., libarchive-tools). Without this, apt skips packages already installed
+  # on the packaging machine, causing dpkg failures on clean offline targets.
+  EMPTY_STATUS=$(mktemp)
+  source /etc/os-release 2>/dev/null || true
+  if [[ "$ID" == "debian" && "${VERSION_ID%%.*}" =~ ^(12|13)$ ]]; then
+    apt-get install --download-only --reinstall --yes \
+      -o Dir::Cache::archives=./nms-nap-compiler/compiler.deps \
+      -o Dir::State::status="${EMPTY_STATUS}" \
+      "$LATEST_COMPILER_VERSION"
+  else
+    apt-get install --download-only --reinstall --yes --print-uris \
+        -o Dir::State::status="${EMPTY_STATUS}" \
+        -o Debug::NoLocking=true \
+        "$LATEST_COMPILER_VERSION" \
+      | grep ^\' | cut -d\' -f2 | xargs -n 1 wget -P ./nms-nap-compiler/compiler.deps
+  fi
+  rm -f "${EMPTY_STATUS}"
+  tar -czf compiler.tar.gz nms-nap-compiler/
+  mv compiler.tar.gz "${TEMP_DIR}/${TARGET_DISTRIBUTION}/"
+  rm -rf nms-nap-compiler
+}
+
+check_for_cross_os_packaging(){
+  # Detect current OS and compare with TARGET_DISTRIBUTION.
+  # NAP compiler dependency resolution only works when packager OS == target OS.
+  local current_os=""
+  sleep 1
+  if cat /etc/*-release | grep -iq 'ubuntu'; then
+    local ubuntu_version
+    ubuntu_version=$(lsb_release -rs 2>/dev/null)
+    case "$ubuntu_version" in
+      "22.04") current_os="${UBUNTU_2204}" ;;
+      "24.04") current_os="${UBUNTU_2404}" ;;
+    esac
+  elif cat /etc/*-release | grep -iq 'debian'; then
+    local debian_version
+    debian_version=$(cut -d'.' -f1 </etc/debian_version 2>/dev/null)
+    case "$debian_version" in
+      "11") current_os="${DEBIAN_11}" ;;
+      "12") current_os="${DEBIAN_12}" ;;
+      "13") current_os="${DEBIAN_13}" ;;
+    esac
+  elif cat /etc/*-release | grep -iq 'rocky'; then
+    local rocky_version
+    rocky_version=$(grep -o 'release [0-9]\+' /etc/*-release | head -1 | awk '{print $2}')
+    case "$rocky_version" in
+      "8")  current_os="${ROCKY_8}" ;;
+      "9")  current_os="${ROCKY_9}" ;;
+      "10") current_os="${ROCKY_10}" ;;
+    esac
+  elif cat /etc/*-release | grep -iq 'oracle'; then
+    local oracle_version
+    oracle_version=$(grep -o 'release [0-9]\+' /etc/*-release | head -1 | awk '{print $2}')
+    case "$oracle_version" in
+      "8") current_os="${ORACLE_8}" ;;
+    esac
+  elif cat /etc/*-release | grep -iq 'rhel\|red hat'; then
+    local rhel_version
+    rhel_version=$(grep -o 'release [0-9]\+' /etc/*-release | head -1 | awk '{print $2}')
+    case "$rhel_version" in
+      "8")  current_os="${REDHAT_8}" ;;
+      "9")  current_os="${REDHAT_9}" ;;
+      "10") current_os="${REDHAT_10}" ;;
+    esac
+  fi
+
+  if [[ -n "${current_os}" && -n "${TARGET_DISTRIBUTION}" && "${current_os}" != "${TARGET_DISTRIBUTION}" ]]; then
+    CROSS_OS_PACKAGING="true"
+  fi
+}
+
 package_nim_offline(){
         if [[ -z ${TARGET_DISTRIBUTION} ]]; then
             echo "Error: target distribution is required when mode set to offline."
@@ -619,7 +912,7 @@ package_nim_offline(){
             echo "Error: The TARGET_DISTRIBUTION ${TARGET_DISTRIBUTION} is not supported in this script... please select one of the following options - ${SUPPORTED_OS[*]}"
             exit 1
         fi
-        if [[ ${RPM_OS[*]} =~ ${TARGET_DISTRIBUTION} || ${CENT_OS[*]} =~ ${TARGET_DISTRIBUTION} ]]; then
+        if [[ ${RPM_OS[*]} =~ ${TARGET_DISTRIBUTION} ]]; then
             PKG_EXTENSION="rpm"
         fi
         if [[ ! -d "${TEMP_DIR}/${TARGET_DISTRIBUTION}" ]]; then
@@ -691,6 +984,21 @@ package_nim_offline(){
         curl -sfLO --cert ${NGINX_CERT_PATH} --key ${NGINX_CERT_KEY_PATH}  "${NIM_REPO[${TARGET_DISTRIBUTION}]}/${NIM_PACKAGE_VERSION}"
         check_last_command_status "curl -sfLO --cert ${NGINX_CERT_PATH} --key ${NGINX_CERT_KEY_PATH}  \"${NIM_REPO[${TARGET_DISTRIBUTION}]}/${NIM_PACKAGE_VERSION}\"" $?
 
+        if [[ "${INSTALL_WAF_COMPILER}" == "true" ]]; then
+            check_for_cross_os_packaging
+            if [[ "${CROSS_OS_PACKAGING}" == "true" ]]; then
+                YELLOW='\033[1;33m'
+                NC='\033[0m'
+                echo -e "\n${YELLOW}WARNING: Cross-OS packaging detected (host != ${TARGET_DISTRIBUTION}). Skipping NAP compiler packaging.${NC}"
+            else
+                if [[ "${PKG_EXTENSION}" == "rpm" ]]; then
+                    package_rpm_compiler_dependencies
+                else
+                    package_deb_compiler_dependencies
+                fi
+            fi
+        fi
+
         NIM_ARCHIVE_FILE_NAME="nim-oss-${TARGET_DISTRIBUTION}.tar.gz"
         if [[ "${USE_NGINX_PLUS}" == "true" ]]; then
           NIM_ARCHIVE_FILE_NAME="nim-plus-${TARGET_DISTRIBUTION}.tar.gz"
@@ -701,9 +1009,17 @@ package_nim_offline(){
         cd "${CWD}" || echo "failed to change directory to ${CWD}"
         tar -zcf "/tmp/${NIM_ARCHIVE_FILE_NAME}" -C "${TEMP_DIR}/${TARGET_DISTRIBUTION}" .
         cp "/tmp/${NIM_ARCHIVE_FILE_NAME}" "${CWD}"
+        if [[ "${INSTALL_WAF_COMPILER}" == "true" && "${CROSS_OS_PACKAGING}" == "true" ]]; then
+          YELLOW='\033[1;33m'
+          NC='\033[0m'
+          echo -e "\n${YELLOW}WARNING: Cross-OS packaging detected!${NC}"
+          echo -e "${YELLOW}Skipped NAP compiler packaging; it won't be installed on the target system.${NC}"
+          echo -e "${YELLOW}For best compatibility, create packages on the same OS as the target deployment environment.${NC}"
+          echo -e "${YELLOW}To install NAP compiler on the target manually, see: https://docs.nginx.com/nginx-instance-manager/nginx-app-protect/setup-waf-config-management/#install-or-update-the-waf-compiler-in-a-disconnected-environment${NC}"
+        fi
         echo -e "\nSuccessfully created the NGINX Instance Manager bundle - ${NIM_ARCHIVE_FILE_NAME}"
         rm -rf "${TEMP_DIR}" || echo "failed to delete the temporary directory ${TEMP_DIR}"
-        curl -s -o /dev/null --cert ${NGINX_CERT_PATH} --key ${NGINX_CERT_KEY_PATH} "https://pkgs.nginx.com/nms/?using_install_script=true&app=nim&mode=offline"
+        curl -s -o /dev/null --connect-timeout 10 --max-time 30 --cert ${NGINX_CERT_PATH} --key ${NGINX_CERT_KEY_PATH} "https://pkgs.nginx.com/nms/?using_install_script=true&app=nim&mode=offline" || echo "Telemetry report skipped (disconnected environment)."
 }
 
 install_nim_offline_from_file(){
@@ -713,8 +1029,10 @@ install_nim_offline_from_file(){
           mkdir -p "${TEMP_DIR}"
         fi
         tar xvf "${INSTALL_PATH}" -C "${TEMP_DIR}"
-        chmod -R 777 "${TEMP_DIR}"
+        # CWE fix: NGINX-nginx-instance-manager-A585B675 — Restrict temp dir permissions to root-only to prevent local package replacement
+        chmod -R 700 "${TEMP_DIR}"
         chown -R "${USER}" "${TEMP_DIR}"
+        sleep 1
         if cat /etc/*-release | grep -iq 'debian\|ubuntu'; then
           for pkg_nginx in "${TEMP_DIR}"/nginx*.deb; do
               echo "Installing nginx from ${pkg_nginx}"
@@ -734,11 +1052,30 @@ install_nim_offline_from_file(){
               done
           fi
 
+          # Ensure rsyslog is installed — Debian 13+ does not include it by default
+          # but nms-instance-manager declares it as a hard dependency.
+          if ! dpkg -l rsyslog 2>/dev/null | grep -q "^ii"; then
+              echo "Installing rsyslog dependency (not present on this system)..."
+              DEBIAN_FRONTEND=noninteractive apt-get update -y
+              DEBIAN_FRONTEND=noninteractive apt-get install -y rsyslog
+          fi
+
           for pkg_nim in "${TEMP_DIR}"/nms-instance-manager*.deb; do
               echo "Installing NGINX Instance Manager from ${pkg_nim}"
               DEBIAN_FRONTEND=noninteractive dpkg -i "$pkg_nim"
               check_last_command_status "dpkg -i \"$pkg_nim\"" $?
           done
+          if [[ "${INSTALL_WAF_COMPILER}" == "true" && -f "${TEMP_DIR}/compiler.tar.gz" ]]; then
+              echo "Installing NAP compiler from ${TEMP_DIR}/compiler.tar.gz"
+              mkdir -p /etc/nms-nap-compiler /opt/nms-nap-compiler
+              chown -R ${NIM_USER}:${NIM_GROUP} /etc/nms-nap-compiler /opt/nms-nap-compiler
+              tar -xzf "${TEMP_DIR}/compiler.tar.gz" -C "${TEMP_DIR}"
+              if compgen -G "${TEMP_DIR}/nms-nap-compiler/compiler.deps/*.deb" > /dev/null; then
+                  DEBIAN_FRONTEND=noninteractive dpkg -i "${TEMP_DIR}"/nms-nap-compiler/compiler.deps/*.deb || true
+              fi
+              DEBIAN_FRONTEND=noninteractive dpkg -i "${TEMP_DIR}"/nms-nap-compiler/nms-nap-compiler*.deb
+              check_last_command_status "dpkg -i nms-nap-compiler*.deb" $?
+          fi
           generate_admin_password
           if [[ ${SKIP_CLICKHOUSE_INSTALL} == "false" ]]; then
               echo "Starting clickhouse-server"
@@ -751,26 +1088,45 @@ install_nim_offline_from_file(){
           systemctl restart nginx || journalctl -xeu nginx
           check_nim_dashboard_status
 
-        elif cat /etc/*-release | grep -iq 'centos\|fedora\|rhel\|Amazon Linux'; then
-          yum update -y
+        elif cat /etc/*-release | grep -iq 'centos\|fedora\|rhel\|Amazon Linux\|rocky'; then
+          echo "Skipping 'yum update' for offline installation on disconnected system."
           for pkg_nginx in "${TEMP_DIR}"/nginx*.rpm; do
             echo "Installing nginx from ${pkg_nginx}"
-            yum localinstall -y -v --disableplugin=subscription-manager --skip-broken "$pkg_nginx"
+            yum localinstall -y -v --disableplugin=subscription-manager --disablerepo="*" --skip-broken "$pkg_nginx"
           done
           if [[ ${SKIP_CLICKHOUSE_INSTALL} == "false" ]]; then
               for pkg_clickhouse in "${TEMP_DIR}"/clickhouse-common*.rpm; do
                 echo "Installing clickhouse dependencies from ${pkg_clickhouse}"
-                yum localinstall -y -v --disableplugin=subscription-manager --skip-broken "$pkg_clickhouse"
+                yum localinstall -y -v --disableplugin=subscription-manager --disablerepo="*" --skip-broken "$pkg_clickhouse"
               done
               for pkg_clickhouse_srv in "${TEMP_DIR}"/clickhouse-server*.rpm; do
-                echo "Installing clickhouse dependencies from ${pkg_clickhouse}"
-                yum localinstall -y -v --disableplugin=subscription-manager --skip-broken "$pkg_clickhouse_srv"
+                echo "Installing clickhouse-server from ${pkg_clickhouse_srv}"
+                yum localinstall -y -v --disableplugin=subscription-manager --disablerepo="*" --skip-broken "$pkg_clickhouse_srv"
               done
           fi
           for pkg_nim in "${TEMP_DIR}"/nms-instance-manager*.rpm; do
             echo "Installing NGINX Instance Manager from ${pkg_nim}"
-            yum localinstall -y -v --disableplugin=subscription-manager --skip-broken "$pkg_nim"
+            yum localinstall -y -v --disableplugin=subscription-manager --disablerepo="*" --skip-broken "$pkg_nim"
           done
+
+          if [[ "${INSTALL_WAF_COMPILER}" == "true" && -f "${TEMP_DIR}/compiler.tar.gz" ]]; then
+              echo "Installing NAP compiler from ${TEMP_DIR}/compiler.tar.gz"
+              mkdir -p /etc/nms-nap-compiler /opt/nms-nap-compiler
+              chown -R ${NIM_USER}:${NIM_GROUP} /etc/nms-nap-compiler /opt/nms-nap-compiler
+              tar -xzf "${TEMP_DIR}/compiler.tar.gz" -C "${TEMP_DIR}"
+              # Collect RPMs into an array with nullglob so a missing *.rpm does
+              # not pass the literal string to yum (which produces a confusing
+              # "Could not open: *.rpm" error).
+              shopt -s nullglob
+              compiler_rpms=("${TEMP_DIR}"/nms-nap-compiler/*.rpm)
+              shopt -u nullglob
+              if [ ${#compiler_rpms[@]} -eq 0 ]; then
+                  echo "Error: no RPMs found in compiler bundle at ${TEMP_DIR}/nms-nap-compiler/"
+                  exit 1
+              fi
+              sudo yum localinstall -y --disablerepo=* "${compiler_rpms[@]}"
+              check_last_command_status "yum localinstall nms-nap-compiler" $?
+          fi
 
           generate_admin_password
           if [[ ${SKIP_CLICKHOUSE_INSTALL} == "false" ]]; then
@@ -798,7 +1154,7 @@ install_nim_offline_from_file(){
         sudo rm -rf /etc/nms/certs/*
         sudo bash /etc/nms/scripts/certs.sh 0 ${NIM_FQDN}
       fi
-      curl -s -o /dev/null --cert ${NGINX_CERT_PATH} --key ${NGINX_CERT_KEY_PATH} "https://pkgs.nginx.com/nms/?using_install_script=true&app=nim&mode=offline"
+      curl -s -o /dev/null --connect-timeout 10 --max-time 30 --cert ${NGINX_CERT_PATH} --key ${NGINX_CERT_KEY_PATH} "https://pkgs.nginx.com/nms/?using_install_script=true&app=nim&mode=offline" || echo "Telemetry report skipped (disconnected environment)."
 }
 
 confirm_action() {
@@ -818,7 +1174,7 @@ printUsageInfo(){
   printf "\n  -a  arch(amd64/arm64) for the offline packages to download. Valid only when mode is set to offline \n"
   printf "\n  -c  /path/to/your/<nginx-repo.crt> file.\n"
   printf "\n  -d  <distribution>. Include the label of a distribution. Requires -m Offline. This creates a file with NGINX Instance Manager dependencies and NGINX Instance Manager install packages for the specified distribution"
-  printf "\n      [ubuntu20.04,ubuntu22.04,ubuntu24.04,debian11,debian12,centos8,rhel8,rhel9,oracle8,oracle9]\n"
+  printf "\n      [ubuntu22.04,ubuntu24.04,debian11,debian12,debian13,rhel8,rhel9,rhel10,oracle8,rocky8,rocky9,rocky10]\n"
   printf "\n  -f  <NIM_FQDN> use to specify the fully qualified domain name to use for generating nim certificates.\n"
   printf "\n  -h  Print this help message.\n"
   printf "\n  -i  <installable_tar_file_path>. Include the path with an archive file to support NGINX Instance Manager installation. Requires -m Offline.\n"
@@ -830,26 +1186,29 @@ printUsageInfo(){
   printf "\n  -r  To uninstall NGINX Instance Manager and its dependencies. \n"
   printf "\n  -s  Skip packaging/installing clickhouse packages. \n"
   printf "\n  -v  clickhouse version to install/package. \n"
+  printf "\n  -w  Install WAF compiler (nms-nap-compiler) for App Protect policy compilation. \n"
   printf "\n  -y  Install Nginx Instance Manager if all the requirements are passed. \n"
   exit 0
 }
 
 printSupportedOS(){
   printf "This script can be run on the following operating systems"
-  printf "\n  1. ubuntu20.04(focal)"
-  printf "\n  2. ubuntu22.04(jammy)"
-  printf "\n  3. ubuntu24.04(noble)"
-  printf "\n  4. debian11(bullseye)"
-  printf "\n  5. debian12(bookworm)"
-  printf "\n  6. centos8(CentOS 8)"
-  printf "\n  7. rhel8(Redhat Enterprise Linux Version 8)"
-  printf "\n  8. rhel9(Redhat Enterprise Linux Version 9)"
+  printf "\n  1. ubuntu22.04(jammy)"
+  printf "\n  2. ubuntu24.04(noble)"
+  printf "\n  3. debian11(bullseye)"
+  printf "\n  4. debian12(bookworm)"
+  printf "\n  5. debian13(trixie)"
+  printf "\n  6. rhel8(Redhat Enterprise Linux Version 8)"
+  printf "\n  7. rhel9(Redhat Enterprise Linux Version 9)"
+  printf "\n  8. rhel10(Redhat Enterprise Linux Version 10)"
   printf "\n  9. oracle8(Oracle Linux Version 8)"
-  printf "\n  10. oracle9(Oracle Linux Version 9)\n"
+  printf "\n  10. rocky8(Rocky Linux Version 8)"
+  printf "\n  11. rocky9(Rocky Linux Version 9)"
+  printf "\n  12. rocky10(Rocky Linux Version 10)\n"
   exit 0
 }
 
-OPTS_STRING="a:c:d:f:hi:j:k:lm:prsv:y"
+OPTS_STRING="a:c:d:f:hi:j:k:lm:prsv:wy"
 
 while getopts ${OPTS_STRING} opt; do
   case ${opt} in
@@ -917,6 +1276,9 @@ while getopts ${OPTS_STRING} opt; do
     v)
       CLICKHOUSE_VERSION=${OPTARG}
       ;;
+    w)
+      INSTALL_WAF_COMPILER="true"
+      ;;
     y)
       ;;
     :)
@@ -941,10 +1303,10 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-validate_nim_installation
 validate_nginx_paths
 
 if [ "${MODE}" == "online" ]; then
+  validate_nim_installation
   install_nim_online
   check_nim_dashboard_status
 else


### PR DESCRIPTION
### Proposed changes
Changes w.r.t NIM patch release 2.22.2 and WAF compiler 5.13.4

-- NIM version bumped up to 2.22.2
-- Support for NGINX-OSS 1.31.3
-- WAF compiler bumped up to 5.13.4

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
