### PR TITLE
fix: Correct the ordering of the F5 WAF sections in NGINXaaS

### DIFF
--- a/content/nginxaas/overview/app-protect/configure-waf.md
+++ b/content/nginxaas/overview/app-protect/configure-waf.md
@@ -1,7 +1,7 @@
 ---
 title: Configure F5 WAF for NGINX 
 description: "Configure F5 WAF for NGINX security features by editing the NGINX configuration file."
-weight: 100
+weight: 110
 toc: true
 f5-docs: DOCS-000
 url: /nginxaas/overview/app-protect/configure-waf/

--- a/content/nginxaas/overview/app-protect/disable-waf.md
+++ b/content/nginxaas/overview/app-protect/disable-waf.md
@@ -1,7 +1,7 @@
 ---
 title: Disable F5 WAF for NGINX 
 description: "Disable F5 WAF for NGINX on an NGINXaaS deployment using the NGINXaaS Console."
-weight: 100
+weight: 120
 toc: true
 f5-docs: DOCS-000
 url: /nginxaas/overview/app-protect/disable-waf/


### PR DESCRIPTION
Fix the ordering of the sections under F5 WAF for NGINX for the NGINXaaS product. They should be in the order Enable-Configure-Disable.

### Proposed changes

[//]: # "Write a clear and concise description of what the pull request changes."
[//]: # "You can use our Commit messages guidance for this."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md#commit-messages"

[//]: # "First, explain what was changed, and why. This should be most of the detail."
[//]: # "Then how the changes were made, such as referring to existing styles and conventions."
[//]: # "Finish by noting anything beyond the scope of the PR changes that may be affected."

[//]: # "Include information on testing if relevant and non-obvious from the deployment preview."
[//]: # "For expediency, you can use screenshots to show small before and after examples."

[//]: # "If the changes were defined by a GitHub issue, reference it using keywords."
[//]: # "https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests"

[//]: # "Do not link to any internal, non-public resources. This includes internal repository issues or anything in an intranet."
[//]: # "You can make reference to internal discussions without linking to them: see 'Referencing internal information'."
[//]: # "https://github.com/nginx/documentation/blob/main/documentation/closed-contributions.md#referencing-internal-information"

### Checklist

Before sharing this pull request, I completed the following checklist:

- [x] I read the [Contributing guidelines](https://github.com/nginx/documentation/blob/main/CONTRIBUTING.md)
- [x] My branch adheres to the [Git conventions](https://github.com/nginx/documentation/blob/main/documentation/git-conventions.md)
- [x] My content changes adhere to the [F5 Technical Writing Style Guide](https://github.com/F5Docs/style-guide)
- [x] If my changes involve potentially sensitive information[^1], I have assessed the possible impact
- [x] I have waited to ensure my changes pass tests, and addressed any discovered issues

[^1]: Potentially sensitive information includes personally identify information (PII), authentication credentials, and live URLs. Refer to the [style guide](https://github.com/F5Docs/style-guide/blob/main/terminology/sensitive-information.md) for guidance about placeholder content.
