### PR TITLE
fix: nms-nap-compiler installation steps for redhat-10

### DIFF
--- a/content/includes/nim/tech-specs/supported-distros.md
+++ b/content/includes/nim/tech-specs/supported-distros.md
@@ -14,7 +14,7 @@ The following table lists the Linux distributions supported by NGINX Instance Ma
 |-----------------|----------------------------------------|------------------|-----------------------------------------------------|----------------------------------------------------|
 | Debian          | 11<hr>12<hr>13                         | x86_64<hr>x86_64<hr>x86_64 | Supported<hr>Supported<hr>Supported                                | Supported<hr>Supported<hr>Supported       |
 | Oracle Linux    | 8.0 and later in the 8.x family        | x86_64           | Supported                                           | Supported                                          |
-| RHEL and Rocky           | 8.0 and later in the 8.x family<hr>9.0 and later in the 9.x family<hr>10.0 and later in the 10.x family  | x86_64<hr>x86_64<hr>x86_64 | Supported<hr>Supported<hr>Supported | Supported<hr>Supported<hr>Supported only on Redhat-10                       |
+| RHEL and Rocky           | 8.0 and later in the 8.x family<hr>9.0 and later in the 9.x family<hr>10.0 and later in the 10.x family  | x86_64<hr>x86_64<hr>x86_64 | Supported<hr>Supported<hr>Supported | Supported<hr>Supported<hr>Supported only on RHEL 10                       |
 | Ubuntu          | 22.04<hr>24.04                         | x86_64<hr>x86_64 | Supported<hr>Supported on 2.18.0+                   | Supported<hr>Supported                             |
 
 {{</table >}}

--- a/content/includes/nim/tech-specs/supported-distros.md
+++ b/content/includes/nim/tech-specs/supported-distros.md
@@ -14,7 +14,7 @@ The following table lists the Linux distributions supported by NGINX Instance Ma
 |-----------------|----------------------------------------|------------------|-----------------------------------------------------|----------------------------------------------------|
 | Debian          | 11<hr>12<hr>13                         | x86_64<hr>x86_64<hr>x86_64 | Supported<hr>Supported<hr>Supported                                | Supported<hr>Supported<hr>Supported       |
 | Oracle Linux    | 8.0 and later in the 8.x family        | x86_64           | Supported                                           | Supported                                          |
-| RHEL and Rocky           | 8.0 and later in the 8.x family<hr>9.0 and later in the 9.x family<hr>10.0 and later in the 10.x family  | x86_64<hr>x86_64<hr>x86_64 | Supported<hr>Supported<hr>Supported | Supported<hr>Supported<hr>Supported                        |
+| RHEL and Rocky           | 8.0 and later in the 8.x family<hr>9.0 and later in the 9.x family<hr>10.0 and later in the 10.x family  | x86_64<hr>x86_64<hr>x86_64 | Supported<hr>Supported<hr>Supported | Supported<hr>Supported<hr>Supported only on Redhat-10                       |
 | Ubuntu          | 22.04<hr>24.04                         | x86_64<hr>x86_64 | Supported<hr>Supported on 2.18.0+                   | Supported<hr>Supported                             |
 
 {{</table >}}

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -49,7 +49,7 @@ If you see a message like this, the certificate or key is likely invalid or expi
 error when creating the nginx repo retriever - NGINX repo certificates not found
 ```
 
-{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages in UI: 
+{{<call-out class="warning" title="Known issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages in the UI: 
 ```text
 <instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
 ```

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -65,7 +65,7 @@ for Debian or Ubuntu-based systems:
 
 <b>OR</b></br>
 
-RHEL based system: 
+for RHEL-based systems: 
 ```text
 Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm
 ```

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -49,4 +49,33 @@ If you see a message like this, the certificate or key is likely invalid or expi
 error when creating the nginx repo retriever - NGINX repo certificates not found
 ```
 
+{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages 
+UI Error: 
+```text
+<instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
+```
+
+If you see any of the following error message in nms log </br>
+
+Debian/ubuntu based system:
+```text
+/usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
+```
+
+RHEL based system: 
+```text
+Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm
+```
+
+<b>Workaround</b>: Execute below command
+   ```shell
+   sudo bash -c '
+   cd /opt/nms-nap-compiler/app_protect-5.690.0/lib && \
+   ln -sfn libre2.so.11.0.0 libre2.so.11 && \
+   ln -sfn libprotobuf.so.3.21.12.0 libprotobuf.so.32 && \
+   ln -sfn libprotobuf.so.32 libprotobuf.so
+   '
+   ```
+{{</call-out>}}
+
 If needed, you can [install the WAF compiler manually]({{< ref "/nim/waf-integration/configuration/install-waf-compiler/install.md" >}}).

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -58,7 +58,7 @@ error when creating the nginx repo retriever - NGINX repo certificates not found
 
 If you see any of the following error message in nms log </br>
 
-debian/ubuntu based system:
+for Debian or Ubuntu-based systems:
 ```text
 /usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
 ```

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -70,7 +70,7 @@ for RHEL-based systems:
 Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm
 ```
 
-<b>Workaround</b>: Execute below command
+<b>Workaround</b>: Run the following command:
    ```shell
    sudo bash -c '
    cd /opt/nms-nap-compiler/app_protect-5.690.0/lib && \

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -54,16 +54,16 @@ error when creating the nginx repo retriever - NGINX repo certificates not found
 <instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
 ```
 
-AND</br>
+<b>AND</b></br>
 
 If you see any of the following error message in nms log </br>
 
-Debian/ubuntu based system:
+debian/ubuntu based system:
 ```text
 /usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
 ```
 
-OR</br>
+<b>OR</b></br>
 
 RHEL based system: 
 ```text

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -56,7 +56,7 @@ error when creating the nginx repo retriever - NGINX repo certificates not found
 
 <b>AND</b></br>
 
-If you see any of the following error message in nms log </br>
+If the log contains any of the following error messages:</br>
 
 for Debian or Ubuntu-based systems:
 ```text

--- a/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/automatic-download.md
@@ -49,11 +49,12 @@ If you see a message like this, the certificate or key is likely invalid or expi
 error when creating the nginx repo retriever - NGINX repo certificates not found
 ```
 
-{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages 
-UI Error: 
+{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages in UI: 
 ```text
 <instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
 ```
+
+AND</br>
 
 If you see any of the following error message in nms log </br>
 
@@ -61,6 +62,8 @@ Debian/ubuntu based system:
 ```text
 /usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
 ```
+
+OR</br>
 
 RHEL based system: 
 ```text

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -134,7 +134,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 1. {{< include "nim/waf/restart-nms-integrations.md" >}}
 
 
-{{<call-out class="warning" title="Known Issue for nms-nap-compiler-v5.690.0" >}}If you see error message `Can't locate JSON/XS.pm` in nms log while policy compilation then install `perl-JSON-XS` package manually.
+{{<call-out class="warning" title="Known issue for nms-nap-compiler-v5.690.0" >}}If the log contains the `Can't locate JSON/XS.pm` error message during policy compilation, install the `perl-JSON-XS` package manually.
 
    ```shell
    sudo yum install perl-JSON-XS

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -134,7 +134,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 1. {{< include "nim/waf/restart-nms-integrations.md" >}}
 
 
-{{<call-out class="warning" title="perl-JSON-XS package missing" >}}If you see error message `Can't locate JSON/XS.pm` in nms log while policy compilation then install `perl-JSON-XS` package manually.
+{{<call-out class="warning" title="Known Issue for nms-nap-compiler-v5.690.0" >}}If you see error message `Can't locate JSON/XS.pm` in nms log while policy compilation then install `perl-JSON-XS` package manually.
 
    ```shell
    sudo yum install perl-JSON-XS

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -178,7 +178,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 
 If you see any of the following error message in nms log </br>
 
-debian/ubuntu based system:
+for Debian or Ubuntu-based systems:
 ```text
 /usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
 ```

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -174,16 +174,16 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 <instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
 ```
 
-AND</br>
+<b>AND</b></br>
 
 If you see any of the following error message in nms log </br>
 
-Debian/ubuntu based system:
+debian/ubuntu based system:
 ```text
 /usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
 ```
 
-OR</br>
+<b>OR</b></br>
 
 RHEL based system: 
 ```text

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -111,6 +111,36 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 
 {{% /tab %}}
 
+{{% tab name="RHEL 10" %}}
+
+1. Download the `dependencies.repo` file to `/etc/yum.repos.d`:
+
+   ```shell
+   sudo wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/dependencies.repo
+   ```
+
+1. Enable the CodeReady Builder repository:
+
+   ```shell
+   sudo subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms
+   ```
+
+1. Install the WAF compiler:
+
+   ```shell
+   sudo yum install nms-nap-compiler-v5.690.0
+   ```
+
+1. {{< include "nim/waf/restart-nms-integrations.md" >}}
+
+Note: If you see error message `Can't locate JSON/XS.pm` in nms log while policy compilation then install `perl-JSON-XS` package manually.
+
+   ```shell
+   sudo yum install perl-JSON-XS
+   ```
+
+{{% /tab %}}
+
 {{% tab name="Oracle Linux 8.1" %}}
 
 1. Download the `dependencies.repo` file to `/etc/yum.repos.d`:

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -169,7 +169,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 
 {{< /tabs >}}
 
-{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages in UI: 
+{{<call-out class="warning" title="Known issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages in the UI: 
 ```text
 <instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
 ```

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -133,11 +133,13 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 
 1. {{< include "nim/waf/restart-nms-integrations.md" >}}
 
-Note: If you see error message `Can't locate JSON/XS.pm` in nms log while policy compilation then install `perl-JSON-XS` package manually.
+
+{{<call-out class="warning" title="perl-JSON-XS package missing" >}}If you see error message `Can't locate JSON/XS.pm` in nms log while policy compilation then install `perl-JSON-XS` package manually.
 
    ```shell
    sudo yum install perl-JSON-XS
    ```
+{{</call-out>}}
 
 {{% /tab %}}
 

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -185,7 +185,7 @@ for Debian or Ubuntu-based systems:
 
 <b>OR</b></br>
 
-RHEL based system: 
+for RHEL-based systems: 
 ```text
 Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm
 ```

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -170,14 +170,24 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 {{< /tabs >}}
 
 {{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages 
-UI Error: `<instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1` 
+UI Error:
+```text
+<instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
+```
+
 If you see any of the following error message in nms log </br>
 
-Debian/ubuntu based system: `/usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE` </br>
+Debian/ubuntu based system:
+```text
+/usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
+```
 
-RHEL based system: `Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm`
+RHEL based system:
+```text
+Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm
+```
 
-Wrokaround:
+<b>Workaround</b>: Execute below command
    ```shell
    sudo bash -c '
    cd /opt/nms-nap-compiler/app_protect-5.690.0/lib && \

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -190,7 +190,7 @@ for RHEL-based systems:
 Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm
 ```
 
-<b>Workaround</b>: Execute below command
+<b>Workaround</b>: Run the following command:
    ```shell
    sudo bash -c '
    cd /opt/nms-nap-compiler/app_protect-5.690.0/lib && \

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -169,11 +169,12 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 
 {{< /tabs >}}
 
-{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages 
-UI Error:
+{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages in UI: 
 ```text
 <instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1
 ```
+
+AND</br>
 
 If you see any of the following error message in nms log </br>
 
@@ -182,7 +183,9 @@ Debian/ubuntu based system:
 /usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE
 ```
 
-RHEL based system:
+OR</br>
+
+RHEL based system: 
 ```text
 Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm
 ```

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -176,7 +176,7 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 
 <b>AND</b></br>
 
-If you see any of the following error message in nms log </br>
+If the log contains any of the following error messages:</br>
 
 for Debian or Ubuntu-based systems:
 ```text

--- a/content/nim/waf-integration/configuration/install-waf-compiler/install.md
+++ b/content/nim/waf-integration/configuration/install-waf-compiler/install.md
@@ -168,3 +168,22 @@ Earlier releases used 4.x.x for VM packages (for example, NAP 4.15.0, NAP 4.16.0
 {{% /tab %}}
 
 {{< /tabs >}}
+
+{{<call-out class="warning" title="Known Issue for auto-downloaded nms-nap-compiler-v5.690.0" >}}If you see following error messages 
+UI Error: `<instance_name>: failed building config payload: policy compilation failed for deployment <deployment_id> due to integrations service error: compiler controller error: exit status 1` 
+If you see any of the following error message in nms log </br>
+
+Debian/ubuntu based system: `/usr/bin/perl: symbol lookup error: /opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so: undefined symbol: _ZN3re23RE2C1ESt17basic_string_viewIcSt11char_traitsIcEERKNS0_7OptionsE` </br>
+
+RHEL based system: `Can't load '/opt/nms-nap-compiler/app_protect-5.690.0/bin/../lib/perl/auto/F5/PatternMatching/PatternMatching.so' for module F5::PatternMatching: libre2.so.11: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm`
+
+Wrokaround:
+   ```shell
+   sudo bash -c '
+   cd /opt/nms-nap-compiler/app_protect-5.690.0/lib && \
+   ln -sfn libre2.so.11.0.0 libre2.so.11 && \
+   ln -sfn libprotobuf.so.3.21.12.0 libprotobuf.so.32 && \
+   ln -sfn libprotobuf.so.32 libprotobuf.so
+   '
+   ```
+{{</call-out>}}


### PR DESCRIPTION
### Proposed changes

- Added Steps for nms-nap-compiler installation on Redhat-10.
- Added workaround for run time error w.r.t. perl-JSON-XS package on Redhat-10 while policy compilation.

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
