### PR TITLE
fix: update NGINX One component brandIcons from .png to .svg

### DIFF
--- a/content/nim/_index.md
+++ b/content/nim/_index.md
@@ -81,10 +81,10 @@ NGINX Instance Manager is part of NGINX One, which includes [NGINX One component
 [//]: # "You can add any extra content for the page here, such as additional cards, diagrams or text."
 
 {{< card-section title="Kubernetes Solutions">}}
-  {{< card title="NGINX Ingress Controller" titleUrl="/nginx-ingress-controller/" brandIcon="NGINX-Ingress-Controller-product-icon.png">}}
+  {{< card title="NGINX Ingress Controller" titleUrl="/nginx-ingress-controller/" brandIcon="NGINX-Ingress-Controller-product-icon.svg">}}
       Kubernetes traffic management with API gateway, identity, and observability features.
     {{</ card >}}
-    {{< card title="NGINX Gateway Fabric" titleUrl="/nginx-gateway-fabric/" brandIcon="NGINX-product-icon.png">}}
+    {{< card title="NGINX Gateway Fabric" titleUrl="/nginx-gateway-fabric/" brandIcon="NGINX-Gateway-Fabric-product-icon.svg">}}
       Next generation Kubernetes connectivity using the Gateway API.
     {{</ card >}}
   {{</ card-section >}}
@@ -94,18 +94,18 @@ NGINX Instance Manager is part of NGINX One, which includes [NGINX One component
     {{</ card >}}
   {{</ card-section >}}
   {{< card-section title="Modern App Delivery">}}
-    {{< card title="NGINX Plus" titleUrl="/nginx/" brandIcon="NGINX-Plus-product-icon-RGB.png">}}
+    {{< card title="NGINX Plus" titleUrl="/nginx/" brandIcon="NGINX-Plus-product-icon.svg">}}
       The all-in-one load balancer, reverse proxy, web server, content cache, and API gateway.
     {{</ card >}}
-    {{< card title="NGINX Open Source" titleUrl="https://nginx.org" brandIcon="NGINX-product-icon.png">}}
+    {{< card title="NGINX Open Source" titleUrl="https://nginx.org" brandIcon="NGINX-Open-Source-product-icon.svg">}}
       The open source all-in-one load balancer, content cache, and web server
     {{</ card >}}
   {{</ card-section >}}
   {{< card-section title="Security">}}
-    {{< card title="F5 WAF for NGINX" titleUrl="/nginx-app-protect-waf" brandIcon="NGINX-App-Protect-WAF-product-icon.png">}}
+    {{< card title="F5 WAF for NGINX" titleUrl="/nginx-app-protect-waf" brandIcon="NGINX-App-Protect-WAF-product-icon.svg">}}
       Lightweight, high-performance, advanced protection against Layer 7 attacks on your apps and APIs.
     {{</ card >}}
-    {{< card title="F5 DoS for NGINX" titleUrl="/nginx-app-protect-dos" brandIcon="NGINX-App-Protect-DoS-product-icon.png">}}
+    {{< card title="F5 DoS for NGINX" titleUrl="/nginx-app-protect-dos" brandIcon="NGINX-App-Protect-DoS-product-icon.svg">}}
       Defend, adapt, and mitigate against Layer 7 denial-of-service attacks on your apps and APIs.
   {{</ card >}}
 {{</ card-section >}}


### PR DESCRIPTION
## Summary

Fixes broken brand icons in the "NGINX One components" section of the NGINX Instance Manager landing page. The icons were referencing `.png` files that don't exist; updated them to the correct `.svg` filenames, matching the icon references already used in `content/nginx-one-console/_index.md`.

## What's changing

**File:** `content/nim/_index.md`

| Card | Before | After |
|---|---|---|
| NGINX Ingress Controller | `NGINX-Ingress-Controller-product-icon.png` | `NGINX-Ingress-Controller-product-icon.svg` |
| NGINX Gateway Fabric | `NGINX-product-icon.png` | `NGINX-Gateway-Fabric-product-icon.svg` |
| NGINX Plus | `NGINX-Plus-product-icon-RGB.png` | `NGINX-Plus-product-icon.svg` |
| NGINX Open Source | `NGINX-product-icon.png` | `NGINX-Open-Source-product-icon.svg` |
| F5 WAF for NGINX | `NGINX-App-Protect-WAF-product-icon.png` | `NGINX-App-Protect-WAF-product-icon.svg` |
| F5 DoS for NGINX | `NGINX-App-Protect-DoS-product-icon.png` | `NGINX-App-Protect-DoS-product-icon.svg` |
