### PR TITLE
NGF: document TLS session and ECDH listener options

### DIFF
--- a/content/ngf/overview/gateway-api-compatibility.md
+++ b/content/ngf/overview/gateway-api-compatibility.md
@@ -97,7 +97,7 @@ See the [controller]({{< ref "/ngf/reference/cli-help.md#controller">}}) command
     - `tls`
       - `mode`: Supported.
       - `certificateRefs` - The TLS certificate and key must be stored in a Secret resource of type `kubernetes.io/tls`.
-      - `options`: The options `nginx.org/ssl-protocols`, `nginx.org/ssl-ciphers` and `nginx.org/ssl-prefer-server-ciphers` are supported. See [ngx_http_ssl_module](https://nginx.org/en/docs/http/ngx_http_ssl_module.html) for more information.
+      - `options`: The options `nginx.org/ssl-protocols`, `nginx.org/ssl-ciphers`, `nginx.org/ssl-prefer-server-ciphers`, `nginx.org/ssl-session-cache`, `nginx.org/ssl-session-timeout` and `nginx.org/ssl-ecdh-curve` are supported. See [ngx_http_ssl_module](https://nginx.org/en/docs/http/ngx_http_ssl_module.html) for more information.
     - `allowedRoutes`: Supported.
   - `addresses`: Valid IPAddresses will be added to the `externalIP` field in the related Services fronting NGINX. Users should ensure that the IP Family of the address matches the IP Family set in the NginxProxy resource (default is dual, meaning both IPv4 and IPv6), otherwise there may be networking issues.
       - `type`: Partially supported. Allowed value: `IPAddress`.
@@ -415,7 +415,7 @@ Fields:
     - `tls`
       - `mode`: Supported.
       - `certificateRefs` - The TLS certificate and key must be stored in a Secret resource of type `kubernetes.io/tls`.
-      - `options`: The options `nginx.org/ssl-protocols`, `nginx.org/ssl-ciphers` and `nginx.org/ssl-prefer-server-ciphers` are supported. See [ngx_http_ssl_module](https://nginx.org/en/docs/http/ngx_http_ssl_module.html) for more information.
+      - `options`: The options `nginx.org/ssl-protocols`, `nginx.org/ssl-ciphers`, `nginx.org/ssl-prefer-server-ciphers`, `nginx.org/ssl-session-cache`, `nginx.org/ssl-session-timeout` and `nginx.org/ssl-ecdh-curve` are supported. See [ngx_http_ssl_module](https://nginx.org/en/docs/http/ngx_http_ssl_module.html) for more information.
     - `allowedRoutes`: Supported.
 - `status`
   - `conditions`: Supported (Condition/Status/Reason):


### PR DESCRIPTION
### Proposed changes

Documents three additional Listener TLS options supported by NGINX Gateway Fabric:

- `nginx.org/ssl-session-cache` (`ssl_session_cache`)
- `nginx.org/ssl-session-timeout` (`ssl_session_timeout`)
- `nginx.org/ssl-ecdh-curve` (`ssl_ecdh_curve`)

These are added to the `spec.listeners.tls.options` list in both the Gateway and ListenerSet sections of the Gateway API Compatibility page, alongside the existing `nginx.org/ssl-protocols`, `nginx.org/ssl-ciphers`, and `nginx.org/ssl-prefer-server-ciphers` options.

This documents the feature added in nginx/nginx-gateway-fabric#5534 (closes nginx/nginx-gateway-fabric#5485).

### Checklist

- [x] I have read the contributing guidelines
- [x] My changes are limited to the documentation content
