### PR TITLE
Update USP docs under keepalive connections for better readability

### DIFF
--- a/content/ngf/traffic-management/upstream-settings.md
+++ b/content/ngf/traffic-management/upstream-settings.md
@@ -435,6 +435,8 @@ upstream default_tea_80 {
 
 ## Enable keepalive connections
 
+By default, the `keepalive` directive is omitted, which results in the default NGINX `keepalive` value being used. You can override this value or disable `keepAlive` entirely by configuring an UpstreamSettingsPolicy. To disable keepalive, set the connections field to 0.
+
 The following example creates an `UpstreamSettingsPolicy` that configures keepalive connections for the `coffee` Service with a value of 32:
 
 ```yaml
@@ -455,7 +457,6 @@ EOF
 
 This `UpstreamSettingsPolicy` targets the `coffee` service in the `targetRefs` field. It sets the number of keepalive connections to 32, which activates the cache for connections to the service's pods and sets the maximum number of idle connections to 32.
 
-If `keepAlive.connections` is omitted, the NGINX default value for the `keepalive` directive is used. To disable keepalive, set `keepAlive.connections` to 0.
 
 Verify that the `UpstreamSettingsPolicy` is Accepted:
 

--- a/content/ngf/traffic-management/upstream-settings.md
+++ b/content/ngf/traffic-management/upstream-settings.md
@@ -437,7 +437,7 @@ upstream default_tea_80 {
 
 By default, the `keepalive` directive is omitted, which results in the default NGINX `keepalive` value being used. You can override this value or disable `keepAlive` entirely by configuring an UpstreamSettingsPolicy. To disable keepalive, set the connections field to 0.
 
-The following example creates an `UpstreamSettingsPolicy` that configures keepalive connections for the `coffee` Service with a value of 32:
+The following example creates an `UpstreamSettingsPolicy` that configures keepalive connections for the `coffee` Service with a value of 24:
 
 ```yaml
 kubectl apply -f - <<EOF
@@ -451,11 +451,11 @@ spec:
     kind: Service
     name: coffee
   keepAlive:
-    connections: 32
+    connections: 24
 EOF
 ```
 
-This `UpstreamSettingsPolicy` targets the `coffee` service in the `targetRefs` field. It sets the number of keepalive connections to 32, which activates the cache for connections to the service's pods and sets the maximum number of idle connections to 32.
+This `UpstreamSettingsPolicy` targets the `coffee` service in the `targetRefs` field. It sets the number of keepalive connections to 24, which activates the cache for connections to the service's pods and sets the maximum number of idle connections to 24.
 
 
 Verify that the `UpstreamSettingsPolicy` is Accepted:
@@ -491,7 +491,7 @@ Next, verify that the policy has been applied to the `coffee` upstreams, by insp
 kubectl exec -it deployments/gateway-nginx -- nginx -T
 ```
 
-You should see that the `coffee` upstream has the `keepalive` directive set to 32:
+You should see that the `coffee` upstream has the `keepalive` directive set to 24:
 
 ```text
 upstream default_coffee_80 {
@@ -499,7 +499,7 @@ upstream default_coffee_80 {
     zone default_coffee_80 1m;
 
     server 10.244.0.14:8080;
-    keepalive 32;
+    keepalive 24;
 }
 ```
 


### PR DESCRIPTION
### Proposed changes

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

This PR updates the `Enable keepalive connections`  section of the Upstream Settings Policy API to improve the readability for users. The change re-orders where the default value for the  `keepalive` directive is mentioned so that users do not have to switch context as much, to align with a suggestion from the team: https://github.com/nginx/documentation/pull/2160#discussion_r3638233562 

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
