### PR TITLE
build: add Netskope CA to local Hugo image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!.dockerignore
+!Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG HUGO_VERSION=0.152.2
+FROM ghcr.io/gohugoio/hugo:v${HUGO_VERSION}
+
+# Docker build containers do not inherit the host's trusted CA certificates.
+# Install F5's Netskope TLS-inspection CA before downloading Hugo modules.
+ARG NETSKOPE_CA_URL=https://cdn.f5.com/apps/netskope/f5-netskope-bundle.pem
+ARG NETSKOPE_CA_SHA256=ae8a2b0668e3b508fa2f1b4d8c98d5bd367fef58c9fd7357aaa47e6312ad6a22
+
+USER root
+RUN set -eu; \
+    wget -qO /tmp/netskope-ca.pem "${NETSKOPE_CA_URL}"; \
+    echo "${NETSKOPE_CA_SHA256}  /tmp/netskope-ca.pem" | sha256sum -c -; \
+    awk '/-----BEGIN CERTIFICATE-----/{n++} n { print > ("/usr/local/share/ca-certificates/f5-netskope-" n ".crt") }' \
+        /tmp/netskope-ca.pem; \
+    rm /tmp/netskope-ca.pem; \
+    update-ca-certificates
+
+USER hugo
+
+EXPOSE 1313
+CMD ["server", "--bind", "0.0.0.0", "--port", "1313", "--disableFastRender"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 HUGO?=hugo
 HUGO_VERSION?=$(shell hugo version 2>/dev/null | awk '{print $$2}' | cut -d '.' -f 2)
-HUGO_IMG?=hugomods/hugo:std-go-git-0.152.2
+HUGO_IMG?=nginx-documentation-hugo:local
+HUGO_DOCKERFILE?=Dockerfile
 
 THEME_MODULE = github.com/nginxinc/nginx-hugo-theme/v2
 
@@ -8,7 +9,8 @@ ifeq ($(shell [ $(HUGO_VERSION) -gt 146 2>/dev/null ] && echo true || echo false
     $(info Hugo is available and has a version greater than 146. Proceeding with build.)
 else
     $(warning Hugo is not available or using a version less than 151. Attempting to use docker. HUGO_VERSION=$(HUGO_VERSION))
-    HUGO=docker run --rm -it -v ${CURDIR}:/src -p 1313:1313 ${HUGO_IMG} /src/hugo-entrypoint.sh
+    HUGO=docker run --rm -it -v ${CURDIR}:/project --workdir /project -p 1313:1313 --entrypoint hugo ${HUGO_IMG}
+    DOCKER_HUGO_TARGETS=docs watch drafts
     ifeq (, $(shell docker version 2> /dev/null))
         $(error Hugo (>0.151) or Docker are required to build the local previews.)
     endif
@@ -35,7 +37,14 @@ endif
 endif
 
 
-.PHONY: docs docs-draft docs-local clean hugo-get hugo-tidy lint-markdown link-check
+.PHONY: docs docs-draft docs-local clean hugo-get hugo-tidy lint-markdown link-check docker-hugo-image
+
+ifdef DOCKER_HUGO_TARGETS
+$(DOCKER_HUGO_TARGETS): docker-hugo-image
+
+docker-hugo-image:
+	docker build --tag ${HUGO_IMG} --file ${HUGO_DOCKERFILE} .
+endif
 
 docs:
 	${HUGO}


### PR DESCRIPTION
### Proposed changes

Replace the removed hugomods Hugo image with a custom image built from ghcr.io/gohugoio/hugo. The custom image installs the Netskope CA bundle for local Docker-based Hugo builds.

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
