### PR TITLE
docs(ngf): fix broken blog link in gateway architecture overview

### DIFF
--- a/content/ngf/overview/gateway-architecture.md
+++ b/content/ngf/overview/gateway-architecture.md
@@ -15,7 +15,7 @@ This document is intended for:
 
 - _Application Developers_ who would like to use NGINX Gateway Fabric to expose and route traffic to their applications within Kubernetes.
 
-The reader needs to be familiar with core Kubernetes concepts, such as pods, deployments, services, and endpoints. For an understanding of how NGINX itself works, you can read the ["Inside NGINX: How We Designed for Performance & Scale"](https://www.nginx.com/blog/inside-nginx-how-we-designed-for-performance-scale/) blog post.
+The reader needs to be familiar with core Kubernetes concepts, such as pods, deployments, services, and endpoints. For an understanding of how NGINX itself works, you can read the ["Inside NGINX: How We Designed for Performance & Scale"](https://blog.nginx.org/blog/inside-nginx-how-we-designed-for-performance-scale) blog post.
 
 If you are interested in contributing to the project or learning about its internal implementation details, please see the [Developer Architecture Guide](https://github.com/nginx/nginx-gateway-fabric/tree/main/docs/architecture).
 


### PR DESCRIPTION
### Issue
The embedded link in [Home -> F5 NGINX Gateway Fabric -> Overview -> Gateway architecture](https://docs.nginx.com/nginx-gateway-fabric/overview/gateway-architecture/) points to a non-existent page on `www.nginx.com`.

Fixes #2268

### Reproduce Issue
1. Navigate to [Gateway Architecture](https://docs.nginx.com/nginx-gateway-fabric/overview/gateway-architecture/).
2. Click the link **"Inside NGINX: How We Designed for Performance & Scale"**.
3. Notice that the request redirects to the general F5 NGINX products landing page instead of the original blog post.

### Proposed changes
Update the target URL in `content/ngf/overview/gateway-architecture.md`:
* **Old:** `https://www.nginx.com/blog/inside-nginx-how-we-designed-for-performance-scale/`
* **New:** `https://blog.nginx.org/blog/inside-nginx-how-we-designed-for-performance-scale`

