### PR TITLE
Update USP docs to match change to default keepalive

### DIFF
--- a/content/ngf/traffic-management/upstream-settings.md
+++ b/content/ngf/traffic-management/upstream-settings.md
@@ -344,14 +344,12 @@ upstream default_coffee_80 {
     random two least_conn;
     zone default_coffee_80 1m;
     state /var/lib/nginx/state/default_coffee_80.conf;
-    keepAlive 16;
 }
 
 upstream default_tea_80 {
     hash $upstream_addr consistent;
     zone default_tea_80 1m;
     state /var/lib/nginx/state/default_tea_80.conf;
-    keepAlive 16;
 }
 ```
 
@@ -425,7 +423,6 @@ upstream default_coffee_80 {
     zone default_coffee_80 1m;
 
     server 10.244.0.14:8080;
-    keepAlive 16;
 }
 
 upstream default_tea_80 {
@@ -433,13 +430,10 @@ upstream default_tea_80 {
     zone default_tea_80 1m;
 
     server 10.244.0.15:8080;
-    keepAlive 16;
 }
 ```
 
 ## Enable keepalive connections
-
-By default, the `keepAlive` directive is enabled with a value of 16. You can override this value or disable `keepAlive` entirely by configuring an `UpstreamSettingsPolicy`. To disable keepalive, set the connections field to 0.
 
 The following example creates an `UpstreamSettingsPolicy` that configures keepalive connections for the `coffee` Service with a value of 32:
 
@@ -460,6 +454,8 @@ EOF
 ```
 
 This `UpstreamSettingsPolicy` targets the `coffee` service in the `targetRefs` field. It sets the number of keepalive connections to 32, which activates the cache for connections to the service's pods and sets the maximum number of idle connections to 32.
+
+If `keepAlive.connections` is omitted, the NGINX default value for the `keepalive` directive is used. To disable keepalive, set `keepAlive.connections` to 0.
 
 Verify that the `UpstreamSettingsPolicy` is Accepted:
 
@@ -506,7 +502,7 @@ upstream default_coffee_80 {
 }
 ```
 
-To disable `keepAlive` directive lets create an `UpstreamSettingsPolicy` targeting the `tea` service with value 0:
+To disable the `keepalive` directive, lets create an `UpstreamSettingsPolicy` targeting the `tea` service with value 0:
 
 ```yaml
 kubectl apply -f - <<EOF
@@ -562,6 +558,7 @@ upstream default_tea_80 {
     zone default_tea_80 1m;
 
     server 10.244.0.15:8080;
+    keepalive 0;
 }
 ```
 


### PR DESCRIPTION
### Proposed changes

This PR updates the default keepalive connections value for the Upstream Settings Policy API, to match recent changes. The change removes the outdated default previously used and updates the configuration examples to reflect the new changes. 

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
