### PR TITLE
Removed % delimiter in enable-nginx-plus-api-with-config-sync-group.md includes for consistency

### DIFF
--- a/content/includes/nginx-one-console/config-snippets/enable-nplus-api-dashboard.md
+++ b/content/includes/nginx-one-console/config-snippets/enable-nplus-api-dashboard.md
@@ -37,6 +37,6 @@ server {
 }
 ```
 
-{{<call-out type="important" title="Important">}}
+{{<call-out class="important" type="important" title="Important">}}
 Make sure that the `server` and  `location` blocks are in the same configuration file, and not split across multiple files using `include` directives.
 {{</call-out>}}

--- a/content/includes/use-cases/monitoring/enable-nginx-plus-api-with-config-sync-group.md
+++ b/content/includes/use-cases/monitoring/enable-nginx-plus-api-with-config-sync-group.md
@@ -15,16 +15,16 @@ f5-files:
 
 {{<tabs name="enable-nginx-metrics-with-sync-groups" >}}
 
-{{%tab name="without SSL"%}}
+{{< tab name="without SSL" >}}
 {{< include "/nginx-one-console/config-snippets/enable-nplus-api-dashboard.md" >}}
 
-{{% /tab %}}
-{{%tab name="with SSL"%}}
+{{< /tab >}}
+{{< tab name="with SSL" >}}
 
 {{< include "/use-cases/monitoring/enable-nginx-plus-api-with-ssl.md" >}}
 
-{{% /tab %}}
-{{% /tabs %}}
+{{< /tab >}}
+{{< /tabs >}}
 
 7. Select **Next**, review the diff, then select **Save and Publish**.
 8. Open your browser to `http://<instance-ip>:9000/dashboard.html` (replace `<instance-ip>` with the IP or hostname of one of your group members). You should see the NGINX Plus dashboard.

--- a/content/includes/use-cases/monitoring/enable-nginx-plus-api-with-ssl.md
+++ b/content/includes/use-cases/monitoring/enable-nginx-plus-api-with-ssl.md
@@ -42,11 +42,11 @@ server {
 }
 ```
 
-{{<call-out type="important" title="Important">}}
+{{<call-out class="important" type="important" title="Important">}}
 Make sure that the `server` and  `location` blocks are in the same configuration file, and not split across multiple files using `include` directives.
 {{</call-out>}}
 
-{{<call-out type="note" title="Configure NGINX Agent">}}
+{{<call-out class="note" type="note" title="Configure NGINX Agent">}}
 To enable NGINX Agent to call the NGINX Plus API, follow the steps below:
 - Add the following configuration to `/etc/nginx-agent/nginx-agent.conf`:
 ```
@@ -72,7 +72,7 @@ Found NGINX Plus API
 ```
 {{</call-out>}}
 
-{{<call-out type="note" title="Note">}}
+{{<call-out class="note" type="note" title="Note">}}
 Here is an example of how to generate self-signed certificates
 ```
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/certs/nginx-selfsigned.key -out /etc/nginx/certs/nginx-selfsigned.crt -subj "/CN=localhost" -addext "subjectAltName=IP:127.0.0.1"


### PR DESCRIPTION
### Proposed changes

- Changed away from `%` delimiter due to it breaking new unified site, and overall consistency is not right (e.g. look at opening and closing for `tabs`)

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
