### PR TITLE
chore: update nic 5.5.2 changelog past cve disclosure

### DIFF
--- a/content/nic/changelog/_index.md
+++ b/content/nic/changelog/_index.md
@@ -69,6 +69,13 @@ We provide technical support for NGINX Ingress Controller on any Kubernetes plat
 
 15 Jul 2026
 
+- Security fix: in the VirtualServer CRD the `Action.Return.Headers` field had improper validation. A carefully crafted value was rendered in the template as-is, leading to injection attacks [CVE-2026-55723](https://my.f5.com/manage/s/article/K000161837)
+- Security fix: `nginx.com/jwt-login-url` annotation had improper validation and sanitization. A carefully crafted value was rendered in the template as-is, leading to injection attacks [CVE-2026-55723](https://my.f5.com/manage/s/article/K000161837)
+- Security fix: `logDest` field on `WAF` policy, and the `appprotect.f5.com/app-protect-security-log-destination` Ingress annotation had improper validation. A carefully crafted value was rendered in the template as-is, leading to injection attacks. [CVE-2026-55723](https://my.f5.com/manage/s/article/K000161837)
+- Security fix: In the `DosProtectedResource` CRD the `.spec.apDosMonitor.uri` field had improver validation. A carefully crafted value was rendered in the template as-is, leading to injection attacks. [CVE-2026-55723](https://my.f5.com/manage/s/article/K000161837)
+- Security fix: an Ingress with a resource backend with the `acme.cert-manager.io/http01-solver: "true"` label would cause NGINX Ingress Controller to go into a crash loop due to insufficient code path validation [CVE-2026-52865](https://my.f5.com/manage/s/article/K000161837)
+- Security fix: an empty `tls` block in the TransportServer CRD caused NGINX Ingress Controller to enter a crash loop due to insufficient code path validation. [CVE-2026-52865](https://my.f5.com/manage/s/article/K000161837)
+
 ### {{% icon bug %}} Fixes
 
 - [10323](https://github.com/nginx/kubernetes-ingress/pull/10323) Fix external auth attachment to multiple ingresses


### PR DESCRIPTION
### Proposed changes

After the disclosure, the details of security fixes are added. Could not do it when 5.5.2 was released.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
