### PR TITLE
NGINXaaS updates to use F5 WAF for NGINX

### DIFF
--- a/content/nginxaas/aws/deploy/create-deployment/deploy-console.md
+++ b/content/nginxaas/aws/deploy/create-deployment/deploy-console.md
@@ -41,6 +41,7 @@ Create a new NGINXaaS deployment using the NGINXaaS Console:
    - Add an optional description for your deployment.
    - Change the [**NCUs**]({{< ref "/nginxaas/aws/overview.md#nginx-capacity-unit-ncu" >}}) if needed.
       - The default value of `20` works for most common scenarios.
+   - Enable **WAF** if you want [F5 WAF for NGINX]({{< ref "/waf" >}}) enabled for your deployment.
    - Select the AWS **Region** where you want the NGINXaaS deployment to be created.
    - Enter an **IPv4 CIDR Block** for the deployment's private network IP space.
       - NGINXaaS only accepts block sizes between `/22` and `/18`.
@@ -78,6 +79,7 @@ In the NGINXaaS Console,
 1. Select **Edit** to modify the deployment.
    - From this form, you can edit the description or reserved [NCUs]({{< ref "/nginxaas/aws/overview.md#nginx-capacity-unit-ncu" >}}).
    - You can apply a different NGINX configuration or configuration version.
+   - Enable or disable WAF.
    - Configure upstream connectivity by adding entries to the **VPC Peering Connections** list as detailed further in [Upstream connectivity](#upstream-connectivity).
    - You can also modify the **Service Frontend** configuration, including frontend type, ACL rules (Managed Public Endpoint) or PrivateLink Connection Allow List entries (Private Endpoint) from here.
       - This is where you can add VPC endpoint IDs to the allow list after you [create an interface VPC endpoint](#private-endpoint-traffic).

--- a/content/nginxaas/aws/monitoring/enable-nginx-logs.md
+++ b/content/nginxaas/aws/monitoring/enable-nginx-logs.md
@@ -38,6 +38,10 @@ When you enable log export, NGINXaaS writes NGINX logs to a CloudWatch Logs log 
 
 {{< include "/nginxaas/logging-config-access-logs.md" >}}
 
+## Set up F5 WAF for NGINX security logs
+
+{{< include "/nginxaas/logging-config-security-logs.md" >}}
+
 ## Export NGINX logs to CloudWatch
 
 To enable exporting logs, turn on the **Export Logs to CloudWatch** toggle when creating or updating a deployment. To create a deployment, see [our documentation on creating an NGINXaaS deployment]({{< ref "/nginxaas/aws/deploy/create-deployment/" >}}) for a step-by-step guide. To update an existing deployment, in the NGINXaaS console,

--- a/content/nginxaas/aws/overview.md
+++ b/content/nginxaas/aws/overview.md
@@ -141,7 +141,6 @@ We are committed to enhancing NGINXaaS for AWS and welcome your feedback to help
 
 Here are the current constraints you should be aware of while using NGINXaaS for AWS:
 
-- F5 WAF is currently not supported for NGINXaaS on AWS, but this feature is expected to be available soon - stay tuned.
 - User Role-Based Access Control (RBAC) is not yet supported, but this enhancement is on our roadmap as we improve access control for multi-user environments.
 - PrivateLink and upstream VPC peering connections must remain within the same AWS region as your deployment. Cross-region connections are not currently supported.
 - NGINXaaS deployments on AWS can only support up to 50 unique listen ports.

--- a/content/nginxaas/changelog.md
+++ b/content/nginxaas/changelog.md
@@ -13,6 +13,14 @@ Learn about the latest updates, new features, and resolved bugs in F5 NGINXaaS.
 
 To see a list of currently active issues, visit the [Known issues]({{< ref "/nginxaas/google/known-issues.md" >}}) page.
 
+## September 1, 2026
+
+- {{% icon-feature %}} **NGINXaaS for AWS now supports F5 WAF for NGINX (Preview)**
+
+You can now deploy NGINXaaS with [F5 WAF for NGINX]({{< ref "/waf" >}}); an advanced high-performance web application firewall (WAF) to provide protection from OWASP Top 10 web application security risks.
+
+**Note:** This feature is currently in Preview and free to use during the preview period. Custom security policies and custom logging profiles are not yet supported.
+
 ## July 31, 2026
 
 - {{% icon-feature %}} **NGINXaaS for AWS is now available (Early Access)**

--- a/content/nginxaas/overview/app-protect/_index.md
+++ b/content/nginxaas/overview/app-protect/_index.md
@@ -1,0 +1,5 @@
+---
+title: F5 WAF for NGINX
+weight: 500
+url: /nginxaas/overview/app-protect/
+---

--- a/content/nginxaas/overview/app-protect/configure-waf.md
+++ b/content/nginxaas/overview/app-protect/configure-waf.md
@@ -1,0 +1,93 @@
+---
+title: Configure F5 WAF for NGINX 
+description: "Configure F5 WAF for NGINX security features by editing the NGINX configuration file."
+weight: 100
+toc: true
+f5-docs: DOCS-000
+url: /nginxaas/overview/app-protect/configure-waf/
+f5-content-type: how-to
+f5-product: F5 NGINXaaS
+f5-keywords: "F5 WAF, app protect, security policy, NGINX configuration"
+f5-summary: >
+  This page explains how to configure F5 WAF for NGINX by loading the module and setting the enforcer address, then enabling a security policy.
+  You need this to protect your application from web threats.
+f5-audience: operator
+contentVars:
+  product: NGINXaaS
+---
+
+## Overview
+
+This guide explains how to configure the F5 WAF for NGINX security features.
+
+## Configure
+
+To use F5 WAF for NGINX, apply the following changes to the NGINX config file.
+
+1. Load the F5 WAF for NGINX module on the main context:
+
+```nginx
+load_module modules/ngx_http_app_protect_module.so;
+```
+
+2. Set the enforcer address:
+
+```nginx
+app_protect_enforcer_address 127.0.0.1:50000;
+```
+
+{{< call-out class="note" >}} The app_protect_enforcer_address directive is a required directive for F5 WAF for NGINX to work and must match `127.0.0.1:50000`{{< /call-out >}}
+
+
+3. Enable F5 WAF for NGINX with the `app_protect_enable` directives in the appropriate scope. The `app_protect_enable` directive may be set in the `http`, `server`, and `location` contexts.
+
+It is recommended to have a basic policy enabled in the `http` or `server` context to process malicious requests in a more complete manner.
+
+```nginx
+app_protect_enable on;
+```
+
+4. Configure the pre-defined policy to use with the `app_protect_policy_file` directive (either the `app_protect_default_policy` or `app_protect_strict_policy`).
+
+```nginx
+app_protect_policy_file app_protect_strict_policy;
+```
+
+Sample Config with F5 WAF for NGINX configured:
+
+```nginx
+user nginx;
+worker_processes auto;
+worker_rlimit_nofile 8192;
+pid /run/nginx/nginx.pid;
+
+load_module modules/ngx_http_app_protect_module.so;
+
+events {
+    worker_connections 4000;
+}
+
+error_log /var/log/nginx/error.log debug;
+
+http {
+    access_log off;
+    server_tokens "";
+
+    app_protect_enforcer_address 127.0.0.1:50000;
+
+    server {
+        listen 80 default_server;
+
+        location / {
+            app_protect_enable on;
+            app_protect_policy_file app_protect_strict_policy;
+            proxy_pass http://127.0.0.1:80/proxy/$request_uri;
+        }
+
+        location /proxy {
+            default_type text/html;
+            return 200 "Hello World\n";
+        }
+    }
+}
+```

--- a/content/nginxaas/overview/app-protect/disable-waf.md
+++ b/content/nginxaas/overview/app-protect/disable-waf.md
@@ -1,0 +1,37 @@
+---
+title: Disable F5 WAF for NGINX 
+description: "Disable F5 WAF for NGINX on an NGINXaaS deployment using the NGINXaaS Console."
+weight: 100
+toc: true
+f5-docs: DOCS-000
+url: /nginxaas/overview/app-protect/disable-waf/
+f5-content-type: how-to
+f5-product: F5 NGINXaaS
+f5-keywords: "F5 WAF, app protect, disable, NGINXaaS Console"
+f5-summary: >
+  This page explains how to disable F5 WAF for NGINX on an NGINXaaS deployment through the NGINXaaS Console.
+  You need this when you no longer want WAF protection applied to your deployment.
+f5-audience: operator
+contentVars:
+  product: NGINXaaS
+---
+
+## Overview
+This guide explains how to disable F5 WAF for NGINX on an NGINX as a Service (NGINXaaS) deployment.
+
+## Before you start
+You must remove the WAF directives from your NGINX config file before attempting to disable WAF.
+
+## Disable F5 WAF for NGINX
+
+### Using the NGINXaaS Console 
+
+{{< include "/nginxaas/access-console.md" >}}
+
+1. Go to your NGINXaaS deployment.
+
+2. Edit your deployment.
+
+3. Disable **WAF** for your deployment.
+
+4. Select **Save Changes** to begin the deployment process.

--- a/content/nginxaas/overview/app-protect/enable-waf.md
+++ b/content/nginxaas/overview/app-protect/enable-waf.md
@@ -1,0 +1,41 @@
+---
+title: Enable F5 WAF for NGINX 
+description: "Enable F5 WAF for NGINX on an NGINXaaS deployment using the NGINXaaS Console."
+weight: 100
+toc: true
+f5-docs: DOCS-000
+url: /nginxaas/overview/app-protect/enable-waf/
+f5-content-type: how-to
+f5-product: F5 NGINXaaS
+f5-keywords: "F5 WAF, app protect, enable, NGINXaaS Console"
+f5-summary: >
+  This page explains how to enable F5 WAF for NGINX on an NGINXaaS deployment through the NGINXaaS Console.
+  You need this because WAF is disabled by default and must be turned on explicitly to protect your applications.
+f5-audience: operator
+contentVars:
+  product: NGINXaaS
+---
+
+## Overview
+
+This guide explains how to enable F5 WAF for NGINX on a F5 NGINX as a Service (NGINXaaS) deployment. [F5 WAF for NGINX](https://docs.nginx.com/nginx-app-protect-waf/v5) provides web application firewall (WAF) security protection for your web applications, including OWASP Top 10; response inspection; Meta characters check; HTTP protocol compliance; evasion techniques; disallowed file types; JSON & XML well-formedness; sensitive parameters & Data Guard.
+
+## Enable F5 WAF for NGINX
+
+F5 WAF for NGINX is disabled by default and needs to be explicitly enabled on an NGINXaaS deployment. Follow these steps:
+
+### Using the NGINXaaS Console 
+
+{{< include "/nginxaas/access-console.md" >}}
+
+1. Go to your NGINXaaS deployment.
+
+2. Edit your deployment.
+
+3. Enable **WAF** for your deployment.
+
+4. Select **Save Changes** to begin the deployment process.
+
+## What's next
+
+[Configure F5 WAF for NGINX]({{< ref "/nginxaas/overview/app-protect/configure-waf.md" >}})


### PR DESCRIPTION
Document usage and limitations of F5 WAF for NGINX when used with NGINXaaS (Google and AWS).

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
