### PR TITLE
Edits the by Tech Writer Agent following the F5 Technical Writing Sty…

### DIFF
--- a/content/nic/install/plm-installation.md
+++ b/content/nic/install/plm-installation.md
@@ -11,45 +11,39 @@ f5-description: >
 f5-audience: operator
 ---
 
-This guide installs F5 NGINX Ingress Controller (NIC) with F5 WAF for NGINX
-using Policy Lifecycle Management (PLM). PLM defines WAF policies as
-Kubernetes custom resources, compiles them automatically, and stores the
-compiled bundles in an in-cluster S3-compatible object store. NIC fetches the
-bundles from PLM storage and enforces the policies at request time.
+Use this guide to install F5 NGINX Ingress Controller with F5 WAF for NGINX using Policy Lifecycle Management (PLM). PLM defines WAF policies as Kubernetes custom resources, compiles them automatically, and stores the compiled bundles in an in-cluster S3-compatible object store. NGINX Ingress Controller then fetches the bundles from PLM storage and enforces the policies at request time.
 
-By the end of this tutorial you will have:
+By the end of this tutorial, you'll have:
 
-- A running PLM backend and a NIC deployment configured for PLM storage.
+- A running PLM backend and NGINX Ingress Controller deployment configured for PLM storage.
 - An `APPolicy` and an `APLogConf` resource compiled by PLM.
 - A `k8s.nginx.org/v1` Policy that references the compiled resources.
-- The Policy attached to either a VirtualServer or an Ingress, with traffic
-  flowing normally and attack payloads blocked.
+- The Policy attached to a VirtualServer or an Ingress, with traffic flowing normally and attack payloads blocked.
 
 ## Before you begin
 
-- You have `kubectl` access to a Kubernetes cluster.
-- You have Helm.
-- You have credentials for `private-registry.nginx.com`.
+Before you start, make sure you have:
 
-This tutorial uses the following example values. If you use different values,
-substitute them consistently throughout.
+- `kubectl` access to a Kubernetes cluster.
+- Helm installed.
+- Credentials for `private-registry.nginx.com`.
+
+This tutorial uses the following example values. If you use different values, replace them consistently throughout.
 
 | Example value | What it represents |
 |---|---|
 | `plm-system` | Namespace for the PLM backend |
 | `plm` | Helm release name for PLM |
-| `nginx-ingress` | Namespace for NIC |
-| `nic` | Helm release name for NIC |
+| `nginx-ingress` | Namespace for NGINX Ingress Controller |
+| `nic` | Helm release name for NGINX Ingress Controller |
 | `security` | Namespace for `APPolicy` and `APLogConf` resources |
-| `default` | Namespace for the NIC Policy, sample application, and routing resource |
+| `default` | Namespace for the Policy, sample application, and routing resource |
 | `webapp.example.com` | Example hostname for VirtualServer routing |
 | `cafe.example.com` | Example hostname for Ingress routing |
 
 ## Deploy PLM infrastructure
 
-Install the PLM backend before you install NIC. It provisions the App
-Protect v1 CRDs, the Policy Controller, the compiler service, and the
-SeaweedFS storage backend in the `plm-system` namespace.
+Install the PLM backend before installing NGINX Ingress Controller. The PLM backend provisions the App Protect v1 CRDs, the Policy Controller, the compiler service, and the SeaweedFS storage backend in the `plm-system` namespace.
 
 {{< include "waf/plm-deploy-infrastructure.md" >}}
 
@@ -70,16 +64,12 @@ apusersigs.appprotect.f5.com
 
 ## Look up the PLM storage endpoint and credentials
 
-NIC connects to PLM's SeaweedFS filer over S3 to fetch compiled bundles.
-Before you install NIC, collect four values that the PLM install produced:
+NGINX Ingress Controller connects to PLM's SeaweedFS filer over S3 to fetch compiled bundles. Before you install the controller, collect these four values from the PLM installation:
 
 1. **PLM storage URL**: the SeaweedFS filer endpoint (HTTPS or HTTP).
-2. **Credentials Secret**: the S3 credentials Secret. The access key ID is
-   `admin` by default; the secret access key is stored in the
-   `seaweedfs_admin_secret` field.
+2. **Credentials Secret**: the S3 credentials Secret. The access key ID is `admin` by default. The secret access key is in the `seaweedfs_admin_secret` field.
 3. **CA Secret** (HTTPS only): verifies the SeaweedFS filer certificate.
-4. **Client TLS Secret** (mutual TLS only): presented by NIC when it
-   connects to the filer.
+4. **Client TLS Secret** (mutual TLS only): presented by NGINX Ingress Controller when it connects to the filer.
 
 List the Services PLM created and identify the filer:
 
@@ -94,8 +84,7 @@ NAME                       TYPE        CLUSTER-IP   PORT(S)
 plm-f5-waf-seaweed-filer   ClusterIP   10.0.0.10    8333/TCP,9333/TCP,...
 ```
 
-Assemble the URL from the service name, namespace, and port. Use `9333`
-for HTTPS and `8333` for HTTP:
+Assemble the URL from the service name, namespace, and port. Use `9333` for HTTPS and `8333` for HTTP:
 
 - HTTPS (mTLS): `https://plm-f5-waf-seaweed-filer.plm-system.svc.cluster.local:9333`
 - HTTP: `http://plm-f5-waf-seaweed-filer.plm-system.svc.cluster.local:8333`
@@ -106,30 +95,23 @@ List the Secrets PLM created:
 kubectl get secret --namespace plm-system
 ```
 
-The default PLM install creates three Secrets that NIC references:
+The default PLM install creates three Secrets that NGINX Ingress Controller references:
 
 - `plm-f5-waf-seaweedfs-auth`: SeaweedFS credentials.
 - `plm-f5-waf-seaweedfs-ca-cert`: CA certificate for the HTTPS filer.
 - `plm-f5-waf-seaweedfs-client-cert`: client TLS certificate for mTLS.
 
-Record the Secret references in `<namespace>/<name>` form. You'll pass all
-four values to NIC as `--set controller.appprotect.plmStorage.*` flags
+Record the Secret references in `<namespace>/<name>` form. You'll pass all four values to NGINX Ingress Controller using `--set controller.appprotect.plmStorage.*` flags.
 
-## Install NIC with PLM storage
+## Install NGINX Ingress Controller with PLM storage
 
-Because PLM owns the `appprotect.f5.com/v1` CRDs, install NIC with
-`--skip-crds`. You apply NIC's own CRDs from the bundled manifest first.
-
-Apply the NIC CRDs. The `deploy/crds.yaml` bundle contains every CRD NIC
-needs (`VirtualServer`, `VirtualServerRoute`, `Policy`, `TransportServer`,
-`GlobalConfiguration`, `DNSEndpoint`) and deliberately excludes the App
-Protect CRDs, which PLM owns.
+Because PLM owns the `appprotect.f5.com/v1` CRDs, you must apply the controller's own CRDs before running `helm install`. The `deploy/crds.yaml` bundle contains every CRD the controller needs (`VirtualServer`, `VirtualServerRoute`, `Policy`, `TransportServer`, `GlobalConfiguration`, `DNSEndpoint`). The bundle deliberately excludes the App Protect CRDs, which PLM owns.
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v{{< nic-version >}}/deploy/crds.yaml
 ```
 
-Create a namespace and image pull Secret for NIC:
+Create a namespace and image pull Secret for NGINX Ingress Controller:
 
 ```shell
 kubectl create namespace nginx-ingress
@@ -147,8 +129,7 @@ helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo update nginx-stable
 ```
 
-Install NIC with PLM storage enabled. This example uses HTTPS PLM storage with mutual TLS. 
-For HTTP storage, set `controller.appprotect.plmStorage.url` and `controller.appprotect.plmStorage.credentialsSecret` only.
+Install NGINX Ingress Controller with PLM storage turned on. This example uses HTTPS with mutual TLS. For HTTP storage, set only `controller.appprotect.plmStorage.url` and `controller.appprotect.plmStorage.credentialsSecret`.
 
 ```shell
 helm install nic nginx-stable/nginx-ingress \
@@ -167,8 +148,7 @@ helm install nic nginx-stable/nginx-ingress \
   --set controller.serviceAccount.imagePullSecretName=regcred
 ```
 
-Wait for the NIC Pod to become ready. Each Pod runs three containers:
-`nginx-ingress`, `waf-enforcer`, and `waf-config-mgr`.
+Wait for the controller pod to become ready. Each pod runs three containers: `nginx-ingress`, `waf-enforcer`, and `waf-config-mgr`.
 
 ```shell
 kubectl wait --for=condition=Ready pods \
@@ -186,8 +166,7 @@ NAME                             READY   STATUS    RESTARTS   AGE
 nic-nginx-ingress-controller-xxxxx  3/3     Running   0          2m
 ```
 
-Save the public IP address and HTTP port of the NIC LoadBalancer service into
-shell variables:
+Save the public IP address and HTTP port of the NGINX Ingress Controller LoadBalancer service to shell variables:
 
 ```shell
 IC_IP=<public IP address>
@@ -196,16 +175,13 @@ IC_HTTP_PORT=<port number>
 
 ## Define the WAF policy
 
-Create the `security` namespace to hold the `APPolicy` and `APLogConf`
-resources:
+Create the `security` namespace to hold the `APPolicy` and `APLogConf` resources:
 
 ```shell
 kubectl create namespace security
 ```
 
-Save the following as `waf-resources.yaml`. It defines an `APPolicy` that
-blocks attack signatures and masks credit card numbers and social security
-numbers in responses, plus an `APLogConf` for security logging.
+Save the following as `waf-resources.yaml`. The file defines an `APPolicy` that blocks attack signatures and masks credit card numbers and social security numbers in responses. It also defines an `APLogConf` for security logging.
 
 ```yaml
 apiVersion: appprotect.f5.com/v1
@@ -268,11 +244,9 @@ kubectl get appolicy dataguard-blocking --namespace security \
   --output jsonpath='State: {.status.bundle.state}{"\n"}Location: {.status.bundle.location}{"\n"}'
 ```
 
-## Create the NIC Policy
+## Create the Policy
 
-Save the following as `waf-policy.yaml`. The `apPolicy` and `apLogConf`
-fields accept `[<namespace>/]<name>`. When namespace is omitted, NIC
-defaults to the Policy's own namespace.
+Save the following as `waf-policy.yaml`. The `apPolicy` and `apLogConf` fields accept `[<namespace>/]<name>`. When you omit the namespace, NGINX Ingress Controller defaults to the Policy's own namespace.
 
 ```yaml
 apiVersion: k8s.nginx.org/v1
@@ -303,17 +277,17 @@ kubectl wait --for=jsonpath='{.status.state}'=Valid \
   policy/waf-policy --namespace default --timeout=180s
 ```
 
-If the Policy stays in `Warning` with a `BundleFetchFailed` reason, see
-[Troubleshooting](#troubleshooting).
+If the Policy stays in `Warning` with a `BundleFetchFailed` reason, see [Troubleshooting](#troubleshooting).
 
-Continue with Section 1 to attach the Policy to a VirtualServer, or Section 2
-to attach it to an Ingress. The Policy resource is the same for both.
+Choose how to attach the Policy:
+- [Attach to a VirtualServer](#attach-to-a-virtualserver)
+- [Attach to an Ingress](#attach-to-an-ingress)
 
-## Section 1: Attach to a VirtualServer
+The Policy resource is the same for both.
 
-Save the following as `webapp.yaml`. It contains the sample application
-Deployment, its Service, and a VirtualServer that references the
-`waf-policy` Policy.
+## Attach to a VirtualServer
+
+Save the following as `webapp.yaml`. The file defines the sample application Deployment, its Service, and a VirtualServer that references the `waf-policy` Policy.
 
 ```yaml
 apiVersion: apps/v1
@@ -405,12 +379,9 @@ The requested URL was rejected. Please consult with your administrator.
 </body></html>
 ```
 
-## Section 2: Attach to an Ingress
+## Attach to an Ingress
 
-Save the following as `cafe.yaml`. It contains the sample cafe application
-(`coffee` and `tea` Deployments and Services) and an Ingress. The
-`nginx.com/policies` annotation attaches the `waf-policy` Policy to every
-route on the Ingress.
+Save the following as `cafe.yaml`. The file defines the sample cafe application (`coffee` and `tea` Deployments and Services) and an Ingress. The `nginx.com/policies` annotation attaches the `waf-policy` Policy to every route on the Ingress.
 
 ```yaml
 apiVersion: apps/v1
@@ -530,17 +501,13 @@ curl --resolve cafe.example.com:$IC_HTTP_PORT:$IC_IP \
   "http://cafe.example.com:$IC_HTTP_PORT/coffee/</script>"
 ```
 
-The response is `Request Rejected` for the attack payload.
+The response body is `Request Rejected`.
 
-Under PLM, Ingress-only App Protect annotations
-(`appprotect.f5.com/app-protect-policy`,
-`appprotect.f5.com/app-protect-security-log`) are not supported. Use the
-`k8s.nginx.org/v1` Policy resource and the `nginx.com/policies` annotation,
-as shown above.
+Under PLM, the Ingress-only App Protect annotations (`appprotect.f5.com/app-protect-policy` and `appprotect.f5.com/app-protect-security-log`) aren't supported. Use the `k8s.nginx.org/v1` Policy resource and the `nginx.com/policies` annotation instead, as shown above.
 
 ## Verify bundles on disk
 
-Confirm the compiled bundles were fetched into the NIC Pod:
+Confirm the compiled bundles are present in the ingress controller pod:
 
 ```shell
 NIC_POD=$(kubectl get pods --namespace nginx-ingress \
@@ -565,18 +532,9 @@ Check the Policy status:
 kubectl describe policy waf-policy
 ```
 
-The status reports `State: Valid` and `Reason: AddedOrUpdated` when the
-bundles are fetched successfully.
+A `State: Valid` and `Reason: AddedOrUpdated` status confirms the bundles were fetched successfully.
 
 ## Troubleshooting
 
-- **Policy status is `Warning` with reason `BundleFetchFailed`.** Check the
-  `APPolicy` or `APLogConf` referenced by the Policy. Run
-  `kubectl describe appolicy <name> --namespace security` and confirm
-  `status.bundle.state` is `ready`. If PLM has not compiled the resource,
-  the Policy fetch cannot proceed.
-- **NIC reports the referenced namespace is not watched.** If
-  `controller.watchNamespace` is set, include the namespace holding the
-  `APPolicy` and `APLogConf` resources. If `controller.watchSecretNamespace`
-  is set, include the PLM namespace so NIC can observe storage Secret
-  rotation.
+- **Policy status is `Warning` with reason `BundleFetchFailed`.** Run `kubectl describe appolicy <name> --namespace security` and confirm `status.bundle.state` is `ready`. If PLM hasn't compiled the resource yet, the Policy fetch can't proceed.
+- **NGINX Ingress Controller reports the referenced namespace isn't watched.** If `controller.watchNamespace` is set, include the namespace that holds the `APPolicy` and `APLogConf` resources. If `controller.watchSecretNamespace` is set, include the PLM namespace so the controller can observe storage Secret rotation.

--- a/content/nic/install/plm-upgrade.md
+++ b/content/nic/install/plm-upgrade.md
@@ -5,69 +5,49 @@ toc: true
 f5-content-type: how-to
 f5-product: F5 NGINX Ingress Controller
 f5-description: >
-  Upgrade an existing F5 NGINX Ingress Controller (NIC) deployment from
-  in-pod App Protect policy compilation (v1beta1 CRDs) to F5 WAF for NGINX
-  with Policy Lifecycle Management (PLM).
+  Upgrade an existing F5 NGINX Ingress Controller deployment from in-pod App Protect policy compilation (v1beta1 CRDs) to F5 WAF for NGINX with Policy Lifecycle Management (PLM).
 f5-audience: operator
 ---
 
-This guide upgrades an existing NIC + F5 WAF for NGINX deployment from in-pod
-App Protect policy compilation to Policy Lifecycle Management (PLM). PLM
-compiles `APPolicy` and `APLogConf` resources in a dedicated controller and
-stores the resulting bundles in an in-cluster S3-compatible object store. NIC
-fetches the compiled bundles instead of compiling them in the data plane.
+Use this guide to upgrade an existing NGINX Ingress Controller + F5 WAF for NGINX deployment from in-pod App Protect policy compilation to Policy Lifecycle Management (PLM). PLM compiles `APPolicy` and `APLogConf` resources in a dedicated controller and stores the resulting bundles in an in-cluster S3-compatible object store. NGINX Ingress Controller then fetches the compiled bundles instead of compiling them in the data plane.
 
-Under PLM, the fields you already write on the NIC `Policy` resource
-(`waf.apPolicy` and `waf.securityLogs[].apLogConf`) continue to work
-unchanged. The `k8s.nginx.org/v1` Policy manifest for a VirtualServer or
-Ingress does not need to be rewritten during the upgrade.
+Under PLM, the fields you already write on the NGINX Ingress Controller `Policy` resource (`waf.apPolicy` and `waf.securityLogs[].apLogConf`) continue to work unchanged. You don't need to rewrite the `k8s.nginx.org/v1` Policy manifest for a VirtualServer or Ingress during the upgrade.
 
-By the end of this guide you will have:
+By the end of this guide, you'll have:
 
-- The PLM backend installed alongside your existing NIC deployment.
-- NIC upgraded to a PLM-capable release with PLM storage configured.
-- Existing `APPolicy` and `APLogConf` resources adopted by PLM and compiled
-  into bundles.
-- WAF-protected traffic served by NIC, with bundles fetched from PLM storage
-  instead of compiled in the data plane.
+- The PLM backend installed alongside your existing NGINX Ingress Controller deployment.
+- NGINX Ingress Controller upgraded to a PLM-capable release with PLM storage configured.
+- Existing `APPolicy` and `APLogConf` resources adopted by PLM and compiled into bundles.
+- WAF-protected traffic served by NGINX Ingress Controller, with bundles fetched from PLM storage instead of compiled in the data plane.
 
 ## Before you begin
 
-- Your cluster runs an existing NIC + F5 WAF for NGINX deployment.
-- Existing `APPolicy` and `APLogConf` resources are served by the
-  `appprotect.f5.com/v1beta1` CRDs shipped with your current NIC installation.
-- You have `kubectl` and Helm access to the cluster.
-- You have credentials for `private-registry.nginx.com`.
+Before you start, make sure you have:
+
+- An existing NGINX Ingress Controller + F5 WAF for NGINX deployment running in your cluster.
+- Existing `APPolicy` and `APLogConf` resources served by the `appprotect.f5.com/v1beta1` CRDs shipped with your current NGINX Ingress Controller installation.
+- `kubectl` and Helm access to the cluster.
+- Credentials for `private-registry.nginx.com`.
 
 Record your current values before you begin:
 
 | Value | Where to find it |
 |---|---|
-| NIC release name | `helm list --namespace <NIC_NAMESPACE>` |
-| NIC chart version | `helm list --namespace <NIC_NAMESPACE>` |
-| Existing NIC values | `helm get values <NIC_RELEASE> --namespace <NIC_NAMESPACE>` |
+| NGINX Ingress Controller release name | `helm list --namespace <NIC_NAMESPACE>` |
+| NGINX Ingress Controller chart version | `helm list --namespace <NIC_NAMESPACE>` |
+| Existing NGINX Ingress Controller values | `helm get values <NIC_RELEASE> --namespace <NIC_NAMESPACE>` |
 | Existing `APPolicy` resources | `kubectl get appolicy --all-namespaces` |
 | Existing `APLogConf` resources | `kubectl get aplogconf --all-namespaces` |
 
-This guide uses `nic` as the NIC release name, `nginx-ingress` as the NIC
-namespace, `plm-system` as the PLM namespace, and `plm` as the PLM release
-name. Substitute your values consistently.
+This guide uses `nic` as the NGINX Ingress Controller release name, `nginx-ingress` as the NGINX Ingress Controller namespace, `plm-system` as the PLM namespace, and `plm` as the PLM release name. Replace these with your own values consistently throughout.
 
 ## Deploy PLM infrastructure
 
-Install the PLM backend into the `plm-system` namespace. The install adds
-the `appprotect.f5.com/v1` versions to the existing `appprotect.f5.com`
-CRDs. The v1 versions are a superset of v1beta1, so adding them does not
-affect NIC while it still watches v1beta1.
+Install the PLM backend into the `plm-system` namespace. The install adds the `appprotect.f5.com/v1` versions to the existing `appprotect.f5.com` CRDs. Because the v1 versions are a superset of v1beta1, adding them doesn't affect NGINX Ingress Controller while it still watches v1beta1.
 
 {{< include "waf/plm-deploy-infrastructure.md" >}}
 
-After the install completes, PLM adopts every existing `APPolicy` and
-`APLogConf` resource in the cluster by adding the
-`appprotect.f5.com/finalizer` finalizer and compiling each resource against
-its current signature package. Your running NIC continues to compile the
-same resources in-pod. Both mechanisms operate independently until you
-upgrade NIC.
+After the install completes, PLM adopts every existing `APPolicy` and `APLogConf` resource in the cluster. It does this by adding the `appprotect.f5.com/finalizer` finalizer and compiling each resource against its current signature package. Your running NGINX Ingress Controller continues to compile the same resources in-pod. The two mechanisms operate independently until you upgrade NGINX Ingress Controller.
 
 Confirm PLM has compiled the existing resources:
 
@@ -79,23 +59,16 @@ kubectl get aplogconf --all-namespaces \
   --output custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATE:.status.bundle.state'
 ```
 
-Every resource should report `STATE: ready`. If any resource is not `ready`,
-inspect the PLM policy-controller logs and resolve compilation errors before
-you continue.
+Every resource should report `STATE: ready`. If any resource isn't `ready`, inspect the PLM policy-controller logs, resolve the compilation errors, and then continue.
 
 ## Look up the PLM storage endpoint and credentials
 
-NIC connects to PLM's SeaweedFS filer over S3 to fetch compiled bundles.
-Before you run `helm upgrade`, collect four values that the PLM install
-produced:
+NGINX Ingress Controller connects to PLM's SeaweedFS filer over S3 to fetch compiled bundles. Before you run `helm upgrade`, collect these four values from the PLM installation:
 
 1. **PLM storage URL**: the SeaweedFS filer endpoint (HTTPS or HTTP).
-2. **Credentials Secret**: the S3 credentials Secret. The access key ID is
-   `admin` by default; the secret access key is stored in the
-   `seaweedfs_admin_secret` field.
+2. **Credentials Secret**: the S3 credentials Secret. The access key ID is `admin` by default. The secret access key is in the `seaweedfs_admin_secret` field.
 3. **CA Secret** (HTTPS only): verifies the SeaweedFS filer certificate.
-4. **Client TLS Secret** (mutual TLS only): presented by NIC when it
-   connects to the filer.
+4. **Client TLS Secret** (mutual TLS only): presented by NGINX Ingress Controller when it connects to the filer.
 
 List the Services PLM created and identify the filer:
 
@@ -110,8 +83,7 @@ NAME                       TYPE        CLUSTER-IP   PORT(S)
 plm-f5-waf-seaweed-filer   ClusterIP   10.0.0.10    8333/TCP,9333/TCP,...
 ```
 
-Assemble the URL from the service name, namespace, and port. Use `9333`
-for HTTPS and `8333` for HTTP:
+Assemble the URL from the service name, namespace, and port. Use `9333` for HTTPS and `8333` for HTTP:
 
 - HTTPS (mTLS): `https://plm-f5-waf-seaweed-filer.plm-system.svc.cluster.local:9333`
 - HTTP: `http://plm-f5-waf-seaweed-filer.plm-system.svc.cluster.local:8333`
@@ -122,23 +94,17 @@ List the Secrets PLM created:
 kubectl get secret --namespace plm-system
 ```
 
-The default PLM install creates three Secrets that NIC references:
+The default PLM install creates three Secrets that NGINX Ingress Controller references:
 
 - `plm-f5-waf-seaweedfs-auth`: SeaweedFS credentials.
 - `plm-f5-waf-seaweedfs-ca-cert`: CA certificate for the HTTPS filer.
 - `plm-f5-waf-seaweedfs-client-cert`: client TLS certificate for mTLS.
 
-Record the Secret references in `<namespace>/<name>` form. You'll pass all
-four values to NIC as `--set controller.appprotect.plmStorage.*` flags when
-you run `helm upgrade`.
+Record the Secret references in `<namespace>/<name>` form. When you run `helm upgrade`, pass all four values to NGINX Ingress Controller using `--set controller.appprotect.plmStorage.*` flags.
 
-## Apply NIC CRDs
+## Apply the NGINX Ingress Controller CRDs
 
-Before you run `helm upgrade`, apply the NIC CRDs from the bundled manifest
-for your target release. The `deploy/crds.yaml` bundle contains every CRD
-NIC needs (`VirtualServer`, `VirtualServerRoute`, `Policy`,
-`TransportServer`, `GlobalConfiguration`, `DNSEndpoint`) and deliberately
-excludes the App Protect CRDs, which PLM owns.
+Before you run `helm upgrade`, apply the NGINX Ingress Controller CRDs from the bundled manifest for your target release. The `deploy/crds.yaml` bundle contains every CRD the controller needs (`VirtualServer`, `VirtualServerRoute`, `Policy`, `TransportServer`, `GlobalConfiguration`, `DNSEndpoint`). The bundle deliberately excludes the App Protect CRDs, which PLM owns.
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v{{< nic-version >}}/deploy/crds.yaml
@@ -146,20 +112,13 @@ kubectl apply -f https://raw.githubusercontent.com/nginx/kubernetes-ingress/v{{<
 
 ## Section 1: Upgrade a VirtualServer-based deployment
 
-This section applies when your existing NIC deployment routes traffic
-through `k8s.nginx.org/v1` VirtualServer resources that reference a Policy
-resource with `waf.apPolicy` and `waf.securityLogs[].apLogConf` fields.
+Follow this section if your existing NGINX Ingress Controller deployment routes traffic through `k8s.nginx.org/v1` VirtualServer resources that reference a Policy resource with `waf.apPolicy` and `waf.securityLogs[].apLogConf` fields.
 
-### 1. Upgrade NIC to enable PLM
+### 1. Upgrade NGINX Ingress Controller with PLM storage
 
-Upgrade the NIC release. `--reuse-values` preserves your existing NIC
-configuration; the `--set` flags overlay PLM storage on top. `--skip-crds`
-prevents Helm from touching CRDs, since you applied the NIC CRDs in the
-previous step and PLM owns the App Protect CRDs.
+Upgrade the NGINX Ingress Controller release. `--reuse-values` preserves your existing configuration. The `--set` flags overlay PLM storage on top. `--skip-crds` prevents Helm from touching CRDs, because you applied the NGINX Ingress Controller CRDs in the previous step and PLM owns the App Protect CRDs.
 
-This example uses HTTPS PLM storage with mutual TLS. For HTTP storage, set
-`controller.appprotect.plmStorage.url` to `http://<host>:8333` and omit the
-`caSecret` and `clientSSLSecret` flags.
+This example uses HTTPS PLM storage with mutual TLS. For HTTP storage, set `controller.appprotect.plmStorage.url` to `http://<host>:8333` and omit the `caSecret` and `clientSSLSecret` flags.
 
 ```shell
 helm upgrade nic nginx-stable/nginx-ingress \
@@ -183,7 +142,7 @@ kubectl rollout status deployment/nic-nginx-ingress-controller \
   --timeout=180s
 ```
 
-Confirm NIC is watching the v1 CRDs by inspecting the controller log:
+Confirm NGINX Ingress Controller is watching the v1 CRDs by inspecting the controller log:
 
 ```shell
 kubectl logs deployment/nic-nginx-ingress-controller \
@@ -213,26 +172,22 @@ NAMESPACE   NAME         STATE   REASON
 default     waf-policy   Valid   AddedOrUpdated
 ```
 
-If a Policy remains in `Warning` with `BundlePending`, the referenced
-`APPolicy` or `APLogConf` is not yet `ready` in PLM. Confirm PLM has
-compiled the resource and retry.
+If a Policy remains in `Warning` with `BundlePending`, the referenced `APPolicy` or `APLogConf` isn't yet `ready` in PLM. Confirm that PLM has compiled the resource, then retry.
 
 ### 3. Verify traffic
 
-Send a normal request to the VirtualServer and confirm the response is
-served:
+Send a normal request to the VirtualServer and confirm the application responds:
 
 ```shell
 curl --resolve webapp.example.com:$IC_HTTP_PORT:$IC_IP \
   http://webapp.example.com:$IC_HTTP_PORT/
 ```
 
-Send a request that triggers the configured WAF violation and confirm the
-response is `Request Rejected`.
+Then send a request that triggers the configured WAF violation and confirm the response is `Request Rejected`.
 
 ### 4. Confirm bundles come from PLM storage
 
-Check the bundle files in the NIC Pod:
+Check the bundle files in the ingress controller pod:
 
 ```shell
 NIC_POD=$(kubectl get pods --namespace nginx-ingress \
@@ -243,39 +198,29 @@ kubectl exec --namespace nginx-ingress $NIC_POD --container nginx-ingress -- \
   ls -l /etc/app_protect/bundles/
 ```
 
-Files named `fetched_<namespace>_<policy-name>_policy.tgz` and
-`fetched_<namespace>_<policy-name>_log_<index>.tgz` confirm the bundles were
-fetched from PLM storage.
+Files named `fetched_<namespace>_<policy-name>_policy.tgz` and `fetched_<namespace>_<policy-name>_log_<index>.tgz` confirm that the bundles were fetched from PLM storage.
 
 ## Section 2: Upgrade an Ingress-based deployment
 
-This section applies when your existing NIC deployment routes traffic
-through Kubernetes Ingress resources. It follows the same overall procedure
-as Section 1, plus one Ingress-specific step.
+Follow this section if your existing NGINX Ingress Controller deployment routes traffic through Kubernetes Ingress resources. The procedure is the same as Section 1, with one additional Ingress-specific step.
 
 ### 1. Audit Ingress annotations
 
-Under PLM, NIC does not support the App Protect Ingress annotations:
+Under PLM, NGINX Ingress Controller doesn't support the App Protect Ingress annotations:
 
 - `appprotect.f5.com/app-protect-policy`
 - `appprotect.f5.com/app-protect-security-log`
 - `appprotect.f5.com/app-protect-security-log-enable`
 
-An Ingress that uses these annotations is accepted but produces a warning
-after the PLM upgrade, and WAF is not applied to that route. Migrate every
-such Ingress to a `k8s.nginx.org/v1` Policy resource before you enable PLM
-storage.
+An Ingress that uses these annotations is accepted but produces a warning after the upgrade. WAF isn't applied to that route. Before you turn on PLM storage, migrate every such Ingress to a `k8s.nginx.org/v1` Policy resource.
 
-### 2. Upgrade NIC to enable PLM
+### 2. Upgrade NGINX Ingress Controller with PLM storage
 
-Run the same `helm upgrade` command shown in
-[Section 1, step 1](#1-upgrade-nic-to-enable-plm).
+Run the same `helm upgrade` command shown in [Section 1, step 1](#1-upgrade-nginx-ingress-controller-with-plm-storage).
 
 ### 3. Verify Ingress traffic
 
-For each Ingress, send a normal request and confirm the response is served.
-Then send a request that matches a WAF violation and confirm the response
-is `Request Rejected`.
+For each Ingress, send a normal request and confirm the application responds. Then send a request that matches a WAF violation and confirm the response is `Request Rejected`.
 
 ### 4. Confirm bundles come from PLM storage
 
@@ -283,13 +228,6 @@ Use the same procedure as [Section 1, step 4](#4-confirm-bundles-come-from-plm-s
 
 ## Troubleshooting
 
-- **Policy stays in `BundlePending` after the upgrade.** The referenced
-  `APPolicy` or `APLogConf` is not `ready` in PLM. Inspect
-  `kubectl describe appolicy <name>` and the PLM policy-controller logs.
-- **NIC reports the referenced namespace is not watched.** If the NIC
-  deployment sets `controller.watchNamespace`, include the namespace of
-  every `APPolicy` and `APLogConf` resource. Also include the PLM namespace
-  in `controller.watchSecretNamespace` so NIC can observe storage Secret
-  rotation.
-- **Helm upgrade fails with a CRD conflict.** Confirm PLM is installed and
-  its v1 CRDs are present. Then run the upgrade with `--skip-crds`.
+- **Policy stays in `BundlePending` after the upgrade.** The referenced `APPolicy` or `APLogConf` isn't `ready` in PLM. Run `kubectl describe appolicy <name>` and inspect the PLM policy-controller logs.
+- **NGINX Ingress Controller reports the referenced namespace isn't watched.** If the deployment sets `controller.watchNamespace`, include the namespace of every `APPolicy` and `APLogConf` resource. Also include the PLM namespace in `controller.watchSecretNamespace` so NGINX Ingress Controller can observe storage Secret rotation.
+- **Helm upgrade fails with a CRD conflict.** Confirm PLM is installed and its v1 CRDs are present, then run the upgrade with `--skip-crds`.


### PR DESCRIPTION
## PR description draft

**Style edits: plm-installation.md and plm-upgrade.md**

This PR applies style edits to both PLM docs to align them with the [F5 Technical Writing Style Guide.](https://github.com/F5Docs/style-guide) No technical content was changed.

### Product naming (`f5-product-names`)

Replaced all uses of the `NIC` abbreviation in body prose with the full product name `NGINX Ingress Controller`. Abbreviating NGINX product names isn't permitted. Shell commands, variable names (`NIC_NAMESPACE`, `NIC_RELEASE`, `NIC_POD`), and Helm release names (`nic`) were left unchanged because they are literal command syntax.

### Second person and active voice (`second-person`, `active-voice`)

- "This guide installs / upgrades" → "Use this guide to install / upgrade" — the guide doesn't act; the reader does.
- "The `k8s.nginx.org/v1` Policy manifest…does not need to be rewritten" → "You don't need to rewrite…"
- "When namespace is omitted, NGINX Ingress Controller defaults…" → "When you omit the namespace…"

### Contractions and tense (`contractions`, `tense`)

- "does not" / "has not" / "is not" / "cannot" → "doesn't" / "hasn't" / "isn't" / "can't" throughout.
- "you will have" → "you'll have".

### Word list (`word-list`)

- "substitute" → "replace"
- "PLM storage enabled" → "PLM storage turned on" (`enable-disable`)

### Ambiguous pronouns (`pronouns`)

- "It deliberately excludes the App Protect CRDs" → "The bundle deliberately excludes…"
- "Both mechanisms operate independently" → "The two mechanisms operate independently"
- "It does this by adding the finalizer" added to resolve "PLM adopts every resource" → ambiguous follow-on sentence

### Conditional sentences — condition first (`conditional-sentences`)

- "You'll pass all four values…when you run `helm upgrade`" → "When you run `helm upgrade`, pass all four values…"
- "Before you turn on PLM storage, migrate every such Ingress" — preceding sentence restructured so the condition leads.
- Troubleshooting bullets restructured so the condition or trigger appears before the action.

### Semicolons (`semicolons`)

- `` `--reuse-values` preserves…; the `--set` flags overlay PLM storage on top`` split into two sentences.
- Credentials Secret list item split from semicolon join into two sentences.

### Paragraph structure and instruction order (`paragraph-structure`, `step-formatting`)

- In plm-installation.md, the install section was restructured: "install with `--skip-crds`. Apply…first" was contradictory. Rewritten as: "you must apply the controller's own CRDs before running `helm install`", with the `kubectl apply` command following naturally.
- Extra blank line before a shell block removed.
- "Send a normal request to confirm the application responds." (period) → colon, so the shell block reads as the step continuation.

### Headings (`headings`, `step-numbers-in-headings`)

- `## Section 1: Attach to a VirtualServer` → `## Attach to a VirtualServer`
- `## Section 2: Attach to an Ingress` → `## Attach to an Ingress`
- `## Create the NIC Policy` → `## Create the Policy`
- `### 1. Upgrade NIC to enable PLM` → `### 1. Upgrade NGINX Ingress Controller with PLM storage` (both sections)

The "Section N:" prefix and numbered subheadings act as step numbers in headings, which isn't permitted. The cross-reference prose was updated to use a short bulleted list of links to the renamed headings.

### Line wrapping

Removed all manual mid-sentence line breaks in prose. Text now wraps at the editor margin instead of at an arbitrary column, making diffs easier to read.‌​​​‍‌​‌⁣​‍‍​⁣⁣‌‌​‍​‌‌‍‍‍‌‍‌​⁣‍⁣‌​‌‍‌‌⁣‌‍​⁣‌‌⁣⁣⁣⁣⁣⁣‍⁣‌‌​‍⁠