### PR TITLE
Removed % delimiter in getting-started.md for N1 for consistency

### DIFF
--- a/content/nginx-one-console/getting-started.md
+++ b/content/nginx-one-console/getting-started.md
@@ -163,16 +163,16 @@ The NGINX One Console dashboard relies on APIs for NGINX Plus and NGINX Open Sou
 
 {{<tabs name="enable-nginx-metrics" >}}
 
-{{%tab name="without SSL"%}}
+{{<tab name="without SSL">}}
 {{< include "/use-cases/monitoring/enable-nginx-plus-api.md" >}}
 
-{{% /tab %}}
-{{%tab name="with SSL"%}}
+{{< /tab >}}
+{{<tab name="with SSL">}}
 
 {{< include "/use-cases/monitoring/enable-nginx-plus-api-with-ssl.md" >}}
 
-{{% /tab %}}
-{{% /tabs %}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Enable NGINX Open Source Metrics
 


### PR DESCRIPTION
### Proposed changes

- Changed away from `%` delimiter due to it breaking new unified site, and overall consistency is not right (e.g. look at opening and closing for `tabs`)

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
